### PR TITLE
Move JS binding code into a JSContext

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -783,7 +783,7 @@ def innerHTML(self, handle, s):
     new_nodes = doc.children[0].children
 ```
 
-Don't forget to register the `innerHTML` function: Note that we
+Don't forget to register the `innerHTML` function. Note that we
 extract all children of the `body` element, because an `innerHTML`
 call can create multiple nodes at a time. These new nodes must now be
 made children of the element `innerHTML` was called on:

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1083,10 +1083,21 @@ Implement all three methods.
 provided child and returns it, bringing that child---and its subtree---back
 into an *unnattached* state. (It can then be *reattached* elsewhere, or
 deleted.) Implement this method. It's more challenging to implement this one,
-, because you'll need to also remove the subtree from the Python side, and
-  delete any layout objects associated with it.
+because you'll need to also remove the subtree from the Python side, and
+delete any layout objects associated with it.
 
 [removeChild]: https://developer.mozilla.org/en-US/docs/Web/API/Node/removeChild
+
+*IDs*: When an HTML element on a page has an `id` attribute, a
+variable is predefined in the JavaScript context refering to that
+element.[^standard] So, if a page has a `<div id="foo"></div>`, then the variable
+`foo` refers to that node. Implement this in your browser. Make sure
+to handle the case of nodes being added and removed (such as with
+`innerHTML`).
+
+[^standard]: This is [standard][html5-varnames] behavior.
+
+[html5-varnames]: http://www.whatwg.org/specs/web-apps/current-work/#named-access-on-the-window-object
 
 *Event Bubbling*: Try to run an event handler when the user clicks on a link:
  you'll find that it's actually impossible. That's because when you click a

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -162,37 +162,46 @@ Registering functions
 Browsers don't just print the last expression in a script; scripts
 call the standard `console.log` function to print. To allow that, we
 will need to *register a function* with DukPy, which would allow
-Javascript code to run Python functions. Those functions are
-registered on a `JSInterpreter` object, which we'll need to create:
+Javascript code to run Python functions. There are going to be a lot
+of these functions, so to avoid polluting the `Tab` object with many
+new methods, let's put this code in a new `JSContext` class:
 
-``` {.python}
-class Tab:
-    def setup_js(self):
-        self.js = dukpy.JSInterpreter()
+``` {.python replace=__init__(self)/__init__(self%2c%20tab)}
+class JSContext:
+    def __init__(self):
+        self.interp = dukpy.JSInterpreter()
+
+    def run(self, code):
+        self.interp.evaljs(code)
 ```
 
-We can call this `setup_js` function when pages load:
+This `JSInterpreter` object stores the values of all the JavaScript
+variables and lets us run multiple JavaScript snippets while sharing
+the same variables.
 
-``` {.python}
+We create a `JSContext` while loading the page:
+
+``` {.python replace=JSContext()/JSContext(self)}
 class Tab:
     def load(self, url, body=None):
         # ...
-        self.setup_js()
+        self.js = JSContext()
         for script in scripts:
             # ...
 ```
 
-The JavaScript function `console.log` corresponds to the Python
-`print` function.[^5] We can register this correspondence using
-`export_function`:
+Let's start registering functions. The JavaScript function
+`console.log` corresponds to the Python `print` function.[^5] We can
+register this correspondence using `export_function`:
 
 [^5]: If you're using Python 2, for some reason, you'll need to write
     a little wrapper function around `print` instead.
 
-``` {.python}
-def setup_js(self):
-    # ...
-    self.js.export_function("log", print)
+``` {.python replace=__init__(self)/__init__(self%2c%20tab)}
+class JSContext:
+    def __init__(self):
+        # ...
+        self.interp.export_function("log", print)
 ```
 
 Then, in JavaScript, Dukpy provides a `call_python` function that you
@@ -230,21 +239,22 @@ code, which handles certain JavaScript functions; and JavaScript code,
 which wraps the Python API to look more like the JavaScript one. We
 can call that JavaScript code our "JavaScript runtime"; we run it
 before we run any user code, so let's stick it in a `runtime.js`
-file that's run in `setup_js`:
+file that's run when the `JSContext` is created:
 
-``` {.python replace=runtime/runtime9}
-def setup_js(self):
-    # ...
-    with open("runtime.js") as f:
-        self.js.evaljs(f.read())
+``` {.python replace=runtime/runtime9,__init__(self)/__init__(self%2c%20tab)}
+class JSContext:
+    def __init__(self):
+        # ...
+        with open("runtime.js") as f:
+            self.interp.evaljs(f.read())
 ```
 
 Now you should be able to run the script `console.log("Hi from JS!")`
 and see output in your terminal. Do test that you can now call
 `console.log`, even multiple times, from a script.
 
-As a side benefit of using one `JSInterpreter` for all scripts, it is
-now possible to run two scripts and have one of them define a variable
+As a side benefit of using one `JSContext` for all scripts, it is now
+possible to run two scripts and have one of them define a variable
 that the other uses, say on a page like:
 
 ``` {.html}
@@ -289,7 +299,7 @@ crashes:
 
 ``` {.python indent=8}
 try:
-    print("Script returned: ", self.js.evaljs(body))
+    print("Script returned: ", self.js.run(body))
 except dukpy.JSRuntimeError as e:
     print("Script", script, "crashed", e)
 ```
@@ -356,12 +366,13 @@ element, and won't allow reading those contents.
 
 Let's start with `querySelectorAll`. First, register a function:
 
-``` {.python indent=4}
-def setup_js(self):
-    # ...
-    self.js.export_function("querySelectorAll",
-        self.js_querySelectorAll)
-    # ...
+``` {.python replace=__init__(self)/__init__(self%2c%20tab)}
+class JSContext:
+    def __init__(self):
+        # ...
+        self.interp.export_function("querySelectorAll",
+            self.querySelectorAll)
+        # ...
 ```
 
 In JavaScript, `querySelectorAll` is a method on the `document`
@@ -373,13 +384,14 @@ document = { querySelectorAll: function(s) {
 }}
 ```
 
-The `js_querySelectorAll` handler will first parse the selector, then
+The `querySelectorAll` handler will first parse the selector, then
 find and return the matching elements. To parse just the selector,
 I'll call into the `CSSParser`'s `selector` method:
 
 ``` {.python}
-def js_querySelectorAll(self, selector_text):
-    selector = CSSParser(selector_text).selector()
+class JSContext:
+    def querySelectorAll(self, selector_text):
+        selector = CSSParser(selector_text).selector()
 ```
 
 If you pass `querySelectorAll` an invalid selector,
@@ -388,12 +400,25 @@ crashes. At that point DukPy turns that Python-side exception into a
 JavaScript-side exception in the web script we are running, which can
 catch it or do something else.
 
-Next we need to find and return all matching elements:
+Next we need to find and return all matching elements. To do that, we
+need the `JSContext` to have access to the `Tab`, specifically to the
+`nodes` field. So let's pass in the `Tab` object when creating a
+`JSContext`:
+
+``` {.python}
+class JSContext:
+    def __init__(self, tab):
+        self.tab = tab
+        # ...
+```
+
+Now inside `querySelectorAll` we can return all matching nodes:
 
 ``` {.python expected=False}
-def js_querySelectorAll(self, selector_text):
+def querySelectorAll(self, selector_text):
     # ...
-    nodes = [node for node in tree_to_list(nodes, [])
+    nodes = [node for node
+             in tree_to_list(self.tab.nodes, [])
              if selector.matches(node)]
     return nodes
 ```
