### PR TITLE
Add font caching to Chapter 3

### DIFF
--- a/book/chrome.md
+++ b/book/chrome.md
@@ -278,8 +278,7 @@ class TextLayout:
         style = self.node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(self.node.style["font-size"][:-2]) * .75)
-        self.font = tkinter.font.Font(
-            size=size, weight=weight, slant=style)
+        self.font = get_font(size, weight, style)
 ```
 
 Next, we need to compute word's size and `x` position. We use the font
@@ -625,7 +624,7 @@ drawn:
 class Browser:
     def draw(self):
         # ...
-        tabfont = tkinter.font.Font(size=20)
+        tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             # ...
 ```
@@ -675,7 +674,7 @@ that on the left of the tab bar, with a big plus in the middle:
 class Browser:
     def draw(self):
         # ...
-        buttonfont = tkinter.font.Font(size=30)
+        buttonfont = get_font(30, "normal", "roman")
         self.canvas.create_rectangle(10, 10, 30, 30, width=1)
         self.canvas.create_text(
             11, 0, font=buttonfont, text="+", anchor="nw")

--- a/book/styles.md
+++ b/book/styles.md
@@ -877,7 +877,7 @@ def text(self, node):
     style = node.style["font-style"]
     if style == "normal": style = "roman"
     size = int(float(node.style["font-size"][:-2]) * .75)
-    font = tkinter.font.Font(size=size, weight=weight, slant=style)
+    font = get_font(size, weight, style)
     # ...
 ```
 

--- a/book/text.md
+++ b/book/text.md
@@ -816,13 +816,12 @@ class Layout:
 ```
 
 ::: {.further}
-Fonts are surprisingly large, sometimes on the order of multiple
-megabytes for scripts like Chinese with a lot of different, complex
-characters. For this reason they are generally stored on disk and only
-loaded into memory on-demand, which is slow. Optimizing font loading
-(and the cost to shape them and lay them out, since many web pages
-have a *lot* of text) turns out to be one of the most important parts
-of speeding up text rendering.
+Fonts for scripts like Chinese can be megabytes in size, so they are
+generally stored on disk and only loaded into memory on-demand. That
+makes font loading slow. Browsers also have extensive caches for
+measuring, shaping, and rendering text. Because web pages have a lot
+of text, these caches turn out to be one of the most important parts
+of speeding up rendering.
 :::
 
 Summary

--- a/book/text.md
+++ b/book/text.md
@@ -759,7 +759,7 @@ specifically the part where you measure each word, is quite slow.
 
 [^macos-cache]: The macOS text APIs do fairly complex system-wide font
     caching that Linux and Windows do not do. The optimization
-    described in this section won't hurt any.
+    described in this section won't hurt any on that platform, though.
 
 Unfortunately, it's hard to make text measurement much faster. With
 proportional fonts and complex font features like hinting and kerning,

--- a/book/text.md
+++ b/book/text.md
@@ -755,11 +755,19 @@ Now that you've implemented styled text, you've probably
 noticed---unless you're on macOS[^macos-cache]---that on a large web
 page like this chapter your browser has slowed significantly from the
 [last chapter](graphics.md). That's because text layout, and
-specifically the part where you measure each word, is quite slow.
+specifically the part where you measure each word, is quite
+slow.[^profile]
 
-[^macos-cache]: The macOS text APIs do fairly complex system-wide font
-    caching that Linux and Windows do not do. The optimization
-    described in this section won't hurt any on that platform, though.
+[^macos-cache]: While we can't confirm this in the documentation, it
+    seems that the macOS "Core Text" APIs cache fonts more
+    aggressively than Linux and Windows. The optimization described in
+    this section won't hurt any on macOS, but also won't improve speed
+    as much as on Windows and Linux.
+
+[^profile]: You can profile Python programs by replacing your
+    `python3` command with `python3 -m cProfile`. Look for the lines
+    corresponding to the `measure` and `metrics` calls to see how much
+    time is spent measuring text.
 
 Unfortunately, it's hard to make text measurement much faster. With
 proportional fonts and complex font features like hinting and kerning,
@@ -770,13 +778,13 @@ these words over and over again, we could measure them once, and then
 cache the results. On normal English text, this usually results in a
 substantial speedup.
 
