### PR TITLE
New focus tracking for Chapter 8

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -215,7 +215,7 @@ class Tab:
                 return
 ```
 
-But remember that keyboard input isn't handled by the `Tab`---it is
+But remember that keyboard input isn't handled by the `Tab`---it's
 handled by the `Browser`. So how does the `Browser` even know that the
 `Tab` should handle a certain keyboard event? Well, the answer is that
 the `Browser` has to remember that the `Tab` is in focus!
@@ -262,8 +262,8 @@ graphical widgets; in a real browser, where web pages can be embedded
 into one another with `iframe`s, the focus tree can be arbitrarily deep.
 
 So now we have user input working with `input` elements. Before we
-move on, just one last tweak that we need to make: drawing the text
-cursor. We can do that in the `Tab`'s `draw` method:
+move on, there is one last tweak that we need to make: drawing the
+text cursor. We can do that in the `Tab`'s `draw` method:
 
 ``` {.python}
 class Tab:


### PR DESCRIPTION
This PR contains *just the text*, so the tests fail, but you should ignore that and just review the text. Overall, the big change here is that we have two levels of focus tracking: once in the `Browser` object and once in the `Tab` object. That was pretty hard to explain well, so please read that part carefully.

One big question I had was whether or not to include blurring; I decided not to, which means if you click in a text box and then in the address bar there will be two cursors onscreen, but I felt that wasn't too bad. The alternative was to add a blur call to tabs, and if we're doing that perhaps we would add explicit focus and blur calls to layout objects, and if we're doing that perhaps text areas should draw their own cursors when focused. This is a cleaner design, but there's more code, and it's not what Chrome actually does, so I decided against.