@@ -427,8 +452,9 @@ We'll need to keep track of the handle to node mapping. Let's create a
 `handle_to_node` map that goes the other way:
 
 ``` {.python}
-class Tab:
-    def setup_js(self):
+class JSContext:
+    def __init__(self, tab):
+        # ...
         self.node_to_handle = {}
         self.handle_to_node = {}
         # ...
@@ -438,7 +464,7 @@ Then, I'll allocate new handles for each node being returned into
 JavaScript:
 
 ``` {.python}
-def js_querySelectorAll(self, selector_text):
+def querySelectorAll(self, selector_text):
     # ...
     return [self.get_handle(node) for node in nodes]
 ```
@@ -449,15 +475,16 @@ exist yet:[^id-elt]
 [^id-elt]: `node_to_handle` uses `id(elt)` instead of `elt` as its key
     because Python objects can't be used as hash keys by default.
 
-``` {.python indent=4}
-def get_handle(self, elt):
-    if elt not in self.node_to_handle:
-        handle = len(self.node_to_handle)
-        self.node_to_handle[id(elt)] = handle
-        self.handle_to_node[handle] = elt
-    else:
-        handle = self.node_to_handle[elt]
-    return handle
+``` {.python}
+class JSContext:
+    def get_handle(self, elt):
+        if elt not in self.node_to_handle:
+            handle = len(self.node_to_handle)
+            self.node_to_handle[id(elt)] = handle
+            self.handle_to_node[handle] = elt
+        else:
+            handle = self.node_to_handle[elt]
+        return handle
 ```
 
 Calling `document.querySelectorAll` will now return something like
@@ -482,8 +509,8 @@ Well, the idea is that `getAttribute` should take in handles and
 convert those handles back into elements. It would look like this:
 
 ``` {.python}
-class Tab:
-    def js_getAttribute(self, handle, attr):
+class JSContext:
+    def getAttribute(self, handle, attr):
         elt = self.handle_to_node[handle]
         return elt.attributes.get(attr, None)
 ```
@@ -582,7 +609,7 @@ class Tab:
         # ...
         elt = objs[-1].node
         if elt:
-            self.dispatch_event("click", elt)
+            self.js.dispatch_event("click", elt)
         # ...
 ```
 
@@ -592,7 +619,7 @@ Second, before updating input area values:
 class Tab:
     def keypress(self, char):
         if self.focus:
-            self.dispatch_event("keydown", self.focus)
+            self.js.dispatch_event("keydown", self.focus)
             self.focus.attributes["value"] += char
 ```
 
@@ -601,7 +628,7 @@ request to the server:
 
 ``` {.python expected=False}
 def submit_form(self, elt):
-    self.dispatch_event("submit", elt)
+    self.js.dispatch_event("submit", elt)
     # ...
 ```
 
@@ -646,11 +673,11 @@ When an event happens in the browser, it can call `__runListeners` from
 Python:
 
 ``` {.python expected=False}
-class Tab:
+class JSContext:
     def dispatch_event(self, type, elt):
         code = "__runListeners(dukpy.type, dukpy.handle)"
         handle = self.node_to_handle.get(elt, -1)
-        self.js.evaljs(code, type=type, handle=handle)
+        self.interp.evaljs(code, type=type, handle=handle)
 ```
 
 Here the `code` variable contains a string of JavaScript code, code
@@ -741,15 +768,6 @@ Object.defineProperty(Node.prototype, 'innerHTML', {
 });
 ```
 
-Next, we need to register the `innerHTML` function:
-
-``` {.python indent=4}
-def setup_js(self):
-    # ...
-    self.js.export_function("innerHTML", self.js_innerHTML)
-    # ...
-```
-
 In `innerHTML`, we'll need to parse the HTML string. That turns out to
 be trickier than you'd think, because our browser's HTML parser is
 intended to parse whole HTML documents, not document fragments like
@@ -760,18 +778,18 @@ HTML string in an `html` and `body` element:
     HTML fragments.
 
 ``` {.python indent=4}
-def js_innerHTML(self, handle, s):
+def innerHTML(self, handle, s):
     doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
     new_nodes = doc.children[0].children
 ```
 
-Note that we extract all children of the `body` element, because an
-`innerHTML` call can create multiple nodes at a time. These new nodes
-must now be made children of the element `innerHTML` was called
-on:
+Don't forget to register the `innerHTML` function: Note that we
+extract all children of the `body` element, because an `innerHTML`
+call can create multiple nodes at a time. These new nodes must now be
+made children of the element `innerHTML` was called on:
 
 ``` {.python indent=4}
-def js_innerHTML(self, handle, s):
+def innerHTML(self, handle, s):
     # ...
     elt = self.handle_to_node[handle]
     elt.children = new_nodes
@@ -818,9 +836,10 @@ Now, whenever the page changes, we can lay it out again by calling
 `render`:
 
 ``` {.python}
-def js_innerHTML(self, handle, s):
-    # ...
-    self.render()
+class JSContext:
+    def innerHTML(self, handle, s):
+        # ...
+        self.tab.render()
 ```
 
 JavaScript can now modify the web page!