-Caching is such a good idea that Tk already implements it internally.
-But there's a small catch: Tk stores the cache inside each `Font`
-object. But our `text` method creates a new `Font` object for each
-word, even if two words are actually rendered with the same font. That
-renders Tk's cache ineffective. To fix this, let's build our own cache
-of `Font` object, so that we can reuse those `Font` objects and their
-associated text measurement cache.
+Caching is such a good idea that most text libraries already implement
+it. But because our `text` method creates a new `Font` object for each
+word, our browser isn't taking advantage of that caching. If we only
+made a new `Font` object when we had to, the built-in caches would
+work better and our browser would be faster. So we'll need our own
+cache, so that we can reuse `Font` objects and have our text
+measurements cached.
 
 We'll store our cache in a global `FONTS` dictionary:
 

--- a/src/lab3-tests.md
+++ b/src/lab3-tests.md
@@ -143,3 +143,20 @@ And with breakpoints:
     create_text: x=69 y=20.1 text=def font=Font size=14 weight=normal slant=italic style=None anchor=nw
 
     >>> test.unpatch_breakpoint()
+
+Testing font caching
+--------------------
+
+To test font caching, we call `get_font` twice and use Python's `is`
+operator to test that we get identical `Font` objects back:
+
+    >>> a = lab3.get_font(16, "normal", "roman")
+    >>> b = lab3.get_font(16, "normal", "roman")
+    >>> c = lab3.get_font(20, "normal", "roman")
+    >>> d = lab3.get_font(16, "bold", "roman")
+    >>> a is b
+    True
+    >>> a is c
+    False
+    >>> a is d
+    False

--- a/src/lab3.hints
+++ b/src/lab3.hints
@@ -1,1 +1,1 @@
-[]
+[{"code": "key not in FONTS", "type": "dict"}]

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -48,6 +48,15 @@ HSTEP, VSTEP = 13, 18
 
 SCROLL_STEP = 100
 
+FONTS = {}
+
+def get_font(size, weight, slant):
+    key = (size, weight, slant)
+    if key not in FONTS:
+        font = tkinter.font.Font(size=size, weight=weight, slant=slant)
+        FONTS[key] = font
+    return FONTS[key]
+
 class Layout:
     def __init__(self, tokens):
         self.tokens = tokens
@@ -90,11 +99,7 @@ class Layout:
             self.cursor_y += VSTEP
         
     def text(self, tok):
-        font = tkinter.font.Font(
-            size=self.size,
-            weight=self.weight,
-            slant=self.style,
-        )
+        font = get_font(self.size, self.weight, self.style)
         for word in tok.text.split():
             w = font.measure(word)
             if self.cursor_x + w > WIDTH - HSTEP:

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -9,6 +9,7 @@ import ssl
 import tkinter
 import tkinter.font
 from lab1 import request
+from lab3 import get_font
 
 class Text:
     def __init__(self, text, parent):
@@ -185,11 +186,7 @@ class Layout:
             self.cursor_y += VSTEP
         
     def text(self, node):
-        font = tkinter.font.Font(
-            size=self.size,
-            weight=self.weight,
-            slant=self.style,
-        )
+        font = get_font(self.size, self.weight, self.style)
         for word in node.text.split():
             w = font.measure(word)
             if self.cursor_x + w > WIDTH - HSTEP:

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -9,6 +9,7 @@ import ssl
 import tkinter
 import tkinter.font
 from lab1 import request
+from lab3 import get_font
 from lab4 import print_tree
 from lab4 import Element
 from lab4 import HTMLParser
@@ -156,11 +157,7 @@ class InlineLayout:
             self.cursor_y += VSTEP
         
     def text(self, node):
-        font = tkinter.font.Font(
-            size=self.size,
-            weight=self.weight,
-            slant=self.style,
-        )
+        font = get_font(self.size, self.weight, self.style)
         for word in node.text.split():
             w = font.measure(word)
             if self.cursor_x + w > self.width - HSTEP:

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -10,6 +10,7 @@ import tkinter
 import tkinter.font
 from lab4 import print_tree
 from lab1 import request
+from lab3 import get_font
 from lab4 import Element
 from lab4 import HTMLParser
 from lab4 import Text
@@ -273,7 +274,7 @@ class InlineLayout:
         style = node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(node.style["font-size"][:-2]) * .75)
-        font = tkinter.font.Font(size=size, weight=weight, slant=style)
+        font = get_font(size, weight, style)
         for word in node.text.split():
             w = font.measure(word)
             if self.cursor_x + w > self.width - HSTEP:

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -10,6 +10,7 @@ import tkinter
 import tkinter.font
 from lab4 import print_tree
 from lab1 import request
