### PR TITLE
Change the standard line spacing from 1.2 to 1.25

### DIFF
--- a/book/chrome.md
+++ b/book/chrome.md
@@ -234,7 +234,7 @@ method:
 # ...
 max_ascent = max([word.font.metrics("ascent")
                   for word in self.children])
-baseline = self.y + 1.2 * max_ascent
+baseline = self.y + 1.25 * max_ascent
 for word in self.children:
     word.y = baseline - word.font.metrics("ascent")
 max_descent = max([word.font.metrics("descent")
@@ -260,7 +260,7 @@ to have a height. We compuate it from the maximum ascent and descent:
 
 ``` {.python indent=8}
 # ...
-self.height = 1.2 * (max_ascent + max_descent)
+self.height = 1.25 * (max_ascent + max_descent)
 ```
 
 Ok, so that's line layout. Now let's think about laying out each word.

--- a/book/reflow.md
+++ b/book/reflow.md
@@ -282,10 +282,10 @@ class LineLayout:
         self.metrics = [child.font.metrics() for child in self.children]
         self.max_ascent = max([metric["ascent"] for metric in self.metrics])
         self.max_descent = max([metric["descent"] for metric in self.metrics])
-        self.h = 1.2 * (self.max_descent + self.max_ascent)
+        self.h = 1.25 * (self.max_descent + self.max_ascent)
 
     def position(self):
-        baseline = self.y + 1.2 * self.max_ascent
+        baseline = self.y + 1.25 * self.max_ascent
         cx = 0
         for child, metrics in zip(self.children, self.metrics):
             child.x = self.x + cx
@@ -480,7 +480,7 @@ Then we can use `self.cxs` in `position`:
 ``` {.python}
 class LineLayout:
     def position(self):
-        baseline = self.y + 1.2 * self.max_ascent
+        baseline = self.y + 1.25 * self.max_ascent
         for cx, child, metrics in \
           zip(self.cxs, self.children, self.metrics):
             child.x = self.x + cx

--- a/book/text.md
+++ b/book/text.md
@@ -863,10 +863,6 @@ should be smaller (perhaps half the normal text size) and be placed so
 that the top of a superscript lines up with the top of a normal
 letter.
 
-*Small caps:* Make the `<abbr>` element render text in small caps,
-<abbr>like this</abbr>. Upper-case letters should be in a normal font,
-while lower-case letters should be small, capitalized, and bold.
-
 *Soft hyphens:* The soft hyphen character, written `\N{soft hyphen}`
 in Python, represents a place where the text renderer can, but doesn't
 have to, insert a hyphen and break the word across lines. Add support
@@ -875,6 +871,11 @@ soft hyphens, and if so break the word across lines. Remember that a
 word can have multiple soft hyphens in it, and make sure to draw a
 hyphen when you break a word. The word
 "super­cala­fraga­listic­expi­ala­do­shus" is a good test case.
+
+*Small caps:* Make the `<abbr>` element render text in small caps,
+<abbr>like this</abbr>. Inside an `<abbr>` tag, lower-case letters
+should be small, capitalized, and bold, while all other characters
+(upper case, numbers, etc) should be drawn in the normal font.
 
 *Preformatted text:* Add support for the `<pre>` tag. Unlike normal
 paragraphs, text inside `<pre>` tags doesn't automatically break

--- a/book/text.md
+++ b/book/text.md
@@ -669,9 +669,9 @@ max_ascent = max([metric["ascent"] for metric in metrics])
 The line is then `max_ascent` below `self.y`—or actually a little more
 to account for the leading:[^leading-half]
 
-[^leading-half]: Actually actually, 25% leading doesn't add 25% of the
-    ascender above the ascender and 25% of the descender below the
-    descender. Instead, it adds [12.5% of the line height in both
+[^leading-half]: Actually, 25% leading doesn't add 25% of the ascender
+    above the ascender and 25% of the descender below the descender.
+    Instead, it adds [12.5% of the line height in both
     places][line-height-def], which is subtly different when fonts are
     mixed. But let's skip that subtlety here.
 

--- a/book/text.md
+++ b/book/text.md
@@ -258,7 +258,7 @@ a time:[^10]
 for word in text.split():
     w = font.measure(word)
     if cursor_x + w >= WIDTH - HSTEP:
-        cursor_y += font.metrics("linespace") * 1.2
+        cursor_y += font.metrics("linespace") * 1.25
         cursor_x = HSTEP
     self.display_list.append((cursor_x, cursor_y, word))
     cursor_x += w + font.measure(" ")
@@ -279,10 +279,10 @@ removed all of the whitespace, and this adds it back. I don't add the
 space to `w` on the second line, though, because you don't need a
 space after the last word on a line.
 
-Finally, note that I multiply the linespace by 1.2 when incrementing
+Finally, note that I multiply the linespace by 1.25 when incrementing
 `y`. Try removing the multiplier: you'll see that the text is harder
 to read because the lines are too close together.[^11] Instead, it is
-common to add "line spacing" or "leading"[^12] between lines. The 20%
+common to add "line spacing" or "leading"[^12] between lines. The 25%
 line spacing is a normal amount.
 
 [^11]: Designers say the text is too "tight".
@@ -669,15 +669,16 @@ max_ascent = max([metric["ascent"] for metric in metrics])
 The line is then `max_ascent` below `self.y`—or actually a little more
 to account for the leading:[^leading-half]
 
-[^leading-half]: Actually actually, 20% leading doesn't add 20% of the
-    ascender above the ascender and 20% of the descender below the
-    descender. Instead, it adds [10% of the line height in both
-    places][line-height-def].
+[^leading-half]: Actually actually, 25% leading doesn't add 25% of the
+    ascender above the ascender and 25% of the descender below the
+    descender. Instead, it adds [12.5% of the line height in both
+    places][line-height-def], which is subtly different when fonts are
+    mixed. But let's skip that subtlety here.
 
 [line-height-def]: https://www.w3.org/TR/CSS2/visudet.html#leading
     
 ``` {.python}
-baseline = self.cursor_y + 1.2 * max_ascent
+baseline = self.cursor_y + 1.25 * max_ascent
 ```
 
 Now that we know where the line is, we can place each word relative to
@@ -705,7 +706,7 @@ deepest descender:
 
 ``` {.python}
 max_descent = max([metric["descent"] for metric in metrics])
-self.cursor_y = baseline + 1.2 * max_descent
+self.cursor_y = baseline + 1.25 * max_descent
 ```
 
 Now all the text is aligned along the line, even when text sizes are

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -326,7 +326,7 @@ class LineLayout:
         self.metrics = [child.font.metrics() for child in self.children]
         self.max_ascent = max([metric["ascent"] for metric in self.metrics])
         self.max_descent = max([metric["descent"] for metric in self.metrics])
-        self.h = 1.2 * (self.max_descent + self.max_ascent)
+        self.h = 1.25 * (self.max_descent + self.max_ascent)
 
         cx = 0
         self.cxs = []
@@ -335,7 +335,7 @@ class LineLayout:
             cx += child.w + child.font.measure(" ")
 
     def position(self):
-        baseline = self.y + 1.2 * self.max_ascent
+        baseline = self.y + 1.25 * self.max_ascent
         for cx, child, metrics in \
           zip(self.cxs, self.children, self.metrics):
             child.x = self.x + cx

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -160,12 +160,12 @@ class LineLayout:
 
         max_ascent = max([-word.font.getMetrics().fAscent 
                           for word in self.children])
-        baseline = self.y + 1.2 * max_ascent
+        baseline = self.y + 1.25 * max_ascent
         for word in self.children:
             word.y = baseline + word.font.getMetrics().fAscent
         max_descent = max([word.font.getMetrics().fDescent
                            for word in self.children])
-        self.height = 1.2 * (max_ascent + max_descent)
+        self.height = 1.25 * (max_ascent + max_descent)
 
     def paint(self, display_list):
         for child in self.children:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -343,7 +343,7 @@ class LineLayout:
         self.metrics = [child.font.metrics() for child in self.children]
         self.max_ascent = max([metric["ascent"] for metric in self.metrics])
         self.max_descent = max([metric["descent"] for metric in self.metrics])
-        self.h = 1.2 * (self.max_descent + self.max_ascent)
+        self.h = 1.25 * (self.max_descent + self.max_ascent)
 
         cx = 0
         self.cxs = []
@@ -352,7 +352,7 @@ class LineLayout:
             cx += child.w + child.font.measure(" ")
 
     def position(self):
-        baseline = self.y + 1.2 * self.max_ascent
+        baseline = self.y + 1.25 * self.max_ascent
         if self.children:
             for cx, child, metrics in \
               zip(self.cxs, self.children, self.metrics):

--- a/src/lab3-tests.md
+++ b/src/lab3-tests.md
@@ -40,22 +40,22 @@ format text. However, note that this test doesn't use real tkinter fonts, but
 rather a mock font that has faked metrics.
 
     >>> lab3.Layout(lab3.lex("abc")).display_list
-    [(13, 20.4, 'abc', Font size=16 weight=normal slant=roman style=None)]
+    [(13, 21.0, 'abc', Font size=16 weight=normal slant=roman style=None)]
 
     >>> lab3.Layout(lab3.lex("<b>abc</b>")).display_list
-    [(13, 20.4, 'abc', Font size=16 weight=bold slant=roman style=None)]
+    [(13, 21.0, 'abc', Font size=16 weight=bold slant=roman style=None)]
     
     >>> lab3.Layout(lab3.lex("<big>abc</big>")).display_list
-    [(13, 21.0, 'abc', Font size=20 weight=normal slant=roman style=None)]
+    [(13, 21.75, 'abc', Font size=20 weight=normal slant=roman style=None)]
 
     >>> lab3.Layout(lab3.lex("<big><big>abc</big></big>")).display_list
-    [(13, 21.599999999999994, 'abc', Font size=24 weight=normal slant=roman style=None)]
+    [(13, 22.5, 'abc', Font size=24 weight=normal slant=roman style=None)]
 
     >>> lab3.Layout(lab3.lex("<big><big><i>abc</i></big></big>")).display_list
-    [(13, 21.599999999999994, 'abc', Font size=24 weight=normal slant=italic style=None)]
+    [(13, 22.5, 'abc', Font size=24 weight=normal slant=italic style=None)]
 
     >>> lab3.Layout(lab3.lex("<big><big><i>abc</i></big>def</big>")).display_list
-    [(13, 21.599999999999994, 'abc', Font size=24 weight=normal slant=italic style=None), (109, 24.599999999999994, 'def', Font size=20 weight=normal slant=roman style=None)]
+    [(13, 22.5, 'abc', Font size=24 weight=normal slant=italic style=None), (109, 25.5, 'def', Font size=20 weight=normal slant=roman style=None)]
 
 Breakpoints can be set after each layout:
 
@@ -65,9 +65,9 @@ Breakpoints can be set after each layout:
     breakpoint(name='initial_y', '18', '[(13, 'abc', Font size=16 weight=normal slant=roman style=None)]')
     breakpoint(name='metrics', '[{'ascent': 12.0, 'descent': 4.0, 'linespace': 16}]')
     breakpoint(name='max_ascent', '12.0')
-    breakpoint(name='aligned', '[(13, 20.4, 'abc', Font size=16 weight=normal slant=roman style=None)]')
+    breakpoint(name='aligned', '[(13, 21.0, 'abc', Font size=16 weight=normal slant=roman style=None)]')
     breakpoint(name='max_descent', '4.0')
-    breakpoint(name='final_y', '37.199999999999996')
+    breakpoint(name='final_y', '38.0')
     
     >>> test.unpatch_breakpoint()
 
@@ -78,27 +78,27 @@ out text with mixed font sizes, and then measure the line heights:
     ...     return word[1] + word[3].metrics("ascent")
     >>> l = lab3.Layout(lab3.lex("Start<br>Regular<br>Regular <big><big>Big"))
     >>> l.display_list #doctest: +NORMALIZE_WHITESPACE
-    [(13, 20.4, 'Start', Font size=16 weight=normal slant=roman style=None),
-     (13, 39.599999999999994, 'Regular', Font size=16 weight=normal slant=roman style=None),
-     (13, 65.99999999999999, 'Regular', Font size=16 weight=normal slant=roman style=None),
-     (141, 59.999999999999986, 'Big', Font size=24 weight=normal slant=roman style=None)]
+    [(13, 21.0, 'Start', Font size=16 weight=normal slant=roman style=None),
+     (13, 41.0, 'Regular', Font size=16 weight=normal slant=roman style=None),
+     (13, 68.5, 'Regular', Font size=16 weight=normal slant=roman style=None),
+     (141, 62.5, 'Big', Font size=24 weight=normal slant=roman style=None)]
     >>> baseline(l.display_list[1]) - baseline(l.display_list[0])
-    19.199999999999996
+    20.0
     >>> baseline(l.display_list[3]) - baseline(l.display_list[1])
-    26.39999999999999
+    27.5
 
 The differing line heights don't occur when text gets smaller:
 
     >>> l = lab3.Layout(lab3.lex("Start<br>Regular<br>Regular <small><small>Small"))
     >>> l.display_list #doctest: +NORMALIZE_WHITESPACE
-    [(13, 20.4, 'Start', Font size=16 weight=normal slant=roman style=None),
-     (13, 39.599999999999994, 'Regular', Font size=16 weight=normal slant=roman style=None),
-     (13, 58.79999999999998, 'Regular', Font size=16 weight=normal slant=roman style=None),
-     (141, 61.79999999999998, 'Small', Font size=12 weight=normal slant=roman style=None)]
+    [(13, 21.0, 'Start', Font size=16 weight=normal slant=roman style=None),
+     (13, 41.0, 'Regular', Font size=16 weight=normal slant=roman style=None),
+     (13, 61.0, 'Regular', Font size=16 weight=normal slant=roman style=None),
+     (141, 64.0, 'Small', Font size=12 weight=normal slant=roman style=None)]
     >>> baseline(l.display_list[1]) - baseline(l.display_list[0])
-    19.199999999999996
+    20.0
     >>> baseline(l.display_list[3]) - baseline(l.display_list[1])
-    19.19999999999999
+    20.0
 
 
 Testing `Browser`
@@ -116,15 +116,15 @@ Now let's test integration of layout into the Browser class.
 Testing the display list output of this URL:
 
     >>> browser.display_list
-    [(13, 20.1, 'abc', Font size=14 weight=normal slant=roman style=None), (69, 20.1, 'def', Font size=14 weight=normal slant=italic style=None)]
+    [(13, 20.625, 'abc', Font size=14 weight=normal slant=roman style=None), (69, 20.625, 'def', Font size=14 weight=normal slant=italic style=None)]
 
 And the canvas:
 
     >>> test.patch_canvas()
     >>> browser = lab3.Browser()
     >>> browser.load(url)
-    create_text: x=13 y=20.1 text=abc font=Font size=14 weight=normal slant=roman style=None anchor=nw
-    create_text: x=69 y=20.1 text=def font=Font size=14 weight=normal slant=italic style=None anchor=nw
+    create_text: x=13 y=20.625 text=abc font=Font size=14 weight=normal slant=roman style=None anchor=nw
+    create_text: x=69 y=20.625 text=def font=Font size=14 weight=normal slant=italic style=None anchor=nw
     >>> test.unpatch_canvas()
 
 And with breakpoints:
@@ -135,12 +135,12 @@ And with breakpoints:
     breakpoint(name='initial_y', '18', '[(13, 'abc', Font size=14 weight=normal slant=roman style=None), (69, 'def', Font size=14 weight=normal slant=italic style=None)]')
     breakpoint(name='metrics', '[{'ascent': 10.5, 'descent': 3.5, 'linespace': 14}, {'ascent': 10.5, 'descent': 3.5, 'linespace': 14}]')
     breakpoint(name='max_ascent', '10.5')
-    breakpoint(name='aligned', '[(13, 20.1, 'abc', Font size=14 weight=normal slant=roman style=None)]')
-    breakpoint(name='aligned', '[(13, 20.1, 'abc', Font size=14 weight=normal slant=roman style=None), (69, 20.1, 'def', Font size=14 weight=normal slant=italic style=None)]')
+    breakpoint(name='aligned', '[(13, 20.625, 'abc', Font size=14 weight=normal slant=roman style=None)]')
+    breakpoint(name='aligned', '[(13, 20.625, 'abc', Font size=14 weight=normal slant=roman style=None), (69, 20.625, 'def', Font size=14 weight=normal slant=italic style=None)]')
     breakpoint(name='max_descent', '3.5')
-    breakpoint(name='final_y', '34.800000000000004')
-    create_text: x=13 y=20.1 text=abc font=Font size=14 weight=normal slant=roman style=None anchor=nw
-    create_text: x=69 y=20.1 text=def font=Font size=14 weight=normal slant=italic style=None anchor=nw
+    breakpoint(name='final_y', '35.5')
+    create_text: x=13 y=20.625 text=abc font=Font size=14 weight=normal slant=roman style=None anchor=nw
+    create_text: x=69 y=20.625 text=def font=Font size=14 weight=normal slant=italic style=None anchor=nw
 
     >>> test.unpatch_breakpoint()
 

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -113,7 +113,7 @@ class Layout:
         metrics = [font.metrics() for x, word, font in self.line]
         breakpoint("metrics", metrics)
         max_ascent = max([metric["ascent"] for metric in metrics])
-        baseline = self.cursor_y + 1.2 * max_ascent
+        baseline = self.cursor_y + 1.25 * max_ascent
         breakpoint("max_ascent", max_ascent);
         for x, word, font in self.line:
             y = baseline - font.metrics("ascent")
@@ -123,7 +123,7 @@ class Layout:
         self.line = []
         max_descent = max([metric["descent"] for metric in metrics])
         breakpoint("max_descent", max_descent);
-        self.cursor_y = baseline + 1.2 * max_descent
+        self.cursor_y = baseline + 1.25 * max_descent
         breakpoint("final_y", self.cursor_y);
 
 class Browser:

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -198,14 +198,14 @@ class Layout:
         if not self.line: return
         metrics = [font.metrics() for x, word, font in self.line]
         max_ascent = max([metric["ascent"] for metric in metrics])
-        baseline = self.cursor_y + 1.2 * max_ascent
+        baseline = self.cursor_y + 1.25 * max_ascent
         for x, word, font in self.line:
             y = baseline - font.metrics("ascent")
             self.display_list.append((x, y, word, font))
         self.cursor_x = HSTEP
         self.line = []
         max_descent = max([metric["descent"] for metric in metrics])
-        self.cursor_y = baseline + 1.2 * max_descent
+        self.cursor_y = baseline + 1.25 * max_descent
 
 class Browser:
     def __init__(self):

--- a/src/lab5-tests.md
+++ b/src/lab5-tests.md
@@ -100,18 +100,18 @@ Testing the layout tree
 
     >>> lab5.print_tree(browser.document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=57.59999999999998)
-         BlockLayout(x=13, y=18, width=774, height=57.59999999999998)
+       BlockLayout(x=13, y=18, width=774, height=60.0)
+         BlockLayout(x=13, y=18, width=774, height=60.0)
            BlockLayout(x=13, y=18, width=774, height=0)
-           InlineLayout(x=13, y=18, width=774, height=19.199999999999996)
-           BlockLayout(x=13, y=37.199999999999996, width=774, height=19.199999999999996)
-             BlockLayout(x=13, y=37.199999999999996, width=774, height=0)
-             InlineLayout(x=13, y=37.199999999999996, width=774, height=19.199999999999996)
-           BlockLayout(x=13, y=56.39999999999999, width=774, height=0)
-           InlineLayout(x=13, y=56.39999999999999, width=774, height=19.19999999999999)
+           InlineLayout(x=13, y=18, width=774, height=20.0)
+           BlockLayout(x=13, y=38.0, width=774, height=20.0)
+             BlockLayout(x=13, y=38.0, width=774, height=0)
+             InlineLayout(x=13, y=38.0, width=774, height=20.0)
+           BlockLayout(x=13, y=58.0, width=774, height=0)
+           InlineLayout(x=13, y=58.0, width=774, height=20.0)
 
-    >>> browser.display_list
-    [DrawText(top=20.4 left=13 bottom=36.4 text=text font=Font size=16 weight=normal slant=roman style=None), DrawText(top=39.599999999999994 left=13 bottom=55.599999999999994 text=text font=Font size=16 weight=normal slant=roman style=None), DrawText(top=58.79999999999998 left=13 bottom=74.79999999999998 text=text font=Font size=16 weight=normal slant=roman style=None)]
+    >>> browser.display_list #doctest
+    [DrawText(top=21.0 left=13 bottom=37.0 text=text font=Font size=16 weight=normal slant=roman style=None), DrawText(top=41.0 left=13 bottom=57.0 text=text font=Font size=16 weight=normal slant=roman style=None), DrawText(top=61.0 left=13 bottom=77.0 text=text font=Font size=16 weight=normal slant=roman style=None)]
 
 Testing background painting
 ===========================
@@ -133,14 +133,14 @@ Testing background painting
 
     >>> lab5.print_tree(browser.document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=19.199999999999996)
-         BlockLayout(x=13, y=18, width=774, height=19.199999999999996)
-           InlineLayout(x=13, y=18, width=774, height=19.199999999999996)
+       BlockLayout(x=13, y=18, width=774, height=20.0)
+         BlockLayout(x=13, y=18, width=774, height=20.0)
+           InlineLayout(x=13, y=18, width=774, height=20.0)
 
 The first display list entry is now a gray rect, since it's for a `<pre>` element:
 
     >>> browser.display_list[0]
-    DrawRect(top=18 left=13 bottom=37.199999999999996 right=787 color=gray)
+    DrawRect(top=18 left=13 bottom=38.0 right=787 color=gray)
 
 
 Testing breakpoints in layout
@@ -156,7 +156,7 @@ Tree-based layout also supports debugging breakpoints.
     breakpoint(name='layout_pre', 'BlockLayout(x=None, y=None, width=None, height=None)')
     breakpoint(name='layout_pre', 'BlockLayout(x=None, y=None, width=None, height=None)')
     breakpoint(name='layout_pre', 'InlineLayout(x=None, y=None, width=None, height=None)')
-    breakpoint(name='layout_post', 'InlineLayout(x=13, y=18, width=774, height=19.199999999999996)')
-    breakpoint(name='layout_post', 'BlockLayout(x=13, y=18, width=774, height=19.199999999999996)')
-    breakpoint(name='layout_post', 'BlockLayout(x=13, y=18, width=774, height=19.199999999999996)')
+    breakpoint(name='layout_post', 'InlineLayout(x=13, y=18, width=774, height=20.0)')
+    breakpoint(name='layout_post', 'BlockLayout(x=13, y=18, width=774, height=20.0)')
+    breakpoint(name='layout_post', 'BlockLayout(x=13, y=18, width=774, height=20.0)')
     breakpoint(name='layout_post', 'DocumentLayout()')

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -169,14 +169,14 @@ class InlineLayout:
         if not self.line: return
         metrics = [font.metrics() for x, word, font in self.line]
         max_ascent = max([metric["ascent"] for metric in metrics])
-        baseline = self.cursor_y + 1.2 * max_ascent
+        baseline = self.cursor_y + 1.25 * max_ascent
         for x, word, font in self.line:
             y = baseline - font.metrics("ascent")
             self.display_list.append((x, y, word, font))
         self.cursor_x = self.x
         self.line = []
         max_descent = max([metric["descent"] for metric in metrics])
-        self.cursor_y = baseline + 1.2 * max_descent
+        self.cursor_y = baseline + 1.25 * max_descent
 
     def paint(self, display_list):
         if isinstance(self.node, Element) and self.node.tag == "pre":

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -38,7 +38,7 @@ Testing tree_to_list
     >>> list = []
     >>> retval = lab6.tree_to_list(browser.document, list)
     >>> retval
-    [DocumentLayout(), BlockLayout(x=13, y=18, width=774, height=19.199999999999996), BlockLayout(x=13, y=18, width=774, height=19.199999999999996), InlineLayout(x=13, y=18, width=774, height=19.199999999999996)]
+    [DocumentLayout(), BlockLayout(x=13, y=18, width=774, height=20.0), BlockLayout(x=13, y=18, width=774, height=20.0), InlineLayout(x=13, y=18, width=774, height=20.0)]
     >>> retval == list
     True
 

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -286,14 +286,14 @@ class InlineLayout:
         if not self.line: return
         metrics = [font.metrics() for x, word, font, color in self.line]
         max_ascent = max([metric["ascent"] for metric in metrics])
-        baseline = self.cursor_y + 1.2 * max_ascent
+        baseline = self.cursor_y + 1.25 * max_ascent
         for x, word, font, color in self.line:
             y = baseline - font.metrics("ascent")
             self.display_list.append((x, y, word, font, color))
         self.cursor_x = self.x
         self.line = []
         max_descent = max([metric["descent"] for metric in metrics])
-        self.cursor_y = baseline + 1.2 * max_descent
+        self.cursor_y = baseline + 1.25 * max_descent
 
     def paint(self, display_list):
         bgcolor = self.node.style.get("background-color",

--- a/src/lab7-tests.md
+++ b/src/lab7-tests.md
@@ -35,22 +35,22 @@ Here is how the lines are represented in chapter 7:
 
     >>> lab7.print_tree(browser.tabs[0].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=43.199999999999996)
-         BlockLayout(x=13, y=18, width=774, height=43.199999999999996)
-           LineLayout(x=13, y=18, width=774, height=43.199999999999996)
-             LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-               TextLayout(x=13, y=19.799999999999997, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=73, y=19.799999999999997, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=109, y=19.799999999999997, width=12, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=133, y=19.799999999999997, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
-             LineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-               TextLayout(x=13, y=34.199999999999996, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=73, y=34.199999999999996, width=12, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=97, y=34.199999999999996, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
-             LineLayout(x=13, y=46.8, width=774, height=14.399999999999999)
-               TextLayout(x=13, y=48.599999999999994, width=36, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=61, y=48.599999999999994, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=121, y=48.599999999999994, width=36, height=12, font=Font size=12 weight=normal slant=roman style=None
+       BlockLayout(x=13, y=18, width=774, height=45.0)
+         BlockLayout(x=13, y=18, width=774, height=45.0)
+           LineLayout(x=13, y=18, width=774, height=45.0)
+             LineLayout(x=13, y=18, width=774, height=15.0)
+               TextLayout(x=13, y=20.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=73, y=20.25, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=109, y=20.25, width=12, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=133, y=20.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
+             LineLayout(x=13, y=33.0, width=774, height=15.0)
+               TextLayout(x=13, y=35.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=73, y=35.25, width=12, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=97, y=35.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
+             LineLayout(x=13, y=48.0, width=774, height=15.0)
+               TextLayout(x=13, y=50.25, width=36, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=61, y=50.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=121, y=50.25, width=36, height=12, font=Font size=12 weight=normal slant=roman style=None
 
 Whereas in chapter 6 there is no direct layout tree representation of text, but the inline
 has the same total height:
@@ -60,9 +60,9 @@ has the same total height:
     >>> browser2.load(url)
     >>> lab6.print_tree(browser2.document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=57.59999999999998)
-         BlockLayout(x=13, y=18, width=774, height=57.59999999999998)
-           InlineLayout(x=13, y=18, width=774, height=57.59999999999998)
+       BlockLayout(x=13, y=18, width=774, height=60.0)
+         BlockLayout(x=13, y=18, width=774, height=60.0)
+           InlineLayout(x=13, y=18, width=774, height=60.0)
 
 Testing Tab
 ===========
@@ -86,11 +86,11 @@ The browser can have multiple tabs:
 
     >>> lab7.print_tree(browser.tabs[1].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=14.399999999999999)
-         LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-           LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-             TextLayout(x=13, y=19.799999999999997, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
-             TextLayout(x=85, y=19.799999999999997, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
+       BlockLayout(x=13, y=18, width=774, height=15.0)
+         LineLayout(x=13, y=18, width=774, height=15.0)
+           LineLayout(x=13, y=18, width=774, height=15.0)
+             TextLayout(x=13, y=20.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
+             TextLayout(x=85, y=20.25, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
 
 Tabs supports navigation---clicking on a link to navigate a tab to a new site:
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -56,12 +56,12 @@ class LineLayout:
 
         max_ascent = max([word.font.metrics("ascent") 
                           for word in self.children])
-        baseline = self.y + 1.2 * max_ascent
+        baseline = self.y + 1.25 * max_ascent
         for word in self.children:
             word.y = baseline - word.font.metrics("ascent")
         max_descent = max([word.font.metrics("descent")
                            for word in self.children])
-        self.height = 1.2 * (max_ascent + max_descent)
+        self.height = 1.25 * (max_ascent + max_descent)
 
     def paint(self, display_list):
         for child in self.children:

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -54,20 +54,20 @@ Testing InputLayout
                'Submit!'
     >>> lab8.print_tree(browser.tabs[0].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=43.199999999999996)
-         BlockLayout(x=13, y=18, width=774, height=43.199999999999996)
-           BlockLayout(x=13, y=18, width=774, height=43.199999999999996)
-             InlineLayout(x=13, y=18, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-                 TextLayout(x=13, y=19.799999999999997, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
-                 InputLayout(x=85, y=19.799999999999997, width=200, height=12)
-             InlineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-                 TextLayout(x=13, y=34.199999999999996, width=96, height=12, font=Font size=12 weight=normal slant=roman style=None
-                 InputLayout(x=121, y=34.199999999999996, width=200, height=12)
-             InlineLayout(x=13, y=46.8, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=46.8, width=774, height=14.399999999999999)
-                 InputLayout(x=13, y=48.599999999999994, width=200, height=12)
+       BlockLayout(x=13, y=18, width=774, height=45.0)
+         BlockLayout(x=13, y=18, width=774, height=45.0)
+           BlockLayout(x=13, y=18, width=774, height=45.0)
+             InlineLayout(x=13, y=18, width=774, height=15.0)
+               LineLayout(x=13, y=18, width=774, height=15.0)
+                 TextLayout(x=13, y=20.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
+                 InputLayout(x=85, y=20.25, width=200, height=12)
+             InlineLayout(x=13, y=33.0, width=774, height=15.0)
+               LineLayout(x=13, y=33.0, width=774, height=15.0)
+                 TextLayout(x=13, y=35.25, width=96, height=12, font=Font size=12 weight=normal slant=roman style=None
+                 InputLayout(x=121, y=35.25, width=200, height=12)
+             InlineLayout(x=13, y=48.0, width=774, height=15.0)
+               LineLayout(x=13, y=48.0, width=774, height=15.0)
+                 InputLayout(x=13, y=50.25, width=200, height=12)
 
 The display list of a button should include its contents, and the display list
 of a text input should be its `value` attribute:
@@ -78,18 +78,18 @@ of a text input should be its `value` attribute:
     >>> display_list = []
     >>> text_input.paint(display_list)
     >>> display_list
-    [DrawRect(top=19.799999999999997 left=85 bottom=31.799999999999997 right=285 color=lightblue), DrawText(text=1)]
+    [DrawRect(top=20.25 left=85 bottom=32.25 right=285 color=lightblue), DrawText(text=1)]
     >>> display_list = []
     >>> button.paint(display_list)
     >>> display_list
-    [DrawRect(top=48.599999999999994 left=13 bottom=60.599999999999994 right=213 color=orange), DrawText(text=Submit!)]
+    [DrawRect(top=50.25 left=13 bottom=62.25 right=213 color=orange), DrawText(text=Submit!)]
 
 Testing form submission
 =======================
 
 Forms are submitted via a click on the submit button.
 
-    >>> browser.handle_click(test.Event(14, 50 + 100))
+    >>> browser.handle_click(test.Event(20, 55 + lab8.CHROME_PX))
     >>> lab8.print_tree(browser.tabs[0].document.node)
      <html>
        <body>

--- a/src/lab9-tests.md
+++ b/src/lab9-tests.md
@@ -150,19 +150,19 @@ Once we've changed the page, the browser should rerender:
 
     >>> lab9.print_tree(b.tabs[0].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-         BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-           BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-             InlineLayout(x=13, y=18, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-                 TextLayout(x=13, y=19.799999999999997, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
-                 TextLayout(x=73, y=19.799999999999997, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
-                 TextLayout(x=109, y=19.799999999999997, width=12, height=12, font=Font size=12 weight=normal slant=roman style=None
-                 TextLayout(x=133, y=19.799999999999997, width=36, height=12, font=Font size=12 weight=bold slant=roman style=None
-                 TextLayout(x=181, y=19.799999999999997, width=96, height=12, font=Font size=12 weight=normal slant=roman style=None
-             InlineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-                 TextLayout(x=13, y=34.199999999999996, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
+       BlockLayout(x=13, y=18, width=774, height=30.0)
+         BlockLayout(x=13, y=18, width=774, height=30.0)
+           BlockLayout(x=13, y=18, width=774, height=30.0)
+             InlineLayout(x=13, y=18, width=774, height=15.0)
+               LineLayout(x=13, y=18, width=774, height=15.0)
+                 TextLayout(x=13, y=20.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
+                 TextLayout(x=73, y=20.25, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
+                 TextLayout(x=109, y=20.25, width=12, height=12, font=Font size=12 weight=normal slant=roman style=None
+                 TextLayout(x=133, y=20.25, width=36, height=12, font=Font size=12 weight=bold slant=roman style=None
+                 TextLayout(x=181, y=20.25, width=96, height=12, font=Font size=12 weight=normal slant=roman style=None
+             InlineLayout(x=13, y=33.0, width=774, height=15.0)
+               LineLayout(x=13, y=33.0, width=774, height=15.0)
+                 TextLayout(x=13, y=35.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
 
 Note that there's now many `TextLayout`s inside the first `LineLayout`, one per
 new word.
@@ -183,15 +183,15 @@ The page is rerendered again:
 
     >>> lab9.print_tree(b.tabs[0].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-         BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-           BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-             InlineLayout(x=13, y=18, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-                 TextLayout(x=13, y=19.799999999999997, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
-             InlineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-               LineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-                 TextLayout(x=13, y=34.199999999999996, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
+       BlockLayout(x=13, y=18, width=774, height=30.0)
+         BlockLayout(x=13, y=18, width=774, height=30.0)
+           BlockLayout(x=13, y=18, width=774, height=30.0)
+             InlineLayout(x=13, y=18, width=774, height=15.0)
+               LineLayout(x=13, y=18, width=774, height=15.0)
+                 TextLayout(x=13, y=20.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
+             InlineLayout(x=13, y=33.0, width=774, height=15.0)
+               LineLayout(x=13, y=33.0, width=774, height=15.0)
+                 TextLayout(x=13, y=35.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
 
 Despite this, the old nodes should stick around:
 
@@ -268,16 +268,16 @@ events. The display list gives us coordinates for clicking.
 
     >>> lab9.print_tree(b.tabs[1].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-         BlockLayout(x=13, y=18, width=774, height=28.799999999999997)
-           InlineLayout(x=13, y=18, width=774, height=14.399999999999999)
-             LineLayout(x=13, y=18, width=774, height=14.399999999999999)
-               TextLayout(x=13, y=19.799999999999997, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
-               TextLayout(x=85, y=19.799999999999997, width=36, height=12, font=Font size=12 weight=normal slant=roman style=None
-           InlineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-             LineLayout(x=13, y=32.4, width=774, height=14.399999999999999)
-               InputLayout(x=13, y=34.199999999999996, width=200, height=12)
-               InputLayout(x=225, y=34.199999999999996, width=200, height=12)
+       BlockLayout(x=13, y=18, width=774, height=30.0)
+         BlockLayout(x=13, y=18, width=774, height=30.0)
+           InlineLayout(x=13, y=18, width=774, height=15.0)
+             LineLayout(x=13, y=18, width=774, height=15.0)
+               TextLayout(x=13, y=20.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
+               TextLayout(x=85, y=20.25, width=36, height=12, font=Font size=12 weight=normal slant=roman style=None
+           InlineLayout(x=13, y=33.0, width=774, height=15.0)
+             LineLayout(x=13, y=33.0, width=774, height=15.0)
+               InputLayout(x=13, y=35.25, width=200, height=12)
+               InputLayout(x=225, y=35.25, width=200, height=12)
     >>> b.tabs[1].click(14, 20)
     a clicked
     >>> b.tabs[1].click(14, 40)


### PR DESCRIPTION
The point of changing the standard line spacing is to avoid floating-point round-off error in our tests. (Yes it is dumb.) I also reordered the soft-hyphens and small-caps exercises because in retrospect small-caps is harder.

I'll work on getting all the tests fixed up before merging, but I'm deploying this to the draft env now for benefit of my students.