@@ -936,35 +955,39 @@ function __runListeners(handle, type) {
 On the Python side, `event` can return that boolean to its handler:
 
 ``` {.python}
-def dispatch_event(self, type, elt):
-    # ...
-    do_default = self.js.evaljs(code, type=type, handle=handle)
-    return not do_default
+class JSContext:
+    def dispatch_event(self, type, elt):
+        # ...
+        do_default = self.interp.evaljs(code, type=type, handle=handle)
+        return not do_default
 ```
 
 Finally, whatever event handler runs `dispatch_event` should check
 that return value and stop if it is `True`. So in `click`:
 
 ``` {.python}
-def click(self, x, y):
-    # ...
-    if elt and self.dispatch_event("click", elt): return
-    # ...
+class Tab:
+    def click(self, x, y):
+        # ...
+        if elt and self.js.dispatch_event("click", elt): return
+        # ...
 ```
 
 And also in `submit_form`:
 
 ``` {.python}
-def submit_form(self, elt):
-    if self.dispatch_event("submit", elt): return
+class Tab:
+    def submit_form(self, elt):
+        if self.js.dispatch_event("submit", elt): return
 ```
 
 And in `keypress`:
 
 ``` {.python}
-def keypress(self, char):
-    if self.focus:
-        if self.dispatch_event("keydown", self.focus): return
+class Tab:
+    def keypress(self, char):
+        if self.focus:
+            if self.js.dispatch_event("keydown", self.focus): return
 ```
 
 With this change, `comment.js` can use a global variable to track

--- a/src/comment9.js
+++ b/src/comment9.js
@@ -9,7 +9,7 @@ function lengthCheck() {
 }
 
 input = document.querySelectorAll("input")[0];
-input.addEventListener("change", lengthCheck);
+input.addEventListener("keydown", lengthCheck);
 
 form = document.querySelectorAll("form")[0];
 form.addEventListener("submit", function(e) {

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -50,6 +50,12 @@ class JSContext:
     def run(self, code):
         self.interp.evaljs(code)
 
+    def dispatch_event(self, type, elt):
+        code = "__runListeners(dukpy.type, dukpy.handle)"
+        handle = self.node_to_handle.get(elt, -1)
+        do_default = self.interp.evaljs(code, type=type, handle=handle)
+        return not do_default
+
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
             handle = len(self.node_to_handle)
@@ -78,12 +84,6 @@ class JSContext:
         for child in elt.children:
             child.parent = elt
         self.tab.render()
-
-    def dispatch_event(self, type, elt):
-        code = "__runListeners(dukpy.type, dukpy.handle)"
-        handle = self.node_to_handle.get(elt, -1)
-        do_default = self.interp.evaljs(code, type=type, handle=handle)
-        return not do_default
 
 class Tab:
     def __init__(self):

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -8,615 +8,199 @@ import socket
 import ssl
 import tkinter
 import tkinter.font
+import urllib.parse
 import dukpy
-from lab8 import request
+from lab4 import print_tree
+from lab4 import Element
+from lab4 import Text
+from lab4 import HTMLParser
+from lab5 import DrawRect
+from lab6 import cascade_priority
+from lab6 import layout_mode
+from lab6 import resolve_url
+from lab6 import style
+from lab6 import tree_to_list
+from lab6 import CSSParser
+from lab6 import DrawText
+from lab7 import LineLayout
+from lab7 import TextLayout
+from lab9 import request
+from lab9 import InputLayout
+from lab9 import BlockLayout
+from lab9 import InlineLayout
+from lab9 import DocumentLayout
 
-class Text:
-    def __init__(self, text):
-        self.text = text
+class Tab:
+    def __init__(self):
+        self.history = []
+        self.focus = None
 
-    def __repr__(self):
-        return "\"" + self.text.replace("\n", "\\n") + "\""
+        with open("browser8.css") as f:
+            self.default_style_sheet = CSSParser(f.read()).parse()
 
-SELF_CLOSING_TAGS = [
-    "area", "base", "br", "col", "embed", "hr", "img", "input",
-    "link", "meta", "param", "source", "track", "wbr",
-]
+    def setup_js(self):
+        self.js = dukpy.JSInterpreter()
+        self.js.export_function("log", print)
+        self.js.export_function("querySelectorAll",
+            self.js_querySelectorAll)
+        self.js.export_function("getAttribute",
+            self.js_getAttribute)
+        self.js.export_function("innerHTML", self.js_innerHTML)
+        with open("runtime9.js") as f:
+            self.js.evaljs(f.read())
+        self.node_to_handle = {}
+        self.handle_to_node = {}
 
-class Tag:
-    def __init__(self, text):
-        parts = text.split()
-        self.tag = parts[0].lower()
-        self.attributes = {}
-        for attrpair in parts[1:]:
-            if "=" in attrpair:
-                key, value = attrpair.split("=", 1)
-                if len(value) > 2 and value[0] in ["'", "\""]:
-                    value = value[1:-1]
-                self.attributes[key.lower()] = value
-            else:
-                self.attributes[attrpair.lower()] = ""
+    def dispatch_event(self, type, elt):
+        code = "__runListeners(dukpy.type, dukpy.handle)"
+        handle = self.node_to_handle.get(elt, -1)
+        do_default = self.js.evaljs(code, type=type, handle=handle)
+        return not do_default
 
-    def __repr__(self):
-        return "<" + self.tag + ">"
+    def js_querySelectorAll(self, selector_text):
+        selector = CSSParser(selector_text).selector()
+        nodes = [node for node in tree_to_list(nodes, [])
+                 if selector.matches(node)]
+        return [self.get_handle(node) for node in nodes]
 
-def lex(body):
-    out = []
-    text = ""
-    in_tag = False
-    for c in body:
-        if c == "<":
-            in_tag = True
-            if text: out.append(Text(text))
-            text = ""
-        elif c == ">":
-            in_tag = False
-            out.append(Tag(text))
-            text = ""
+    def js_getAttribute(self, handle, attr):
+        elt = self.handle_to_node[handle]
+        return elt.attributes.get(attr, None)
+
+    def js_innerHTML(self, handle, s):
+        doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
+        new_nodes = doc.children[0].children
+        elt = self.handle_to_node[handle]
+        elt.children = new_nodes
+        for child in elt.children:
+            child.parent = elt
+        self.render()
+
+    def get_handle(self, elt):
+        if elt not in self.node_to_handle:
+            handle = len(self.node_to_handle)
+            self.node_to_handle[id(elt)] = handle
+            self.handle_to_node[handle] = elt
         else:
-            text += c
-    if not in_tag and text:
-        out.append(Text(text))
-    return out
+            handle = self.node_to_handle[elt]
+        return handle
 
-class ElementNode:
-    def __init__(self, tag, attributes):
-        self.tag = tag
-        self.attributes = attributes
-        self.children = []
+    def load(self, url, body=None):
+        self.scroll = 0
+        self.url = url
+        self.history.append(url)
+        headers, body = request(url, body)
+        self.nodes = HTMLParser(body).parse()
 
-        self.style = {}
-        for pair in self.attributes.get("style", "").split(";"):
-            if ":" not in pair: continue
-            prop, val = pair.split(":")
-            self.style[prop.strip().lower()] = val.strip()
-
-    def __repr__(self):
-        return "<" + self.tag + ">"
-
-class TextNode:
-    def __init__(self, text):
-        self.text = text
-        self.tag = None
-        self.children = []
-
-    def __repr__(self):
-        return self.text.replace("\n", "\\n")
-        
-def parse(tokens):
-    currently_open = []
-    for tok in tokens:
-        implicit_tags(tok, currently_open)
-        if isinstance(tok, Text):
-            node = TextNode(tok.text)
-            if not currently_open: continue
-            node.parent = currently_open[-1]
-            currently_open[-1].children.append(node)
-        elif tok.tag.startswith("/"):
-            node = currently_open.pop()
-            if not currently_open: return node
-            currently_open[-1].children.append(node)
-        elif tok.tag in SELF_CLOSING_TAGS:
-            node = ElementNode(tok.tag, tok.attributes)
-            node.parent = currently_open[-1]
-            currently_open[-1].children.append(node)
-        elif tok.tag.startswith("!"):
-            continue
-        else:
-            node = ElementNode(tok.tag, tok.attributes)
-            if len(currently_open) > 0:
-                node.parent = currently_open[-1]
-            else:
-                node.parent = None
-            currently_open.append(node)
-    while currently_open:
-        node = currently_open.pop()
-        if not currently_open: return node
-        currently_open[-1].children.append(node)
-
-HEAD_TAGS = [
-    "base", "basefont", "bgsound", "noscript",
-    "link", "meta", "title", "style", "script",
-]
-            
-def implicit_tags(tok, currently_open):
-    tag = tok.tag if isinstance(tok, Tag) else None
-    while True:
-        open_tags = [node.tag for node in currently_open]
-        if open_tags == [] and tag != "html":
-            node = ElementNode("html", {})
-            node.parent = None
-            currently_open.append(node)
-        elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
-            if tag in HEAD_TAGS:
-                implicit = "head"
-            else:
-                implicit = "body"
-            node = ElementNode(implicit, {})
-            node.parent = currently_open[-1]
-            currently_open.append(node)
-        elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
-            node = currently_open.pop()
-            currently_open[-1].children.append(node)
-        else:
-            break
-
-class CSSParser:
-    def __init__(self, s):
-        self.s = s
-
-    def whitespace(self, i):
-        while i < len(self.s) and self.s[i].isspace():
-            i += 1
-        return None, i
-
-    def literal(self, i, literal):
-        l = len(literal)
-        assert self.s[i:i+l] == literal
-        return None, i + l
-
-    def word(self, i):
-        j = i
-        while j < len(self.s) and self.s[j].isalnum() or self.s[j] in "-.":
-            j += 1
-        assert j > i
-        return self.s[i:j], j
-
-    def pair(self, i):
-        prop, i = self.word(i)
-        _, i = self.whitespace(i)
-        _, i = self.literal(i, ":")
-        _, i = self.whitespace(i)
-        val, i = self.word(i)
-        return (prop.lower(), val), i
-
-    def ignore_until(self, i, chars):
-        while i < len(self.s) and self.s[i] not in chars:
-            i += 1
-        return None, i
-
-    def body(self, i):
-        pairs = {}
-        _, i = self.literal(i, "{")
-        _, i = self.whitespace(i)
-        while i < len(self.s) and self.s[i] != "}":
+        scripts = [node.attributes["src"] for node
+                   in tree_to_list(self.nodes, [])
+                   if isinstance(node, Element)
+                   and node.tag == "script"
+                   and "src" in node.attributes]
+        self.setup_js()
+        for script in scripts:
+            header, body = request(resolve_url(script, url))
             try:
-                (prop, val), i = self.pair(i)
-                pairs[prop] = val
-                _, i = self.whitespace(i)
-                _, i = self.literal(i, ";")
-            except AssertionError:
-                _, i = self.ignore_until(i, [";", "}"])
-                if i < len(self.s) and self.s[i] == ";":
-                    _, i = self.literal(i, ";")
-            _, i = self.whitespace(i)
-        _, i = self.literal(i, "}")
-        return pairs, i
+                print("Script returned: ", self.js.evaljs(body))
+            except dukpy.JSRuntimeError as e:
+                print("Script", script, "crashed", e)
 
-    def selector(self, i):
-        if self.s[i] == "#":
-            _, i = self.literal(i, "#")
-            name, i = self.word(i)
-            return IdSelector(name), i
-        elif self.s[i] == ".":
-            _, i = self.literal(i, ".")
-            name, i = self.word(i)
-            return ClassSelector(name), i
-        else:
-            name, i = self.word(i)
-            return TagSelector(name.lower()), i
-
-    def rule(self, i):
-        selector, i = self.selector(i)
-        _, i = self.whitespace(i)
-        body, i = self.body(i)
-        return (selector, body), i
-
-    def file(self, i):
-        rules = []
-        _, i = self.whitespace(i)
-        while i < len(self.s):
+        self.rules = self.default_style_sheet.copy()
+        links = [node.attributes["href"]
+                 for node in tree_to_list(self.nodes, [])
+                 if isinstance(node, Element)
+                 and node.tag == "link"
+                 and "href" in node.attributes
+                 and node.attributes.get("rel") == "stylesheet"]
+        for link in links:
             try:
-                rule, i = self.rule(i)
-                rules.append(rule)
-            except AssertionError:
-                _, i = self.ignore_until(i, "}")
-                _, i = self.literal(i, "}")
-            _, i = self.whitespace(i)
-        return rules, i
+                header, body = request(resolve_url(link, url))
+            except:
+                continue
+            self.rules.extend(CSSParser(body).parse())
+        self.render()
 
-    def parse(self):
-        rules, _ = self.file(0)
-        return rules
-    
-class TagSelector:
-    def __init__(self, tag):
-        self.tag = tag
+    def render(self):
+        style(self.nodes, sorted(self.rules, key=cascade_priority))
+        self.document = DocumentLayout(self.nodes)
+        self.document.layout()
+        self.display_list = []
+        self.document.paint(self.display_list)
 
-    def matches(self, node):
-        return self.tag == node.tag
+    def draw(self, canvas):
+        for cmd in self.display_list:
+            if cmd.top > self.scroll + HEIGHT - CHROME_PX: continue
+            if cmd.bottom < self.scroll: continue
+            cmd.execute(self.scroll - CHROME_PX, canvas)
 
-    def priority(self):
-        return 1
+        if self.focus:
+            obj = [obj for obj in tree_to_list(self.document, [])
+                   if obj.node == self.focus][0]
+            text = self.focus.attributes.get("value", "")
+            x = obj.x + obj.font.measure(text)
+            y = obj.y - self.scroll + CHROME_PX
+            canvas.create_line(x, y, x, y + obj.height)
 
-class ClassSelector:
-    def __init__(self, cls):
-        self.cls = cls
+    def scrolldown(self):
+        max_y = self.document.height - HEIGHT
+        self.scroll = min(self.scroll + SCROLL_STEP, max_y)
 
-    def matches(self, node):
-        return self.cls in node.attributes.get("class", "").split()
+    def click(self, x, y):
+        self.focus = None
+        y += self.scroll
+        objs = [obj for obj in tree_to_list(self.document, [])
+                if obj.x <= x < obj.x + obj.width
+                and obj.y <= y < obj.y + obj.height]
+        if not objs: return
+        elt = objs[-1].node
+        if elt and self.dispatch_event("click", elt): return
+        while elt:
+            if isinstance(elt, Text):
+                pass
+            elif elt.tag == "a" and "href" in elt.attributes:
+                url = resolve_url(elt.attributes["href"], self.url)
+                return self.load(url)
+            elif elt.tag == "input":
+                elt.attributes["value"] = ""
+                self.focus = elt
+                return
+            elif elt.tag == "button":
+                while elt:
+                    if elt.tag == "form" and "action" in elt.attributes:
+                        return self.submit_form(elt)
+                    elt = elt.parent
+            elt = elt.parent
 
-    def priority(self):
-        return 16
+    def submit_form(self, elt):
+        if self.dispatch_event("submit", elt): return
+        inputs = [node for node in tree_to_list(elt, [])
+                  if isinstance(node, Element)
+                  and node.tag == "input"
+                  and "name" in node.attributes]
 
-class IdSelector:
-    def __init__(self, id):
-        self.id = id
+        body = ""
+        for input in inputs:
+            name = input.attributes["name"]
+            value = input.attributes.get("value", "")
+            name = urllib.parse.quote(name)
+            value = urllib.parse.quote(value)
+            body += "&" + name + "=" + value
+        body = body [1:]
 
-    def matches(self, node):
-        return self.id == node.attributes.get("id", "")
+        url = resolve_url(elt.attributes["action"], self.url)
+        self.load(url, body)
 
-    def priority(self):
-        return 256
+    def keypress(self, char):
+        if self.focus:
+            if self.dispatch_event("keydown", self.focus): return
+            self.focus.attributes["value"] += char
+        self.document.paint(self.display_list) # TODO: is this necessary?
 
-INHERITED_PROPERTIES = {
-    "font-style": "normal",
-    "font-weight": "normal",
-    "font-size": "16px",
-    "color": "black",
-}
-
-def style(node, parent, rules):
-    if isinstance(node, TextNode):
-        node.style = parent.style
-    else:
-        for selector, pairs in rules:
-            if selector.matches(node):
-                for property in pairs:
-                    if property not in node.style:
-                        node.style[property] = pairs[property]
-        for property, default in INHERITED_PROPERTIES.items():
-            if property not in node.style:
-                if parent:
-                    node.style[property] = parent.style[property]
-                else:
-                    node.style[property] = default
-    for child in node.children:
-        style(child, node, rules)
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
-
-SCROLL_STEP = 100
-
-class LineLayout:
-    def __init__(self, node, parent):
-        self.node = node
-        self.parent = parent
-        self.children = []
-        self.cx = 0
-        self.laid_out = False
-
-    def append(self, child):
-        self.children.append(child)
-        child.parent = self
-        self.cx += child.w + child.font.measure(" ")
-
-    def layout(self):
-        self.w = self.parent.w
-        if not self.children:
-            self.h = 0
-            return
-        metrics = [child.font.metrics() for child in self.children]
-        max_ascent = max([metric["ascent"] for metric in metrics])
-        baseline = self.y + 1.2 * max_ascent
-        self.cx = 0
-        for child, metric in zip(self.children, metrics):
-            child.x = self.x + self.cx
-            child.y = baseline - metric["ascent"]
-            self.cx += child.w + child.font.measure(" ")
-        max_descent = max([metric["descent"] for metric in metrics])
-        self.h = 1.2 * (max_descent + max_ascent)
-
-    def paint(self, to):
-        for child in self.children:
-            child.paint(to)
-
-class TextLayout:
-    def __init__(self, node, word):
-        self.node = node
-        self.children = []
-        self.word = word
-
-    def layout(self):
-        weight = self.node.style["font-weight"]
-        style = self.node.style["font-style"]
-        if style == "normal": style = "roman"
-        size = int(px(self.node.style["font-size"]) * .75)
-        self.font = tkinter.font.Font(size=size, weight=weight, slant=style)
-        
-        self.w = self.font.measure(self.word)
-        self.h = self.font.metrics('linespace')
-
-    def paint(self, to):
-        color = self.node.style["color"]
-        to.append(DrawText(self.x, self.y, self.word, self.font, color))
-
-class InputLayout:
-    def __init__(self, node):
-        self.node = node
-        self.children = []
-
-    def layout(self):
-        weight = self.node.style["font-weight"]
-        style = self.node.style["font-style"]
-        if style == "normal": style = "roman"
-        size = int(px(self.node.style["font-size"]) * .75)
-        self.font = tkinter.font.Font(size=size, weight=weight, slant=style)
-        self.w = 200
-        self.h = 20
-
-    def paint(self, to):
-        x1, x2 = self.x, self.x + self.w
-        y1, y2 = self.y, self.y + self.h
-        bgcolor = "light gray" if self.node.tag == "input" else "yellow"
-        to.append(DrawRect(x1, y1, x2, y2, bgcolor))
-
-        if self.node.tag == "input":
-            text = self.node.attributes.get("value", "")
-        else:
-            text = self.node.children[0].text
-        color = self.node.style["color"]
-        to.append(DrawText(self.x, self.y, text, self.font, color))
-
-class InlineLayout:
-    def __init__(self, node, parent):
-        self.node = node
-        self.parent = parent
-        self.children = [LineLayout(self.node, self)]
-
-    def layout(self):
-        self.mt = self.bt = self.pt = 0
-        self.mr = self.br = self.pr = 0
-        self.mb = self.bb = self.pb = 0
-        self.ml = self.bl = self.pl = 0
-
-        self.w = self.parent.w - self.parent.pl - self.parent.pr \
-            - self.parent.bl - self.parent.br
-
-        self.cy = self.y
-        self.recurse(self.node)
-        self.flush()
-        self.children.pop()
-
-        self.h = self.cy - self.y
-
-    def recurse(self, node):
-        if isinstance(node, TextNode):
-            self.text(node)
-        elif node.tag == "br":
-            self.flush()
-        elif node.tag == "input":
-            self.input(node)
-        else:
-            for child in node.children:
-                self.recurse(child)
-
-    def text(self, node):
-        for word in node.text.split():
-            child = TextLayout(node, word)
-            child.layout()
-            if self.children[-1].cx + child.w > self.w:
-                self.flush()
-            self.children[-1].append(child)
-
-    def input(self, node):
-        child = InputLayout(node)
-        child.layout()
-        if self.children[-1].cx + child.w > self.w:
-            self.flush()
-        self.children[-1].append(child)
-
-    def flush(self):
-        child = self.children[-1]
-        child.x = self.x
-        child.y = self.cy
-        child.layout()
-        self.cy += child.h
-        self.children.append(LineLayout(self.node, self))
-
-    def paint(self, to):
-        for child in self.children:
-            child.paint(to)
-
-def px(s):
-    if s.endswith("px"):
-        return int(s[:-2])
-    else:
-        return 0
-
-class BlockLayout:
-    def __init__(self, node, parent):
-        self.node = node
-        self.parent = parent
-        self.children = []
-
-        self.x = -1
-        self.y = -1
-        self.w = -1
-        self.h = -1
-
-    def has_block_children(self):
-        for child in self.node.children:
-            if isinstance(child, TextNode):
-                if not child.text.isspace():
-                    return False
-            elif child.style.get("display", "block") == "inline":
-                return False
-        return True
-
-    def layout(self):
-        # block layout here
-        if self.has_block_children():
-            for child in self.node.children:
-                if isinstance(child, TextNode): continue
-                self.children.append(BlockLayout(child, self))
-        else:
-            self.children.append(InlineLayout(self.node, self))
-
-        self.mt = px(self.node.style.get("margin-top", "0px"))
-        self.bt = px(self.node.style.get("border-top-width", "0px"))
-        self.pt = px(self.node.style.get("padding-top", "0px"))
-        self.mr = px(self.node.style.get("margin-right", "0px"))
-        self.br = px(self.node.style.get("border-right-width", "0px"))
-        self.pr = px(self.node.style.get("padding-right", "0px"))
-        self.mb = px(self.node.style.get("margin-bottom", "0px"))
-        self.bb = px(self.node.style.get("border-bottom-width", "0px"))
-        self.pb = px(self.node.style.get("padding-bottom", "0px"))
-        self.ml = px(self.node.style.get("margin-left", "0px"))
-        self.bl = px(self.node.style.get("border-left-width", "0px"))
-        self.pl = px(self.node.style.get("padding-left", "0px"))
-
-        self.w = self.parent.w - self.parent.pl - self.parent.pr \
-            - self.parent.bl - self.parent.br \
-            - self.ml - self.mr
-
-        self.y += self.mt
-        self.x += self.ml
-
-        y = self.y
-        for child in self.children:
-            child.x = self.x + self.pl + self.bl
-            child.y = y
-            child.layout()
-            y += child.mt + child.h + child.mb
-        self.h = y - self.y
-
-    def paint(self, to):
-        if self.node.tag == "pre":
-            x2, y2 = self.x + self.w, self.y + self.h
-            to.append(DrawRect(self.x, self.y, x2, y2, "gray"))
-        for child in self.children:
-            child.paint(to)
-
-class DocumentLayout:
-    def __init__(self, node):
-        self.node = node
-        self.parent = None
-        self.children = []
-
-        self.x = -1
-        self.y = -1
-        self.w = -1
-        self.h = -1
-
-    def layout(self):
-        child = BlockLayout(self.node, self)
-        self.children.append(child)
-
-        self.w = WIDTH
-        self.mt = self.bt = self.pt = 0
-        self.mr = self.br = self.pr = 0
-        self.mb = self.bb = self.pb = 0
-        self.ml = self.bl = self.pl = 0
-
-        child.x = self.x = 0
-        child.y = self.y = 0
-        child.layout()
-        self.h = child.h
-
-    def paint(self, to):
-        self.children[0].paint(to)
-
-class DrawText:
-    def __init__(self, x1, y1, text, font, color):
-        self.x1 = x1
-        self.y1 = y1
-        self.text = text
-        self.font = font
-        self.color = color
-
-        self.y2 = y1 + font.metrics("linespace")
-
-    def draw(self, scroll, canvas):
-        canvas.create_text(
-            self.x1, self.y1 - scroll,
-            text=self.text,
-            font=self.font,
-            fill=self.color,
-            anchor='nw',
-        )
-
-class DrawRect:
-    def __init__(self, x1, y1, x2, y2, color):
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
-        self.color = color
-
-    def draw(self, scroll, canvas):
-        canvas.create_rectangle(
-            self.x1, self.y1 - scroll,
-            self.x2, self.y2 - scroll,
-            width=0,
-            fill=self.color,
-        )
-
-def find_links(node, lst):
-    if not isinstance(node, ElementNode): return
-    if node.tag == "link" and \
-       node.attributes.get("rel", "") == "stylesheet" and \
-       "href" in node.attributes:
-        lst.append(node.attributes["href"])
-    for child in node.children:
-        find_links(child, lst)
-    return lst
-
-def resolve_url(url, current):
-    if "://" in url:
-        return url
-    elif url.startswith("/"):
-        return "/".join(current.split("/")[:3]) + url
-    else:
-        return current.rsplit("/", 1)[0] + "/" + url
-
-def find_layout(x, y, tree):
-    for child in reversed(tree.children):
-        result = find_layout(x, y, child)
-        if result: return result
-    if tree.x <= x < tree.x + tree.w and \
-       tree.y <= y < tree.y + tree.h:
-        return tree
-
-def find_inputs(elt, out):
-    if not isinstance(elt, ElementNode): return
-    if elt.tag == "input" and "name" in elt.attributes:
-        out.append(elt)
-    for child in elt.children:
-        find_inputs(child, out)
-    return out
-
-def find_scripts(node, out):
-    if not isinstance(node, ElementNode): return
-    if node.tag == "script" and \
-       "src" in node.attributes:
-        out.append(node.attributes["src"])
-    for child in node.children:
-        find_scripts(child, out)
-    return out
-
-def find_selected(node, sel, out):
-    if not isinstance(node, ElementNode): return
-    if sel.matches(node):
-        out.append(node)
-    for child in node.children:
-        find_selected(child, sel, out)
-    return out
-
-def is_link(node):
-    return isinstance(node, ElementNode) \
-        and node.tag == "a" and "href" in node.attributes
+    def go_back(self):
+        if len(self.history) > 1:
+            self.history.pop()
+            back = self.history.pop()
+            self.load(back)
 
 class Browser:
     def __init__(self):
@@ -628,195 +212,101 @@ class Browser:
         )
         self.canvas.pack()
 
-        self.history = []
+        self.window.bind("<Down>", self.handle_down)
+        self.window.bind("<Button-1>", self.handle_click)
+        self.window.bind("<Key>", self.handle_key)
+        self.window.bind("<Return>", self.handle_enter)
+
+        self.tabs = []
+        self.active_tab = None
         self.focus = None
         self.address_bar = ""
-        self.scroll = 0
 
-        self.window.bind("<Down>", self.scrolldown)
-        self.window.bind("<Button-1>", self.handle_click)
-        self.window.bind("<Key>", self.keypress)
-        self.window.bind("<Return>", self.pressenter)
-        self.display_list = []
+    def handle_down(self, e):
+        self.tabs[self.active_tab].scrolldown()
+        self.draw()
 
     def handle_click(self, e):
-        self.focus = None
-        if e.y < 60: # Browser chrome
-            if 10 <= e.x < 35 and 10 <= e.y < 50:
-                self.go_back()
-            elif 50 <= e.x < 790 and 10 <= e.y < 50:
+        if e.y < CHROME_PX:
+            self.focus = None
+            if 40 <= e.x < 40 + 80 * len(self.tabs) and 0 <= e.y < 40:
+                self.active_tab = int((e.x - 40) / 80)
+            elif 10 <= e.x < 30 and 10 <= e.y < 30:
+                self.load("https://browser.engineering/")
+            elif 10 <= e.x < 35 and 40 <= e.y < 90:
+                self.tabs[self.active_tab].go_back()
+            elif 50 <= e.x < WIDTH - 10 and 40 <= e.y < 90:
                 self.focus = "address bar"
                 self.address_bar = ""
-                self.render()
         else:
-            x, y = e.x, e.y + self.scroll - 60
-            obj = find_layout(x, y, self.document)
-            if not obj: return
-            elt = obj.node
-            if elt and self.dispatch_event("click", elt): return
-            while elt:
-                if isinstance(elt, TextNode):
-                    pass
-                elif is_link(elt):
-                    url = resolve_url(elt.attributes["href"], self.url)
-                    return self.load(url)
-                elif elt.tag == "input":
-                    elt.attributes["value"] = ""
-                    self.focus = obj
-                    return self.layout(self.document.node)
-                elif elt.tag == "button":
-                    self.submit_form(elt)
-                elt = elt.parent
+            self.focus = "content"
+            self.tabs[self.active_tab].click(e.x, e.y - CHROME_PX)
+        self.draw()
 
-    def keypress(self, e):
-        if not (len(e.char) == 1 and 0x20 <= ord(e.char) < 0x7f):
-            return
-
-        if not self.focus:
-            return
-        elif self.focus == "address bar":
+    def handle_key(self, e):
+        if len(e.char) == 0: return
+        if not (0x20 <= ord(e.char) < 0x7f): return
+        if self.focus == "address bar":
             self.address_bar += e.char
-            self.render()
-        else:
-            self.focus.node.attributes["value"] += e.char
-            self.dispatch_event("change", self.focus.node)
-            self.layout(self.document.node)
+            self.draw()
+        elif self.focus == "content":
+            self.tabs[self.active_tab].keypress(e.char)
+            self.draw()
 
-    def submit_form(self, elt):
-        while elt and elt.tag != "form":
-            elt = elt.parent
-        if not elt: return
-        if self.dispatch_event("submit", elt): return
-        inputs = find_inputs(elt, [])
-        body = ""
-        for input in inputs:
-            name = input.attributes["name"]
-            value = input.attributes.get("value", "")
-            body += "&" + name + "=" + value.replace(" ", "%20")
-        body = body[1:]
-        url = resolve_url(elt.attributes["action"], self.url)
-        self.load(url, body)
-
-    def pressenter(self, e):
+    def handle_enter(self, e):
         if self.focus == "address bar":
+            self.tabs[self.active_tab].load(self.address_bar)
             self.focus = None
-            self.load(self.address_bar)
+            self.draw()
 
-    def go_back(self):
-        if len(self.history) > 1:
-            self.history.pop()
-            back = self.history.pop()
-            self.load(back)
+    def load(self, url):
+        new_tab = Tab()
+        new_tab.load(url)
+        self.active_tab = len(self.tabs)
+        self.tabs.append(new_tab)
+        self.draw()
 
-    def load(self, url, body=None):
-        self.address_bar = url
-        self.url = url
-        self.history.append(url)
-        header, body = request(url, body)
-        self.nodes = parse(lex(body))
-        
-        with open("browser8.css") as f:
-            self.rules = CSSParser(f.read()).parse()
-
-        for link in find_links(self.nodes, []):
-            header, body = request(resolve_url(link, url))
-            self4.rules.extend(CSSParser(body).parse())
-
-        self.rules.sort(key=lambda x: x[0].priority())
-        self.rules.reverse()
-
-        self.setup_js()
-        for script in find_scripts(self.nodes, []):
-            header, body = request(resolve_url(script, self.history[-1]))
-            try:
-                print("Script returned: ", self.js.evaljs(body))
-            except dukpy.JSRuntimeError as e:
-                print("Script", script, "crashed", e)
-        self.layout(self.nodes)
-
-    def setup_js(self):
-        self.js = dukpy.JSInterpreter()
-        self.node_to_handle = {}
-        self.handle_to_node = {}
-        self.js.export_function("log", print)
-        self.js.export_function("querySelectorAll",
-            self.js_querySelectorAll)
-        self.js.export_function("getAttribute", self.js_getAttribute)
-        self.js.export_function("innerHTML", self.js_innerHTML)
-        with open("runtime9.js") as f:
-            self.js.evaljs(f.read())
-
-    def js_querySelectorAll(self, sel):
-        selector, _ = CSSParser(sel + "{").selector(0)
-        elts = find_selected(self.nodes, selector, [])
-        return [self.make_handle(elt) for elt in elts]
-    
-    def js_getAttribute(self, handle, attr):
-        elt = self.handle_to_node[handle]
-        return elt.attributes.get(attr, None)
-
-    def js_innerHTML(self, handle, s):
-        doc = parse(lex("<html><body>" + s + "</body></html>"))
-        new_nodes = doc.children[0].children
-        elt = self.handle_to_node[handle]
-        elt.children = new_nodes
-        for child in elt.children:
-            child.parent = elt
-        self.layout(self.document.node)
-
-    def dispatch_event(self, type, elt):
-        handle = self.node_to_handle.get(elt, -1)
-        do_default = self.js.evaljs(
-            "__runHandlers({}, \"{}\")".format(handle, type))
-        return not do_default
-
-    def make_handle(self, elt):
-        if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle)
-            self.node_to_handle[elt] = handle
-            self.handle_to_node[handle] = elt
-        else:
-            handle = self.node_to_handle[elt]
-        return handle
-
-    def layout(self, tree):
-        style(tree, None, self.rules)
-        self.document = DocumentLayout(tree)
-        self.document.layout()
-        self.display_list = []
-        self.document.paint(self.display_list)
-        self.render()
-        self.max_y = self.document.h - HEIGHT
-
-    def render(self):
+    def draw(self):
         self.canvas.delete("all")
-        for cmd in self.display_list:
-            if cmd.y1 > self.scroll + HEIGHT - 60: continue
-            if cmd.y2 < self.scroll: continue
-            cmd.draw(self.scroll - 60, self.canvas)
-        self.canvas.create_rectangle(0, 0, 800, 60, width=0, fill='light gray')
-        self.canvas.create_rectangle(50, 10, 790, 50)
-        font = tkinter.font.Font(family="Courier", size=30)
-        self.canvas.create_text(55, 15, anchor='nw', text=self.address_bar, font=font)
-        self.canvas.create_rectangle(10, 10, 35, 50)
-        self.canvas.create_polygon(15, 30, 30, 15, 30, 45, fill='black')
-        if self.focus == "address bar":
-            w = font.measure(self.address_bar)
-            self.canvas.create_line(55 + w, 15, 55 + w, 45)
-        elif isinstance(self.focus, InputLayout):
-            text = self.focus.node.attributes.get("value", "")
-            x = self.focus.x + self.focus.font.measure(text)
-            y = self.focus.y - self.scroll + 60
-            self.canvas.create_line(x, y, x, y + self.focus.h)
+        self.tabs[self.active_tab].draw(self.canvas)
+        self.canvas.create_rectangle(
+            0, 0, WIDTH, CHROME_PX, fill="white")
 
-    def scrolldown(self, e):
-        self.scroll = self.scroll + SCROLL_STEP
-        self.scroll = min(self.scroll, self.max_y)
-        self.scroll = max(0, self.scroll)
-        self.render()
+        tabfont = tkinter.font.Font(size=20)
+        for i, tab in enumerate(self.tabs):
+            name = "Tab {}".format(i)
+            x1, x2 = 40 + 80 * i, 120 + 80 * i
+            self.canvas.create_line(x1, 0, x1, 40)
+            self.canvas.create_line(x2, 0, x2, 40)
+            self.canvas.create_text(
+                x1 + 10, 10, text=name, font=tabfont, anchor="nw")
+            if i == self.active_tab:
+                self.canvas.create_line(0, 40, x1, 40)
+                self.canvas.create_line(x2, 40, WIDTH, 40)
+
+        buttonfont = tkinter.font.Font(size=30)
+        self.canvas.create_rectangle(10, 10, 30, 30, width=1)
+        self.canvas.create_text(
+            11, 0, font=buttonfont, text="+", anchor="nw")
+
+        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90, width=1)
+        if self.focus == "address bar":
+            self.canvas.create_text(
+                55, 55, anchor='nw', text=self.address_bar,
+                font=buttonfont)
+            w = buttonfont.measure(self.address_bar)
+            self.canvas.create_line(55 + w, 55, 55 + w, 85)
+        else:
+            url = self.tabs[self.active_tab].url
+            self.canvas.create_text(
+                55, 55, anchor='nw', text=url, font=buttonfont)
+
+        self.canvas.create_rectangle(10, 50, 35, 90, width=1)
+        self.canvas.create_polygon(
+            15, 70, 30, 55, 30, 85, fill='black')
+
 
 if __name__ == "__main__":
     import sys