+from lab3 import get_font
 from lab4 import Element
 from lab4 import HTMLParser
 from lab4 import Text
@@ -88,8 +89,7 @@ class TextLayout:
         style = self.node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(self.node.style["font-size"][:-2]) * .75)
-        self.font = tkinter.font.Font(
-            size=size, weight=weight, slant=style)
+        self.font = get_font(size, weight, style)
 
         # Do not set self.y!!!
         self.width = self.font.measure(self.word)
@@ -201,7 +201,7 @@ class InlineLayout:
         style = node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(node.style["font-size"][:-2]) * .75)
-        font = tkinter.font.Font(size=size, weight=weight, slant=style)
+        font = get_font(size, weight, style)
         for word in node.text.split():
             w = font.measure(word)
             if self.cursor_x + w > self.width - HSTEP:
@@ -388,7 +388,7 @@ class Browser:
         self.canvas.create_rectangle(
             0, 0, WIDTH, CHROME_PX, fill="white")
 
-        tabfont = tkinter.font.Font(size=20)
+        tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
@@ -400,7 +400,7 @@ class Browser:
                 self.canvas.create_line(0, 40, x1, 40)
                 self.canvas.create_line(x2, 40, WIDTH, 40)
 
-        buttonfont = tkinter.font.Font(size=30)
+        buttonfont = get_font(30, "normal", "roman")
         self.canvas.create_rectangle(10, 10, 30, 30, width=1)
         self.canvas.create_text(
             11, 0, font=buttonfont, text="+", anchor="nw")

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -9,6 +9,7 @@ import ssl
 import tkinter
 import tkinter.font
 import urllib.parse
+from lab3 import get_font
 from lab4 import print_tree
 from lab4 import Element
 from lab4 import Text
@@ -100,8 +101,7 @@ class InputLayout:
         style = self.node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(self.node.style["font-size"][:-2]) * .75)
-        self.font = tkinter.font.Font(
-            size=size, weight=weight, slant=style)
+        self.font = get_font(size, weight, style)
 
         self.width = INPUT_WIDTH_PX
 
@@ -229,7 +229,7 @@ class InlineLayout:
         style = node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(node.style["font-size"][:-2]) * .75)
-        return tkinter.font.Font(size=size, weight=weight, slant=style)
+        return get_font(size, weight, style)
 
     def text(self, node):
         font = self.get_font(node)
@@ -472,7 +472,7 @@ class Browser:
         self.canvas.create_rectangle(
             0, 0, WIDTH, CHROME_PX, fill="white")
 
-        tabfont = tkinter.font.Font(size=20)
+        tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
@@ -484,7 +484,7 @@ class Browser:
                 self.canvas.create_line(0, 40, x1, 40)
                 self.canvas.create_line(x2, 40, WIDTH, 40)
 
-        buttonfont = tkinter.font.Font(size=30)
+        buttonfont = get_font(30, "normal", "roman")
         self.canvas.create_rectangle(10, 10, 30, 30, width=1)
         self.canvas.create_text(
             11, 0, font=buttonfont, text="+", anchor="nw")

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -10,6 +10,7 @@ import tkinter
 import tkinter.font
 import urllib.parse
 import dukpy
+from lab3 import get_font
 from lab4 import print_tree
 from lab4 import Element
 from lab4 import Text
@@ -282,7 +283,7 @@ class Browser:
         self.canvas.create_rectangle(
             0, 0, WIDTH, CHROME_PX, fill="white")
 
-        tabfont = tkinter.font.Font(size=20)
+        tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
@@ -294,7 +295,7 @@ class Browser:
                 self.canvas.create_line(0, 40, x1, 40)
                 self.canvas.create_line(x2, 40, WIDTH, 40)
 
-        buttonfont = tkinter.font.Font(size=30)
+        buttonfont = get_font(30, "normal", "roman")
         self.canvas.create_rectangle(10, 10, 30, 30, width=1)
         self.canvas.create_text(
             11, 0, font=buttonfont, text="+", anchor="nw")


### PR DESCRIPTION
This PR takes the Chapter 13 code and text on font caching and ports it to Chapter 3. I think it's a better place since Ch3 already discusses text, while Ch13 is mostly about something else; plus, it means the browser won't be super-slow for most of the book.

I updated the code for Chapters 3-9 to account for this change, but didn't remove the relevant part of Chapter 13, since we might want further reorganization there.