### PR TITLE
New text on submitting forms

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -327,24 +327,28 @@ class Tab:
 ```
 
 Now, any time you see something like this, you've got to ask: what if
-the name or the value has an equal sign or an ampersand in it? So form
-encoding has special handling for special characters:
+the name or the value has an equal sign or an ampersand in it? In
+fact, there is special handling for special characters: "percent
+encoding" replaces all special characters with a percent sign followed
+by those characters' hex codes. For example, a space becomes `%20` and
+a period becomes `%2e`. Python provides a percent-encoding function as
+`quote` in the `urllib` module:
+
 
 ``` {.python indent=8}
 for input in inputs:
     # ...
-    name = percent_encode(name)
-    value = percent_encode(value)
+    name = urllib.quote(name)
+    value = urllib.quote(value)
     # ...
 ```
 
-This "percent encoding" replaces all special characters with a percent
-sign followed by those characters' hex codes; for example, a space
-becomes `%20` and a period becomes `%2e`. Python provides a
-percent-encoding function as `quote` in the `urllib` module, or you
-can write your own. (You can even skip percent encoding, but then you
+You can write your own `percent_encode` function using Python's `ord`
+and `hex` functions instead if you'd like, but here we're using the
+standard function for expediency; it's not a particularly interesting
+funciton, but it is necessary (if you skip percent encoding, your
 browser won't handle requests with equal signs, percent signs, or
-ampersands correctly.)
+ampersands correctly).
 
 Now that `submit_form` has built the request body, it needs to finally
 send that request:

--- a/book/forms.md
+++ b/book/forms.md
@@ -653,12 +653,21 @@ is better with friends!
 Exercises
 =========
 
+*Enter key*: In most browsers, if you hit the "Enter" or "Return" key
+while inside a text entry, that submits the form that the text entry
+was in. Add this feature to your browser.
+
 *Check boxes*: Add checkboxes. In HTML, checkbox `<input>`
 elements with the `type` attribute set to `checkbox`. The checkbox is
 checked if it has the `checked` attribute set, and unchecked
 otherwise. Submitting checkboxes in a form is a little tricky,
 though. A checkbox named `foo` only appears in the form encoding if
 it is checked. Its key is its `name` and its value is the empty string.
+
+*Blurring*: Right now, if you click inside a text entry, and then
+inside the address bar, two cursors will appear on the screen. To fix
+this, add a `blur` method to each `Tab` which unfocuses anything that
+is focused, and call it whenever focus leaves that tab.
 
 *GET forms*: Forms can be submitted via GET requests as well as POST
 requests. In GET requests, the form-encoded data is pasted onto the

--- a/book/forms.md
+++ b/book/forms.md
@@ -332,23 +332,31 @@ fact, there is special handling for special characters: "percent
 encoding" replaces all special characters with a percent sign followed
 by those characters' hex codes. For example, a space becomes `%20` and
 a period becomes `%2e`. Python provides a percent-encoding function as
-`quote` in the `urllib` module:
+`quote` in the `urllib.parse` module:
 
 
 ``` {.python indent=8}
 for input in inputs:
     # ...
-    name = urllib.quote(name)
-    value = urllib.quote(value)
+    name = urllib.parse.quote(name)
+    value = urllib.parse.quote(value)
     # ...
 ```
 
 You can write your own `percent_encode` function using Python's `ord`
-and `hex` functions instead if you'd like, but here we're using the
-standard function for expediency; it's not a particularly interesting
-funciton, but it is necessary (if you skip percent encoding, your
-browser won't handle requests with equal signs, percent signs, or
-ampersands correctly).
+and `hex` functions instead if you'd like,[^why-use-library] but here
+we're using the standard function for expediency; it's not a
+particularly interesting funciton, but it is necessary (if you skip
+percent encoding, your browser won't handle requests with equal signs,
+percent signs, or ampersands correctly).
+
+[^why-use-library]: Why use the `urllib` library here, but not
+    elsewhere in our browser? Why, for example, use its `quote` method
+    here but not its `parse` method in [Chapter 1](http.md)?
+    Basically, because while percent encoding is necessary, it is
+    not conceptually interesting, and in these later chapters my goal
+    is to show how conceptual extensions to the browser get built.
+    Some details are necessarily elided.
 
 Now that `submit_form` has built the request body, it needs to finally
 send that request:

--- a/book/forms.md
+++ b/book/forms.md
@@ -679,7 +679,7 @@ it is checked. Its key is its `name` and its value is the empty string.
 *Blurring*: Right now, if you click inside a text entry, and then
 inside the address bar, two cursors will appear on the screen. To fix
 this, add a `blur` method to each `Tab` which unfocuses anything that
-is focused, and call it whenever focus leaves that tab.
+is focused, and call it before changing focus.
 
 *GET forms*: Forms can be submitted via GET requests as well as POST
 requests. In GET requests, the form-encoded data is pasted onto the

--- a/book/forms.md
+++ b/book/forms.md
@@ -339,23 +339,12 @@ for input in inputs:
 ```
 
 This "percent encoding" replaces all special characters with a percent
-sign followed by those characters' hex codes:
-
-``` {.python}
-def percent_encode(s):
-    out = ""
-    for c in s:
-        if c.isalnum():
-            out += c
-        else:
-            out += "%" + hex(ord(c))[2:]
-    return s
-```
-
-Here the `ord` function in Python gets the character's numeric value,
-`hex` converts it to a hexadecimal string like `0x25`, and then the
-code strips off the first two characters (the `0x`) and replaces them
-with a percent sign.
+sign followed by those characters' hex codes; for example, a space
+becomes `%20` and a period becomes `%2e`. Python provides a
+percent-encoding function as `quote` in the `urllib` module, or you
+can write your own. (You can even skip percent encoding, but then you
+browser won't handle requests with equal signs, percent signs, or
+ampersands correctly.)
 
 Now that `submit_form` has built the request body, it needs to finally
 send that request:


### PR DESCRIPTION
This PR has *just the text*, so the tests fail, but we should ignore that and merge it anyway.

Mostly the changes here are small. First, I'm leveraging `tree_to_list` to make the code that finds all `inputs` inside a `form` clearer. I also implemented proper percent encoding because I realized that implementing "bad" percent encoding is a bad habit security wise. This will require proper decoding on the server, so it's at least two tricky code blocks, but I felt that cost was worth paying.