-    browser = Browser()
-    browser.load(sys.argv[1])
+    Browser().load(sys.argv[1])
     tkinter.mainloop()

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -30,51 +30,25 @@ from lab9 import BlockLayout
 from lab9 import InlineLayout
 from lab9 import DocumentLayout
 
-class Tab:
-    def __init__(self):
-        self.history = []
-        self.focus = None
+class JSContext:
+    def __init__(self, tab):
+        self.tab = tab
 
-        with open("browser8.css") as f:
-            self.default_style_sheet = CSSParser(f.read()).parse()
-
-    def setup_js(self):
-        self.js = dukpy.JSInterpreter()
-        self.js.export_function("log", print)
-        self.js.export_function("querySelectorAll",
-            self.js_querySelectorAll)
-        self.js.export_function("getAttribute",
-            self.js_getAttribute)
-        self.js.export_function("innerHTML", self.js_innerHTML)
+        self.interp = dukpy.JSInterpreter()
+        self.interp.export_function("log", print)
+        self.interp.export_function("querySelectorAll",
+            self.querySelectorAll)
+        self.interp.export_function("getAttribute",
+            self.getAttribute)
+        self.interp.export_function("innerHTML", self.innerHTML)
         with open("runtime9.js") as f:
-            self.js.evaljs(f.read())
+            self.interp.evaljs(f.read())
+
         self.node_to_handle = {}
         self.handle_to_node = {}
 
