### PR TITLE
Pass over Ch9

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -74,6 +74,12 @@ chapter.
 [^2]: Or, on my Linux machine, I sometimes get errors due to file
     ownership. You may have to do some sleuthing.
 
+::: {.quirk}
+Note to JS experts: Dukpy does not implement newer JS syntax like
+`let` and `const` or arrow functions. You'll need to use old-school
+JavaScript from the turn of the centry.
+:::
+
 
 Running JavaScript code
 =======================
@@ -574,11 +580,7 @@ Note that if the attribute is not assigned, the `get` method will
 return `None`, which DukPy will translate to JavaScript's `null`.
 Don't forget to export this function as `getAttribute`.
 
-You should now be able to run a script like this:[^9]
-
-[^9]: Note to JS experts: Dukpy does not implement newer JS syntax
-    like `let` and `const` or arrow functions. You'll need to use
-    old-school JavaScript from the turn of the centry.
+You should now be able to run a script like this:
 
 ``` {.javascript}
 scripts = document.querySelectorAll("script")
@@ -647,7 +649,8 @@ page, the browser generates *events*. Each event has a name, like
 link, or a form). JavaScript code can call `addEventListener` to react
 to those events: `node.addEventListener('click', handler)` sets
 `handler` to run every time the element corresponding to `node`
-generates a `click` event.
+generates a `click` event. It's basically Tk's `bind`, but in the
+browser. Let's implement it.
 
 Let's start with generating events. I'll create a `dispatch_event`
 method and call it whenever an event is generated. That includes,
@@ -952,6 +955,19 @@ server, `/comment.css`, with the contents:
 
 But even though we tell the user that their comment is too long the
 user can submit the guest book entry anyway. Oops! Let's fix that.
+
+::: {.further}
+This code has a subtle memory leak: if you access an HTML element from
+JavaScript (thereby creating a handle for it) and then remove the
+element from the page (using `innerHTML`), Python won't be able to
+garbage-collect the `Element` object because it is still stored in the
+`node_to_handle` map. And that's good, if JavaScript can still access
+that `Element` via its handle, but bad otherwise. Solving this is
+quite tricky, because it requires the Python and JavaScript garbage
+collectors to [cooperate][cross-component].
+:::
+
+[cross-component]: https://research.google/pubs/pub47359/
 
 Event defaults
 ==============

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -21,7 +21,7 @@ if it sounds interesting!] so this chapter uses the `dukpy` library
 for executing JavaScript.
 
 [DukPy](https://github.com/amol-/dukpy) is a Python library that wraps
-a JavaScript interpreter called [Duktape](https://duktape.org). Those
+a JavaScript interpreter called [Duktape](https://duktape.org). The
 most famous JavaScript interpreters are those used in browsers:
 TraceMonkey (Firefox), JavaScriptCore (Safari), and V8 (Chrome).
 Unlike those implementations, which are extremely fast but also
@@ -157,8 +157,8 @@ much trickier to [implement efficiently][speculative].
 Exporting functions
 =====================
 
-Right now our browsers just prints the last expression in a script;
-but in a real browser scripts must call the `console.log` function to
+Right now our browser just prints the last expression in a script; but
+in a real browser scripts must call the `console.log` function to
 print. To support that, we will need to *export a function* from
 Python into JavaScript. We'll be exporting a lot of functions, so to
 avoid polluting the `Tab` object with many new methods, let's put this
@@ -263,9 +263,9 @@ class JSContext:
             self.interp.evaljs(f.read())
 ```
 
-Now you should be able to run the put `console.log("Hi from JS!")`
-into a JavaScript file, run it from your browser, and see output in
-your terminal. You should also be able to call `console.log` multiple
+Now you should be able to put `console.log("Hi from JS!")` into a
+JavaScript file, run it from your browser, and see output in your
+terminal. You should also be able to call `console.log` multiple
 times.
 
 ::: {.further}
