### PR TITLE
Convert all widgets and js-based browsers to use JS modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ www/widgets/lab%.js: src/lab%.py src/lab%.hints infra/compile.py
 	python3 infra/compile.py $< $@ --hints src/lab$*.hints
 
 www/widgets/rt-module.js: www/widgets/rt.js
-	echo "export { breakpoint, http_textarea, lib, pysplit, truthy, Widget }" > www/widgets/rt-module.js
+	echo "export { breakpoint, http_textarea, lib, pysplit, rt_constants, truthy, Widget };" > www/widgets/rt-module.js
 	cat www/widgets/rt.js >> www/widgets/rt-module.js
 
 www/widgets/lab%-browser.html: infra/labN-browser.html infra/labN-browser.lua config.json www/widgets/lab%.js

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIDGET_LAB_CODE=lab2 lab3 lab5 lab7
 book: $(patsubst %,www/%.html,$(CHAPTERS)) www/rss.xml widgets
 blog: $(patsubst blog/%.md,www/blog/%.html,$(wildcard blog/*.md)) www/rss.xml
 draft: $(patsubst %,www/draft/%.html,$(CHAPTERS)) www/onepage.html widgets
-widgets: $(patsubst lab%,www/widgets/lab%-browser.html,$(WIDGET_LAB_CODE)) www/widgets/rt-module.js
+widgets: $(patsubst lab%,www/widgets/lab%-browser.html,$(WIDGET_LAB_CODE)) $(patsubst lab%,www/widgets/lab%.js,$(WIDGET_LAB_CODE))
 
 lint: book/*.md src/*.py
 	python3 infra/compare.py --config config.json
@@ -27,18 +27,8 @@ www/draft/%.html: book/%.md infra/template.html infra/signup.html infra/filter.l
 www/rss.xml: news.yaml infra/rss-template.xml
 	pandoc --template infra/rss-template.xml  -f markdown -t html $< -o $@
 
-www/widgets/lab2.js: src/lab2.py src/lab2.hints infra/compile.py
-	python3 infra/compile.py $< $@ --hints src/lab2.hints --use-js-modules
-
-www/widgets/lab3.js: src/lab3.py src/lab2.hints infra/compile.py
-	python3 infra/compile.py $< $@ --hints src/lab3.hints --use-js-modules
-
 www/widgets/lab%.js: src/lab%.py src/lab%.hints infra/compile.py
-	python3 infra/compile.py $< $@ --hints src/lab$*.hints
-
-www/widgets/rt-module.js: www/widgets/rt.js
-	echo "export { breakpoint, http_textarea, lib, pysplit, rt_constants, truthy, Widget };" > www/widgets/rt-module.js
-	cat www/widgets/rt.js >> www/widgets/rt-module.js
+	python3 infra/compile.py $< $@ --hints src/lab$*.hints --use-js-modules
 
 www/widgets/lab%-browser.html: infra/labN-browser.html infra/labN-browser.lua config.json www/widgets/lab%.js
 	pandoc --lua-filter=infra/labN-browser.lua --metadata-file=config.json --metadata chapter=$* --template $< book/index.md -o $@

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ www/rss.xml: news.yaml infra/rss-template.xml
 www/widgets/lab2.js: src/lab2.py src/lab2.hints infra/compile.py
 	python3 infra/compile.py $< $@ --hints src/lab2.hints --use-js-modules
 
+www/widgets/lab3.js: src/lab3.py src/lab2.hints infra/compile.py
+	python3 infra/compile.py $< $@ --hints src/lab3.hints --use-js-modules
+
 www/widgets/lab%.js: src/lab%.py src/lab%.hints infra/compile.py
 	python3 infra/compile.py $< $@ --hints src/lab$*.hints
 

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -283,7 +283,7 @@ def compile_function(name, args, ctx):
     if name in RENAME_FNS:
         return RENAME_FNS[name] + "(" + ", ".join(args_js) + ")"
     elif name in OUR_FNS:
-        EXPORTS.append(name)
+     #   EXPORTS.append(name)
         return "await " + name + "(" + ", ".join(args_js) + ")"
     elif name in OUR_CLASSES:
         return "await (new " + name + "()).init(" + ", ".join(args_js) + ")"
@@ -600,6 +600,8 @@ def compile(tree, ctx, indent=0):
             last_line = "\n" + " " * indent + "}"
             return def_line + body + last_line
         else:
+            if ctx.type == "module":
+                EXPORTS.append(tree.name)
             kw = "" if ctx.type == "class" else "function "
             def_line = kw + tree.name + "(" + ", ".join(args) + ") {\n"
             if ctx.type != "class" or tree.name not in OUR_SYNC_METHODS:
@@ -765,10 +767,10 @@ def compile_module(tree, name, use_js_modules):
 
         imports_str = "import {{ {} }} from \"./{}\";"
 
-        rt_imports_arr = [ 'breakpoint', 'pysplit', 'truthy' ]
-        rt_imports = imports_str.format(",".join(rt_imports_arr), "rt-module.js")
+        rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'pysplit', 'truthy' ]
+        rt_imports = imports_str.format(",".join(rt_imports_arr), "rt.js")
 
-        render_imports_array = [ 'tkinter', 'socket' ]
+        render_imports_array = [ 'socket', 'ssl', 'tkinter' ]
         render_imports = imports_str.format(",".join(render_imports_array), "render.js")
         constants_export = "export " + constants_export
 

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -762,13 +762,13 @@ def compile_module(tree, name, use_js_modules):
     constants_export = "const constants = {};"
     if use_js_modules:
         if len(EXPORTS) > 0:
-            exports = "export {{ {} }};".format(",".join(EXPORTS))
+            exports = "export {{ {} }};".format(", ".join(EXPORTS))
 
         imports_str = "import {{ {} }} from \"./{}\";"
 
         rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'pysplit', 'truthy' ]
-        rt_imports_arr += IMPORTS
-        rt_imports = imports_str.format(",".join(rt_imports_arr), "rt.js")
+        rt_imports_arr += set([ mod.split(".")[0] for mod in IMPORTS])
+        rt_imports = imports_str.format(", ".join(rt_imports_arr), "rt.js")
 
         constants_export = "export " + constants_export
 

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -766,8 +766,8 @@ def compile_module(tree, name, use_js_modules):
 
         imports_str = "import {{ {} }} from \"./{}\";"
 
-        rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'pysplit',
-        'socket', 'ssl', 'tkinter', 'truthy' ]
+        rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'pysplit', 'truthy' ]
+        rt_imports_arr += IMPORTS
         rt_imports = imports_str.format(",".join(rt_imports_arr), "rt.js")
 
         constants_export = "export " + constants_export

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -767,15 +767,14 @@ def compile_module(tree, name, use_js_modules):
 
         imports_str = "import {{ {} }} from \"./{}\";"
 
-        rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'pysplit', 'truthy' ]
+        rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'pysplit',
+        'socket', 'ssl', 'tkinter', 'truthy' ]
         rt_imports = imports_str.format(",".join(rt_imports_arr), "rt.js")
 
-        render_imports_array = [ 'socket', 'ssl', 'tkinter' ]
-        render_imports = imports_str.format(",".join(render_imports_array), "render.js")
         constants_export = "export " + constants_export
 
-    return "{}\n{}\n{}\n{}\n\n{}".format(
-        exports, rt_imports, render_imports, constants_export, "\n\n".join(items))
+    return "{}\n{}\n{}\n\n{}".format(
+        exports, rt_imports, constants_export, "\n\n".join(items))
 
 if __name__ == "__main__":
     import sys, os

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -283,7 +283,6 @@ def compile_function(name, args, ctx):
     if name in RENAME_FNS:
         return RENAME_FNS[name] + "(" + ", ".join(args_js) + ")"
     elif name in OUR_FNS:
-     #   EXPORTS.append(name)
         return "await " + name + "(" + ", ".join(args_js) + ")"
     elif name in OUR_CLASSES:
         return "await (new " + name + "()).init(" + ", ".join(args_js) + ")"

--- a/infra/labN-browser.html
+++ b/infra/labN-browser.html
@@ -17,12 +17,13 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script src="rt.js"></script>
-<script src="lab$chapter$.js"></script>
-<script>
-socket = lib.socket({});
-ssl = lib.ssl();
-tkinter = lib.tkinter({ canvas: document.querySelector("#canvas") });
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab$chapter$.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab$chapter$.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
 
 let widget = new Widget(document.querySelector("#controls"));
 widget.run(async function() {

--- a/www/widgets/lab2-render.html
+++ b/www/widgets/lab2-render.html
@@ -20,7 +20,7 @@
 </figure>
 
 <script type="module" src="lab2.js"></script>
-<script type="module" src="rt.js"></script>
+<script type="module" src="rt-module.js"></script>
 <script type="module">
 import { Widget } from "./rt-module.js";
 import { Browser, constants }

--- a/www/widgets/lab2-render.html
+++ b/www/widgets/lab2-render.html
@@ -20,11 +20,15 @@
 </figure>
 
 <script type="module" src="lab2.js"></script>
-<script type="module" src="rt-module.js"></script>
+<script type="module" src="rt.js"></script>
 <script type="module">
-import { Widget } from "./rt-module.js";
-import { Browser, constants }
-  from "./lab2.js";
+import { http_textarea, rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab2.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+rt_constants.URLS = {
+  "http://input/": http_textarea(document.querySelector("#input"))
+};
 
 let widget = new Widget(document.querySelector("#controls"));
 widget.pause("draw");

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -230,7 +230,11 @@ function draw_widget() {
 function record(... names) {
     console.log('record')
     return function(... values) {
-        names.forEach((n, i) => (STATE[n] = values[i]));
+        names.forEach((n, i) => {
+            console.log(n);
+            //debugger;
+          (STATE[n] = values[i]);  
+        } );
         draw_widget();
     }
 }

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -74,9 +74,13 @@ line.baseline { stroke-dasharray: 5, 5; }
   </svg>
 </figure>
 
-<script src="lab3.js"></script>
-<script src="rt.js"></script>
-<script>
+<script type="module" src="lab3.js"></script>
+<script type="module" src="rt-module.js"></script>
+<script type="module">
+import { http_textarea, lib, Widget } from "./rt-module.js";
+import { Browser, constants }
+  from "./lab2.js";
+
 const ZOOM = 1.5;
 const colors = { a: "pink", A: "darkred", d: "lightblue", D: "darkblue" };
 
@@ -233,9 +237,12 @@ widget.pause("aligned", record("display_list"));
 widget.pause("max_descent", record("max_desc"));
 widget.pause("final_y", record("final_y"));
 
+console.log('here');
 widget.run(async function() {
+console.log('here2');
     STATE = {};
     let b = await (new Browser()).init();
+    console.log('loaded..');
     await b.load("http://input/")
 });
 </script>

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -77,16 +77,11 @@ line.baseline { stroke-dasharray: 5, 5; }
 <script type="module" src="lab3.js"></script>
 <script type="module" src="rt-module.js"></script>
 <script type="module">
-import { http_textarea, lib, Widget } from "./rt-module.js";
-import { Browser, constants }
-  from "./lab3.js";
+import { rt_constants, Widget } from "./rt-module.js";
+import { Browser, constants } from "./lab3.js";
 
-const ZOOM = 1.5;
+rt_constants.ZOOM = 1.5;
 const colors = { a: "pink", A: "darkred", d: "lightblue", D: "darkblue" };
-
-const socket = lib.socket({ "http://input/": http_textarea(document.querySelector("#input")) });
-const ssl = lib.ssl();
-const tkinter = lib.tkinter({ zoom: ZOOM });
 
 let widget = new Widget(document.querySelector("#controls"));
   
@@ -122,8 +117,8 @@ function draw_widget() {
     let width = 220;
     let tmargin = 30;
     let y1 = tmargin;
-    let b = y1 + 1.2 * STATE.max_asc * ZOOM;
-    let y2 = y1 + ZOOM * (STATE.final_y - STATE.initial_y);
+    let b = y1 + 1.2 * STATE.max_asc * rt_constants.ZOOM;
+    let y2 = y1 + rt_constants.ZOOM * (STATE.final_y - STATE.initial_y);
 
     if (STATE.initial_y || STATE.final_y) {
         g2.appendChild(svg("text", { x: 0, y: 20, class: "title" }, "Phase 2"));
@@ -151,7 +146,7 @@ function draw_widget() {
             x2: width, y2: b,
             class: "baseline",
         }));
-        let h = STATE.max_asc * ZOOM;
+        let h = STATE.max_asc * rt_constants.ZOOM;
         g2.appendChild(svg("rect", {
             x: -5, y: b - h,
             width: 5, height: h,
@@ -164,7 +159,7 @@ function draw_widget() {
         }));
     }
     if (STATE.max_desc) {
-        let h = STATE.max_desc * ZOOM;
+        let h = STATE.max_desc * rt_constants.ZOOM;
         g2.appendChild(svg("rect", {
             x: -5, y: b,
             width: 5, height: h,
@@ -183,7 +178,7 @@ function draw_widget() {
         g1.appendChild(svg("line", { x1: 0, y1: tmargin, x2: width, y2: tmargin }));
         for (let [x, word, font] of STATE.line) {
             g1.appendChild(svg("text", {
-                x: 5 + (x - constants.HSTEP) * ZOOM, y: tmargin,
+                x: 5 + (x - constants.HSTEP) * rt_constants.ZOOM, y: tmargin,
                 style: "font: " + font.string,
                 class: "drawn",
             }, word));
@@ -193,15 +188,15 @@ function draw_widget() {
     if (STATE.display_list) {
         STATE.display_list.forEach(function ([x, y, word, font], i) {
             let metric = STATE.metrics[i];
-            let dy = (y - STATE.initial_y) * ZOOM;
+            let dy = (y - STATE.initial_y) * rt_constants.ZOOM;
             g2.appendChild(svg("text", {
-                x: 10 + (x - constants.HSTEP) * ZOOM, y: dy + y1,
+                x: 10 + (x - constants.HSTEP) * rt_constants.ZOOM, y: dy + y1,
                 style: "font: " + font.string,
                 class: "drawn",
             }, word));
             g2.appendChild(svg("rect", {
-                x: 4 + (x - constants.HSTEP) * ZOOM, y: b - metric.ascent * ZOOM,
-                width: 5, height: metric.ascent * ZOOM,
+                x: 4 + (x - constants.HSTEP) * rt_constants.ZOOM, y: b - metric.ascent * rt_constants.ZOOM,
+                width: 5, height: metric.ascent * rt_constants.ZOOM,
                 class: "areg",
             }))
         });
@@ -214,13 +209,13 @@ function draw_widget() {
         STATE.line.forEach(function ([x, word, font], i){
             let metric = STATE.metrics[i];
             g1.appendChild(svg("rect", {
-                x: (x - constants.HSTEP) * ZOOM, y: tmargin,
-                width: 5, height: metric.ascent * ZOOM,
+                x: (x - constants.HSTEP) * rt_constants.ZOOM, y: tmargin,
+                width: 5, height: metric.ascent * rt_constants.ZOOM,
                 class: metric.ascent === STATE.max_asc ? "amax" : "areg",
             }))
             g1.appendChild(svg("rect", {
-                x: (x - constants.HSTEP) * ZOOM, y: tmargin + metric.ascent * ZOOM,
-                width: 5, height: metric.descent * ZOOM,
+                x: (x - constants.HSTEP) * rt_constants.ZOOM, y: tmargin + metric.ascent * rt_constants.ZOOM,
+                width: 5, height: metric.descent * rt_constants.ZOOM,
                 class: metric.ascent === STATE.max_asc ? "dmax" : "dreg",
             }))
         });

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -220,9 +220,7 @@ function draw_widget() {
 
 function record(... names) {
     return function(... values) {
-        names.forEach((n, i) => {
-          (STATE[n] = values[i]);  
-        } );
+        names.forEach((n, i) => (STATE[n] = values[i]));
         draw_widget();
     }
 }

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -75,12 +75,17 @@ line.baseline { stroke-dasharray: 5, 5; }
 </figure>
 
 <script type="module" src="lab3.js"></script>
-<script type="module" src="rt-module.js"></script>
+<script type="module" src="rt.js"></script>
 <script type="module">
-import { rt_constants, Widget } from "./rt-module.js";
+import { http_textarea, rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab3.js";
 
 rt_constants.ZOOM = 1.5;
+rt_constants.TKELEMENT = document.createElement("canvas");
+rt_constants.URLS = {
+  "http://input/": http_textarea(document.querySelector("#input"))
+};
+
 const colors = { a: "pink", A: "darkred", d: "lightblue", D: "darkblue" };
 
 let widget = new Widget(document.querySelector("#controls"));

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -208,6 +208,9 @@ function draw_widget() {
     }
 
     if (STATE.metrics) {
+        console.log('metrics');
+        console.log(constants.HSTEP)
+        console.log(constants.VSTEP)
         STATE.line.forEach(function ([x, word, font], i){
             let metric = STATE.metrics[i];
             g1.appendChild(svg("rect", {

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -108,7 +108,6 @@ function svg(tag, attrs, children) {
 }
   
 function draw_widget() {
-    console.log('draw_widget')
     let g1 = document.querySelector("#g1");
     let g2 = document.querySelector("#g2");
     while (g1.children.length) g1.removeChild(g1.children[0]);
@@ -203,9 +202,6 @@ function draw_widget() {
     }
 
     if (STATE.metrics) {
-        console.log('metrics');
-        console.log(constants.HSTEP)
-        console.log(constants.VSTEP)
         STATE.line.forEach(function ([x, word, font], i){
             let metric = STATE.metrics[i];
             g1.appendChild(svg("rect", {
@@ -223,11 +219,8 @@ function draw_widget() {
 }
 
 function record(... names) {
-    console.log('record')
     return function(... values) {
         names.forEach((n, i) => {
-            console.log(n);
-            //debugger;
           (STATE[n] = values[i]);  
         } );
         draw_widget();
@@ -241,7 +234,6 @@ widget.pause("aligned", record("display_list"));
 widget.pause("max_descent", record("max_desc"));
 widget.pause("final_y", record("final_y"));
 
-console.log('here');
 widget.run(async function() {
     STATE = {};
     let b = await (new Browser()).init();

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -79,7 +79,7 @@ line.baseline { stroke-dasharray: 5, 5; }
 <script type="module">
 import { http_textarea, lib, Widget } from "./rt-module.js";
 import { Browser, constants }
-  from "./lab2.js";
+  from "./lab3.js";
 
 const ZOOM = 1.5;
 const colors = { a: "pink", A: "darkred", d: "lightblue", D: "darkblue" };
@@ -113,6 +113,7 @@ function svg(tag, attrs, children) {
 }
   
 function draw_widget() {
+    console.log('draw_widget')
     let g1 = document.querySelector("#g1");
     let g2 = document.querySelector("#g2");
     while (g1.children.length) g1.removeChild(g1.children[0]);
@@ -224,6 +225,7 @@ function draw_widget() {
 }
 
 function record(... names) {
+    console.log('record')
     return function(... values) {
         names.forEach((n, i) => (STATE[n] = values[i]));
         draw_widget();
@@ -239,10 +241,8 @@ widget.pause("final_y", record("final_y"));
 
 console.log('here');
 widget.run(async function() {
-console.log('here2');
     STATE = {};
     let b = await (new Browser()).init();
-    console.log('loaded..');
     await b.load("http://input/")
 });
 </script>

--- a/www/widgets/lab5-propagate.html
+++ b/www/widgets/lab5-propagate.html
@@ -29,12 +29,16 @@
   <pre id="output" style="width: 352px; height: 160px;"></pre>
 </figure>
 
-<script src="lab5.js"></script>
-<script src="rt.js"></script>
-<script>
-const socket = lib.socket({ "http://input/": http_textarea(document.querySelector("#input")) });
-const ssl = lib.ssl();
-const tkinter = lib.tkinter({ zoom: 2.0 });
+<script type="module" src="lab5.js"></script>
+<script type="module" src="rt.js"></script>
+<script type="module">
+import { http_textarea, rt_constants, Widget } from "./rt.js";
+import { BlockLayout, Browser, DocumentLayout, InlineLayout } from "./lab5.js";
+
+rt_constants.TKELEMENT = document.createElement("canvas");
+rt_constants.URLS = {
+  "http://input/": http_textarea(document.querySelector("#input"))
+};
 
 let widget = new Widget(document.querySelector("#controls"));
   

--- a/www/widgets/render.js
+++ b/www/widgets/render.js
@@ -1,7 +1,0 @@
-import { http_textarea, lib } from "./rt.js";
-
-export { socket, ssl, tkinter };
-
-const socket = lib.socket();
-const ssl = lib.ssl();
-const tkinter = lib.tkinter();

--- a/www/widgets/render.js
+++ b/www/widgets/render.js
@@ -1,6 +1,7 @@
-import { http_textarea, lib } from "./rt-module.js";
+import { http_textarea, lib } from "./rt.js";
 
-export { socket, tkinter };
+export { socket, ssl, tkinter };
 
-const socket = lib.socket({ "http://input/": http_textarea(document.querySelector("#input")) });
-const tkinter = lib.tkinter({ canvas: document.querySelector("#canvas"), zoom: 2.0 });
+const socket = lib.socket();
+const ssl = lib.ssl();
+const tkinter = lib.tkinter();

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -459,5 +459,10 @@ class FileSystem {
     }
 }
 
-
 const filesystem = new FileSystem();
+
+export { socket, ssl, tkinter };
+
+const socket = lib.socket();
+const ssl = lib.ssl();
+const tkinter = lib.tkinter();

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -1,5 +1,8 @@
 /* This file simulates Python packages used by the WBE browser */
 
+
+export { breakpoint, comparator, filesystem, http_textarea, lib, pysplit, rt_constants, truthy, Widget };
+
 window.TKELEMENT = null;
 
 function wrap_class(cls) {
@@ -24,6 +27,8 @@ function http_textarea(elt) {
 
 const rt_constants = {};
 rt_constants.ZOOM = 1.0;
+rt_constants.TKELEMENT = null;
+rt_constants.URLS = {};
 
 class lib {
 
@@ -52,7 +57,7 @@ static socket(URLS) {
             let [line1] = this.input.split("\r\n", 1);
             let [method, path, protocol] = line1.split(" ");
             this.url = this.scheme + "://" + this.host + path;
-            if (typeof URLS[this.url] == "undefined" && this.host == "browser.engineering") {
+            if (typeof rt_constants.URLS[this.url] == "undefined" && this.host == "browser.engineering") {
                 let response = await fetch(path);
                 this.output = "HTTP/1.0 " + response.status + " " + response.statusText + "\r\n";
                 for (let [header, value] of response.headers.entries()) {
@@ -64,7 +69,7 @@ static socket(URLS) {
                 this.idx = 0;
                 return this;
             } else {
-                this.output = URLS[this.url];
+                this.output = rt_constants.URLS[this.url];
                 if (!this.output) {
                     throw Error("Unknown URL " + this.url);               
                 } else if (typeof this.output === "function") {
@@ -108,12 +113,10 @@ static ssl() {
     return { create_default_context: wrap_class(context) };
 }
 
-static tkinter(options) {
-    let TKELEMENT = options?.canvas ?? document.createElement("canvas");
- 
+static tkinter(options) { 
     class Tk {
         constructor() {
-            this.elt = TKELEMENT;
+            this.elt = rt_constants.TKELEMENT;
         }
 
         bind(key, fn) {
@@ -222,13 +225,13 @@ static tkinter(options) {
         }
 
         measure(text) {
-            let ctx = TKELEMENT.getContext('2d');
+            let ctx = rt_constants.TKELEMENT.getContext('2d');
             ctx.font = this.string;
             return ctx.measureText(text).width / rt_constants.ZOOM;
         }
 
         metrics(field) {
-            let ctx = TKELEMENT.getContext('2d');
+            let ctx = rt_constants.TKELEMENT.getContext('2d');
             ctx.textBaseline = "alphabetic";
             ctx.font = this.string;
             let m = ctx.measureText("Hxy");

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -1,7 +1,8 @@
 /* This file simulates Python packages used by the WBE browser */
 
 
-export { breakpoint, comparator, filesystem, http_textarea, lib, pysplit, rt_constants, truthy, Widget };
+export { breakpoint, comparator, filesystem, http_textarea, lib, pysplit,
+    rt_constants, socket, ssl, tkinter, truthy, Widget };
 
 window.TKELEMENT = null;
 
@@ -460,8 +461,6 @@ class FileSystem {
 }
 
 const filesystem = new FileSystem();
-
-export { socket, ssl, tkinter };
 
 const socket = lib.socket();
 const ssl = lib.ssl();

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -22,6 +22,9 @@ function http_textarea(elt) {
     }
 }
 
+const rt_constants = {};
+rt_constants.ZOOM = 1.0;
+
 class lib {
 
 static socket(URLS) {
@@ -107,8 +110,7 @@ static ssl() {
 
 static tkinter(options) {
     let TKELEMENT = options?.canvas ?? document.createElement("canvas");
-    let ZOOM = options?.zoom ?? 1.0;
-
+ 
     class Tk {
         constructor() {
             this.elt = TKELEMENT;
@@ -148,10 +150,10 @@ static tkinter(options) {
     class Canvas {
         constructor(tk, params) {
             this.tk = tk;
-            this.tk.elt.width = params.width * ZOOM;
-            this.tk.elt.height = params.height * ZOOM;
+            this.tk.elt.width = params.width * rt_constants.ZOOM;
+            this.tk.elt.height = params.height * rt_constants.ZOOM;
             this.ctx = tk.elt.getContext('2d');
-            this.ctx.font = "normal normal " + 16 * ZOOM + "px serif"
+            this.ctx.font = "normal normal " + 16 * rt_constants.ZOOM + "px serif"
         }
 
         pack() {}
@@ -163,7 +165,7 @@ static tkinter(options) {
 
         create_rectangle(x1, y1, x2, y2, params) {
             this.ctx.beginPath();
-            this.ctx.rect(x1 * ZOOM, y1 * ZOOM, (x2 - x1) * ZOOM, (y2 - y1) * ZOOM);
+            this.ctx.rect(x1 * rt_constants.ZOOM, y1 * rt_constants.ZOOM, (x2 - x1) * rt_constants.ZOOM, (y2 - y1) * rt_constants.ZOOM);
             this.ctx.fillStyle = params.fill ?? "transparent";
             this.ctx.fill();
             if ((params.width ?? 0) != 0) {
@@ -175,8 +177,8 @@ static tkinter(options) {
 
         create_line(x1, y1, x2, y2) {
             this.ctx.beginPath();
-            this.ctx.moveTo(x1 * ZOOM, y1 * ZOOM);
-            this.ctx.lineTo(x2 * ZOOM, y2 * ZOOM);
+            this.ctx.moveTo(x1 * rt_constants.ZOOM, y1 * rt_constants.ZOOM);
+            this.ctx.lineTo(x2 * rt_constants.ZOOM, y2 * rt_constants.ZOOM);
             this.ctx.lineWidth = 1;
             this.ctx.strokeStyle = "black";
             this.ctx.stroke();
@@ -184,10 +186,10 @@ static tkinter(options) {
 
         create_polygon(... args) {
             this.ctx.beginPath();
-            this.ctx.moveTo(args[0] * ZOOM, args[1] * ZOOM);
+            this.ctx.moveTo(args[0] * rt_constants.ZOOM, args[1] * rt_constants.ZOOM);
             let i;
             for (i = 2; i < args.length - 1; i += 2) {
-                this.ctx.lineTo(args[i] * ZOOM, args[i + 1] * ZOOM);
+                this.ctx.lineTo(args[i] * rt_constants.ZOOM, args[i + 1] * rt_constants.ZOOM);
             }
             this.ctx.fillStyle = args[i].fill ?? "transparent";
             this.ctx.fill();
@@ -206,7 +208,7 @@ static tkinter(options) {
             if (params.font) this.ctx.font = params.font.string;
             this.ctx.lineWidth = 0;
             this.ctx.fillStyle = params.fill ?? "black";
-            if (params.text) this.ctx.fillText(params.text, x * ZOOM, y * ZOOM);
+            if (params.text) this.ctx.fillText(params.text, x * rt_constants.ZOOM, y * rt_constants.ZOOM);
         }
     }
     
@@ -216,13 +218,13 @@ static tkinter(options) {
             this.weight = params.weight ?? "normal";
             this.style = params.style ?? "normal";
             this.string = (this.style == "roman" ? "normal" : this.style) + 
-                " " + this.weight + " " + this.size * ZOOM + "px serif";
+                " " + this.weight + " " + this.size * rt_constants.ZOOM + "px serif";
         }
 
         measure(text) {
             let ctx = TKELEMENT.getContext('2d');
             ctx.font = this.string;
-            return ctx.measureText(text).width / ZOOM;
+            return ctx.measureText(text).width / rt_constants.ZOOM;
         }
 
         metrics(field) {
@@ -236,11 +238,11 @@ static tkinter(options) {
             // We fake them in the other browsers by guessing that emHeight = font.size
             // This is not quite right but is close enough for many fonts...
             if (m.emHeightAscent && m.emHeightDescent) {
-                asc = ctx.measureText("Hxy").emHeightAscent / ZOOM;
-                desc = ctx.measureText("Hxy").emHeightDescent / ZOOM;
+                asc = ctx.measureText("Hxy").emHeightAscent / rt_constants.ZOOM;
+                desc = ctx.measureText("Hxy").emHeightDescent / rt_constants.ZOOM;
             } else {
-                asc = ctx.measureText("Hxy").actualBoundingBoxAscent / ZOOM;
-                desc = ctx.measureText("Hxy").actualBoundingBoxDescent / ZOOM;
+                asc = ctx.measureText("Hxy").actualBoundingBoxAscent / rt_constants.ZOOM;
+                desc = ctx.measureText("Hxy").actualBoundingBoxDescent / rt_constants.ZOOM;
                 let gap = this.size - (asc + desc)
                 asc += gap / 2;
                 desc += gap / 2;


### PR DESCRIPTION
To do this, I had to change the configuration options bound to tkinter, ssl, and socket to global variables. This is because not all labs use the same options, and otherwise there wasn't a way to set it from the HTML file's module. This also allowed me to remove render.js. A future change can refactor rt.js a bit to remove the need for the tkinter, ssl and socket global variables, as they no longer bind a variable.