-    def dispatch_event(self, type, elt):
-        code = "__runListeners(dukpy.type, dukpy.handle)"
-        handle = self.node_to_handle.get(elt, -1)
-        do_default = self.js.evaljs(code, type=type, handle=handle)
-        return not do_default
-
-    def js_querySelectorAll(self, selector_text):
-        selector = CSSParser(selector_text).selector()
-        nodes = [node for node in tree_to_list(nodes, [])
-                 if selector.matches(node)]
-        return [self.get_handle(node) for node in nodes]
-
-    def js_getAttribute(self, handle, attr):
-        elt = self.handle_to_node[handle]
-        return elt.attributes.get(attr, None)
-
-    def js_innerHTML(self, handle, s):
-        doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
-        new_nodes = doc.children[0].children
-        elt = self.handle_to_node[handle]
-        elt.children = new_nodes
-        for child in elt.children:
-            child.parent = elt
-        self.render()
+    def run(self, code):
+        self.interp.evaljs(code)
 
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
@@ -85,6 +59,40 @@ class Tab:
             handle = self.node_to_handle[elt]
         return handle
 
+    def querySelectorAll(self, selector_text):
+        selector = CSSParser(selector_text).selector()
+        nodes = [node for node
+                 in tree_to_list(self.tab.nodes, [])
+                 if selector.matches(node)]
+        return [self.get_handle(node) for node in nodes]
+
+    def getAttribute(self, handle, attr):
+        elt = self.handle_to_node[handle]
+        return elt.attributes.get(attr, None)
+
+    def innerHTML(self, handle, s):
+        doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
+        new_nodes = doc.children[0].children
+        elt = self.handle_to_node[handle]
+        elt.children = new_nodes
+        for child in elt.children:
+            child.parent = elt
+        self.tab.render()
+
+    def dispatch_event(self, type, elt):
+        code = "__runListeners(dukpy.type, dukpy.handle)"
+        handle = self.node_to_handle.get(elt, -1)
+        do_default = self.interp.evaljs(code, type=type, handle=handle)
+        return not do_default
+
+class Tab:
+    def __init__(self):
+        self.history = []
+        self.focus = None
+
+        with open("browser8.css") as f:
+            self.default_style_sheet = CSSParser(f.read()).parse()
+
     def load(self, url, body=None):
         self.scroll = 0
         self.url = url