@@ -428,7 +428,7 @@ class Tab:
         # ...
 ```
 
-Now `querySelectorAll` we find all nodes matching the selector:
+Now `querySelectorAll` will find all nodes matching the selector:
 
 ``` {.python}
 def querySelectorAll(self, selector_text):
@@ -438,8 +438,8 @@ def querySelectorAll(self, selector_text):
              if selector.matches(node)]
 ```
 
-Finally we need to return those nodes back to JavaScript, and you
-might think of doing something like this:
+Finally we need to return those nodes back to JavaScript. You might
+try something like this:
 
 ``` {.python expected=False}
 def querySelectorAll(self, selector_text):
@@ -447,7 +447,7 @@ def querySelectorAll(self, selector_text):
     return nodes
 ```
 
-However, if you try this, you'll see an error:[^7]
+However, this throws an error:[^7]
 
     _dukpy.JSRuntimeError: EvalError:
     Error while calling Python Function:
@@ -640,7 +640,7 @@ Event handling
 
 The browser executes JavaScript code as soon as it loads the web page,
 but most changes to the page should be made *in response* to user
-actions. To bridging the gap, scripts ask for code to run when *page
+actions. To bridge the gap, scripts ask for code to run when *page
 events*, like button clicks or key presses, occur.
 
 Here's how that works. First, any time the user interacts with the

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -27,7 +27,10 @@ from lab7 import TextLayout
 from lab8 import request
 from lab8 import DocumentLayout
 
+DISPATCH_CODE = "new Node(dukpy.handle).dispatchEvent(new Event(dukpy.type))"
+
 class JSContext:
+
     def __init__(self, tab):
         self.tab = tab
 
@@ -37,7 +40,7 @@ class JSContext:
             self.querySelectorAll)
         self.interp.export_function("getAttribute",
             self.getAttribute)
-        self.interp.export_function("innerHTML", self.innerHTML)
+        self.interp.export_function("innerHTML", self.innerHTML_set)
         with open("runtime9.js") as f:
             self.interp.evaljs(f.read())
 
@@ -48,18 +51,17 @@ class JSContext:
         return self.interp.evaljs(code)
 
     def dispatch_event(self, type, elt):
-        code = "__runListeners(dukpy.type, dukpy.handle)"
-        handle = self.node_to_handle.get(id(elt), -1)
-        do_default = self.interp.evaljs(code, type=type, handle=handle)
+        handle = self.node_to_handle.get(elt, -1)
+        do_default = self.interp.evaljs(DISPATCH_CODE, type=type, handle=handle)
         return not do_default
 
     def get_handle(self, elt):
-        if id(elt) not in self.node_to_handle:
+        if elt not in self.node_to_handle:
             handle = len(self.node_to_handle)
-            self.node_to_handle[id(elt)] = handle
+            self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt
         else:
-            handle = self.node_to_handle[id(elt)]
+            handle = self.node_to_handle[elt]
         return handle
 
     def querySelectorAll(self, selector_text):
@@ -73,7 +75,7 @@ class JSContext:
         elt = self.handle_to_node[handle]
         return elt.attributes.get(attr, None)
 
-    def innerHTML(self, handle, s):
+    def innerHTML_set(self, handle, s):
         doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
         new_nodes = doc.children[0].children
         elt = self.handle_to_node[handle]

--- a/src/runtime9.js
+++ b/src/runtime9.js
@@ -36,11 +36,12 @@ Object.defineProperty(Node.prototype, 'innerHTML', {
     }
 });
 
-function __runListeners(type, handle) {
+Node.prototype.dispatchEvent = function(evt) {
+    var type = evt.type;
+    var handle = this.handle
     var list = (LISTENERS[handle] && LISTENERS[handle][type]) || [];
-    var evt = new Event(type);
     for (var i = 0; i < list.length; i++) {
-        list[i].call(new Node(handle), evt);
+        list[i].call(this, evt);
     }
     return evt.do_default;
 }


### PR DESCRIPTION
This PR cleaned up a lot of small things in the writing, and also changed the code to implement JavaScript's standard `dispatchEvent` function instead of a custom `__runHandlers` method. The result is cleaner and more standards-compliant!