### PR TITLE
Add support for from-imports to the outliner

### DIFF
--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -281,6 +281,12 @@ deduplicate the code a bit:
     >>> Test.stmt("from lab1 import request")
     import { request } from "./lab1.js";
     >>> assert "request" in LAB_IMPORT_FNS
+    >>> Test.stmt("from lab2 import HSTEP")
+    import { HSTEP } from "./lab2.js";
+    >>> assert "HSTEP" in LAB_IMPORT_CONSTANTS
+    >>> Test.stmt("from lab4 import Element")
+    import { Element } from "./lab4.js";
+    >>> assert "HSTEP" in LAB_IMPORT_CLASSES
     >>> Test.stmt("from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP")
     import { WIDTH, HEIGHT, HSTEP, VSTEP } from "./lab2.js";
     >>> assert "WIDTH" in LAB_IMPORT_CONSTANTS

--- a/src/lab2.py
+++ b/src/lab2.py
@@ -4,10 +4,10 @@ up to and including Chapter 2 (Drawing to the Screen),
 without exercises.
 """
 
-from lab1 import request
 import socket
 import ssl
 import tkinter
+from lab1 import request
 
 def lex(body):
     text = ""

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -9,6 +9,7 @@ import ssl
 import tkinter
 import tkinter.font
 from lab1 import request
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 
 class Text:
     def __init__(self, text):
@@ -42,11 +43,6 @@ def lex(body):
     if not in_tag and text:
         out.append(Text(text))
     return out
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
-
-SCROLL_STEP = 100
 
 FONTS = {}
 

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -9,7 +9,8 @@ import ssl
 import tkinter
 import tkinter.font
 from lab1 import request
-from lab3 import get_font
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab3 import FONTS, get_font
 
 class Text:
     def __init__(self, text, parent):
@@ -132,11 +133,6 @@ class HTMLParser:
             parent = self.unfinished[-1]
             parent.children.append(node)
         return self.unfinished.pop()
-            
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
-
-SCROLL_STEP = 100
 
 class Layout:
     def __init__(self, tree):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -9,16 +9,9 @@ import ssl
 import tkinter
 import tkinter.font
 from lab1 import request
-from lab3 import get_font
-from lab4 import print_tree
-from lab4 import Element
-from lab4 import HTMLParser
-from lab4 import Text            
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
-
-SCROLL_STEP = 100
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab3 import FONTS, get_font
+from lab4 import Text, Element, print_tree, HTMLParser
 
 BLOCK_ELEMENTS = [
     "html", "body", "article", "section", "nav", "aside",

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -35,10 +35,18 @@ Testing tree_to_list
 
     >>> browser = lab6.Browser()
     >>> browser.load(url)
+    >>> lab6.print_tree(browser.document)
+     DocumentLayout()
+       BlockLayout(x=13, y=18, width=774, height=15.0)
+         BlockLayout(x=13, y=18, width=774, height=15.0)
+           InlineLayout(x=13, y=18, width=774, height=15.0)
     >>> list = []
     >>> retval = lab6.tree_to_list(browser.document, list)
-    >>> retval
-    [DocumentLayout(), BlockLayout(x=13, y=18, width=774, height=20.0), BlockLayout(x=13, y=18, width=774, height=20.0), InlineLayout(x=13, y=18, width=774, height=20.0)]
+    >>> retval #doctest: +NORMALIZE_WHITESPACE
+    [DocumentLayout(),
+     BlockLayout(x=13, y=18, width=774, height=15.0),
+     BlockLayout(x=13, y=18, width=774, height=15.0),
+     InlineLayout(x=13, y=18, width=774, height=15.0)]
     >>> retval == list
     True
 

--- a/src/lab7-tests.md
+++ b/src/lab7-tests.md
@@ -37,7 +37,7 @@ Here is how the lines are represented in chapter 7:
      DocumentLayout()
        BlockLayout(x=13, y=18, width=774, height=45.0)
          BlockLayout(x=13, y=18, width=774, height=45.0)
-           LineLayout(x=13, y=18, width=774, height=45.0)
+           InlineLayout(x=13, y=18, width=774, height=45.0)
              LineLayout(x=13, y=18, width=774, height=15.0)
                TextLayout(x=13, y=20.25, width=48, height=12, font=Font size=12 weight=normal slant=roman style=None
                TextLayout(x=73, y=20.25, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None
@@ -60,9 +60,9 @@ has the same total height:
     >>> browser2.load(url)
     >>> lab6.print_tree(browser2.document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=60.0)
-         BlockLayout(x=13, y=18, width=774, height=60.0)
-           InlineLayout(x=13, y=18, width=774, height=60.0)
+       BlockLayout(x=13, y=18, width=774, height=45.0)
+         BlockLayout(x=13, y=18, width=774, height=45.0)
+           InlineLayout(x=13, y=18, width=774, height=45.0)
 
 Testing Tab
 ===========
@@ -87,7 +87,7 @@ The browser can have multiple tabs:
     >>> lab7.print_tree(browser.tabs[1].document)
      DocumentLayout()
        BlockLayout(x=13, y=18, width=774, height=15.0)
-         LineLayout(x=13, y=18, width=774, height=15.0)
+         InlineLayout(x=13, y=18, width=774, height=15.0)
            LineLayout(x=13, y=18, width=774, height=15.0)
              TextLayout(x=13, y=20.25, width=60, height=12, font=Font size=12 weight=normal slant=roman style=None
              TextLayout(x=85, y=20.25, width=24, height=12, font=Font size=12 weight=normal slant=roman style=None

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -8,24 +8,13 @@ import socket
 import ssl
 import tkinter
 import tkinter.font
-from lab4 import print_tree
 from lab1 import request
-from lab3 import get_font
-from lab4 import Element
-from lab4 import HTMLParser
-from lab4 import Text
-from lab5 import DocumentLayout
-from lab5 import DrawRect
-from lab6 import cascade_priority
-from lab6 import layout_mode
-from lab6 import resolve_url
-from lab6 import style
-from lab6 import tree_to_list
-from lab6 import CSSParser
-from lab6 import DrawText
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab3 import FONTS, get_font
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
+from lab6 import DocumentLayout, BlockLayout, InlineLayout, DrawText
+from lab6 import CSSParser, cascade_priority, style, resolve_url, tree_to_list
 
 class LineLayout:
     def __init__(self, node, parent, previous):
@@ -223,7 +212,7 @@ class InlineLayout:
             child.paint(display_list)
 
     def __repr__(self):
-        return "LineLayout(x={}, y={}, width={}, height={})".format(
+        return "InlineLayout(x={}, y={}, width={}, height={})".format(
             self.x, self.y, self.width, self.height)
 
 class DocumentLayout:
@@ -251,7 +240,6 @@ class DocumentLayout:
     def __repr__(self):
         return "DocumentLayout()"
 
-SCROLL_STEP = 100
 CHROME_PX = 100
 
 class Tab:

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -9,21 +9,12 @@ import ssl
 import tkinter
 import tkinter.font
 import urllib.parse
-from lab3 import get_font
-from lab4 import print_tree
-from lab4 import Element
-from lab4 import Text
-from lab4 import HTMLParser
-from lab5 import DrawRect
-from lab6 import cascade_priority
-from lab6 import layout_mode
-from lab6 import resolve_url
-from lab6 import style
-from lab6 import tree_to_list
-from lab6 import CSSParser
-from lab6 import DrawText
-from lab7 import LineLayout
-from lab7 import TextLayout
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab3 import FONTS, get_font
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
+from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab7 import LineLayout, TextLayout, CHROME_PX
 
 def request(url, payload=None):
     scheme, url = url.split("://", 1)
@@ -79,9 +70,6 @@ def request(url, payload=None):
     s.close()
 
     return headers, body
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
 
 INPUT_WIDTH_PX = 200
 
@@ -292,9 +280,6 @@ class DocumentLayout:
     def __repr__(self):
         return "DocumentLayout()"
 
-SCROLL_STEP = 100
-CHROME_PX = 100
-
 class Tab:
     def __init__(self):
         self.history = []
@@ -504,7 +489,6 @@ class Browser:
         self.canvas.create_rectangle(10, 50, 35, 90, width=1)
         self.canvas.create_polygon(
             15, 70, 30, 55, 30, 85, fill='black')
-
 
 if __name__ == "__main__":
     import sys

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -10,23 +10,13 @@ import tkinter
 import tkinter.font
 import urllib.parse
 import dukpy
-from lab3 import get_font
-from lab4 import print_tree
-from lab4 import Element
-from lab4 import Text
-from lab4 import HTMLParser
-from lab5 import DrawRect
-from lab6 import cascade_priority
-from lab6 import layout_mode
-from lab6 import resolve_url
-from lab6 import style
-from lab6 import tree_to_list
-from lab6 import CSSParser
-from lab6 import DrawText
-from lab7 import LineLayout
-from lab7 import TextLayout
-from lab8 import request
-from lab8 import DocumentLayout
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab3 import FONTS, get_font
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
+from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab7 import LineLayout, TextLayout, CHROME_PX
+from lab8 import request, DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
 
 EVENT_DISPATCH_CODE = \
     "new Node(dukpy.handle).dispatchEvent(new Event(dukpy.type))"
@@ -216,8 +206,6 @@ class Tab:
             self.history.pop()
             back = self.history.pop()
             self.load(back)
-
-WIDTH, HEIGHT = 800, 600
 
 class Browser:
     def __init__(self):

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -77,9 +77,6 @@ class JSContext:
             child.parent = elt
         self.tab.render()
 
-SCROLL_STEP = 100
-CHROME_PX = 100
-
 class Tab:
     def __init__(self):
         self.history = []


### PR DESCRIPTION
This PR allows the outliner to inline from-imported functions and classes. This means the outlines in each chapter are once again complete. I also added support for from-importing multiple things at a time, and fixed a few minor test bugs.

The order of the inlined elements depends on the order of the from-imports. Right now they're not ordered in the ideal way, but it's at least complete.