@@ -92,16 +100,16 @@ class Tab:
         headers, body = request(url, body)
         self.nodes = HTMLParser(body).parse()
 
+        self.js = JSContext(self)
         scripts = [node.attributes["src"] for node
                    in tree_to_list(self.nodes, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
-        self.setup_js()
         for script in scripts:
             header, body = request(resolve_url(script, url))
             try:
-                print("Script returned: ", self.js.evaljs(body))
+                print("Script returned: ", self.js.run(body))
             except dukpy.JSRuntimeError as e:
                 print("Script", script, "crashed", e)
 
@@ -153,7 +161,7 @@ class Tab:
                 and obj.y <= y < obj.y + obj.height]
         if not objs: return
         elt = objs[-1].node
-        if elt and self.dispatch_event("click", elt): return
+        if elt and self.js.dispatch_event("click", elt): return
         while elt:
             if isinstance(elt, Text):
                 pass
@@ -172,7 +180,7 @@ class Tab:
             elt = elt.parent
 
     def submit_form(self, elt):
-        if self.dispatch_event("submit", elt): return
+        if self.js.dispatch_event("submit", elt): return
         inputs = [node for node in tree_to_list(elt, [])
                   if isinstance(node, Element)
                   and node.tag == "input"
@@ -192,7 +200,7 @@ class Tab:
 
     def keypress(self, char):
         if self.focus:
-            if self.dispatch_event("keydown", self.focus): return
+            if self.js.dispatch_event("keydown", self.focus): return
             self.focus.attributes["value"] += char
         self.document.paint(self.display_list) # TODO: is this necessary?
 

--- a/src/runtime9.js
+++ b/src/runtime9.js
@@ -1,16 +1,26 @@
 console = { log: function(x) { call_python("log", x); } }
 
 document = { querySelectorAll: function(s) {
-    var handles = call_python("querySelectorAll", s)
+    var handles = call_python("querySelectorAll", s);
     return handles.map(function(h) { return new Node(h) });
 }}
 
 function Node(handle) { this.handle = handle; }
+
 Node.prototype.getAttribute = function(attr) {
     return call_python("getAttribute", this.handle, attr);
 }
 
 LISTENERS = {}
+
+function Event(type) {
+    this.type = type
+    this.do_default = true;
+}
+
+Event.prototype.preventDefault = function() {
+    this.do_default = false;
+}
 
 Node.prototype.addEventListener = function(type, handler) {
     if (!LISTENERS[this.handle]) LISTENERS[this.handle] = {};
@@ -22,24 +32,15 @@ Node.prototype.addEventListener = function(type, handler) {
 
 Object.defineProperty(Node.prototype, 'innerHTML', {
     set: function(s) {
-        call_python("innerHTML", this.handle, "" + s);
+        call_python("innerHTML", this.handle, s.toString());
     }
 });
 
-function __runHandlers(handle, type) {
+function __runListeners(handle, type) {
     var list = (LISTENERS[handle] && LISTENERS[handle][type]) || [];
     var evt = new Event(type);
     for (var i = 0; i < list.length; i++) {
         list[i].call(new Node(handle), evt);
     }
     return evt.do_default;
-}
-
-function Event(type) {
-    this.type = type
-    this.do_default = true;
-}
-
-Event.prototype.preventDefault = function() {
-    this.do_default = false;
 }


### PR DESCRIPTION
This PR creates a new `JSContext` object which implements JS APIs like `innerHTML` and stores the dukpy object and the node/handle dictionaries. The main advantage is that the `Tab` class avoids growing super long.

**Note:** This PR requires the `ch9-upgrade` PR #193 be merged first.