### PR TITLE
Rewrite Chapter 10 XSS section

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -678,7 +678,7 @@ request line:
 
 ``` {.python file=server}
 def handle_connection(conx):
-    req = conx.makefile("rb")
+    req = conx.makefile("b")
     reqline = req.readline().decode('utf8')
     method, url, version = reqline.split(" ", 2)
     assert method in ["GET", "POST"]

--- a/book/forms.md
+++ b/book/forms.md
@@ -838,12 +838,14 @@ def form_decode(body):
     params = {}
     for field in body.split("&"):
         name, value = field.split("=", 1)
-        params[urllib.unquote(name)] = urllib.unquote(value)
+        params[urllib.unquote_plus(name)] = urllib.unquote_plus(value)
     return params
 ```
 
-The `add_entry` function then looks up the `guest` parameter and adds
-its content as a new guest book entry:
+Note that I use `unquote_plus` instead of `unquote`, because some
+browsers use a plus sign to encode a space. The `add_entry` function
+then looks up the `guest` parameter and adds its content as a new
+guest book entry:
 
 ``` {.python file=server}
 def add_entry(params):

--- a/book/security.md
+++ b/book/security.md
@@ -23,13 +23,18 @@ you're writing security-sensitive code, this book is not enough.
 Cookies
 =======
 
-The most basic kind of user data on the web is the *cookie*. A
-cookie---the name is meaningless, ignore it---is a little bit of
-information stored by your browser on behalf of a web server. It's
-that information that allows the server to distinguish one web request
-from another. Bereft of cookies, your web browser is effectively
-anonymous:[^1] it isn't logged in anywhere so it can't do any useful
-personalization or show you your private data.
+With what we've implemented so far there's no way for a web server to
+tell whether two HTTP requests come from the same browsers, or
+different ones. Our web browser is effectively anonymous.[^1] That
+means it can't "log in" anywhere, because there's no way for the
+server to know which later requests come from the logged in browser
+and which come from some unrelated browser.
+
+The web fixes this problem with cookies. A cookie---the name is
+meaningless, ignore it---is a little bit of information stored by your
+browser on behalf of a web server. The cookie establishes that
+browser's identity and allows the server to distinguish one web
+request from another.
 
 [^1]: I don't mean anonymous against malicious attackers, who might
     use *browser fingerprinting* or similar techniques to tell users
@@ -38,99 +43,106 @@ personalization or show you your private data.
 
 Here's how cookies work. A web server, when it sends you an HTTP
 response, can add a `Set-Cookie` header. This header contains a
-key-value pair, plus a bunch of parameters describing how long the
-cookie should be stored and who it should be shown to. For example,
-the following `Set-Cookie` header sets the value of the `foo` key to
-`bar` and saves it until 2020:
+key-value pair; for example, the following header sets
+the `foo` to `bar`:
 
-    Set-Cookie: foo=bar; expires=Wed, 1 Jan 2020 00:00:00 GMT
-
-The expiration date is not mandatory, and there are other parameters
-you could add to a cookie; for now let's focus just on the key-value
-pair involved. That's what your browser needs to remember: that `foo`
-is `bar`. Every time it visits the server again it tells the server
-that `foo=bar` using the `Cookie` header:
+    Set-Cookie: foo=bar
+    
+The browser remembers this key-value pair, and the next time it makes
+a request to the same server (cookies are site-specific) it echoes it
+back in the `Cookie` header:
 
     Cookie: foo=bar
 
-Parameters like expiration dates are not reported to the server.
-If the browser is storing multiple cookies for that server, it
-combines the key-value pairs with a semicolon.
+Servers can also set multiple cookies and also set parameters like
+expiration dates, but this `Set-Cookie` / `Cookie` mechanism is the
+core principle.
 
-Let's implement cookies. We'll start storing cookies in our `Browser`;
-that database is traditionally called a *cookie jar*[^2] but I'll
-just call it `cookies`:
+Before we start implementing cookies, let's see how they're used by
+implementing a login system for our guest book. That's going to
+require is using cookies to create identities for all the browsers
+using our website.
 
-[^2]: Because once you have one silly name it's important to stay
-    on-brand.
+Let's have each browser identified by a long random number stored in
+the `token` cookie. When a request is made to the guest book, we'll
+either extract a token from the `Cookie` header, or generate a new
+one:[^secure-random]
 
-``` {.python}
-class Tab:
-    def __init__(self):
-        # ...
-        self.cookies = {}
-```
+[^secure-random]: This use of `random.random` returns a decimal number
+    with 53 bits of randomness. That's not great; 256 bits is ideal.
+    And `random.random` is not a secure random number generator: by
+    observing enough tokens you can predict future values and use
+    those to hijack accounts. A real web application must use a
+    cryptographically secure random number generator for tokens.
 
-Then, when responses are processed:
+``` {.python file=server}
+import random
 
-``` {.python expected=False}
-def load(self, url, body=None):
+def handle_connection(conx):
     # ...
-    if "set-cookie" in headers:
-        if ";" in headers["set-cookie"]:
-            kv, params = headers["set-cookie"].split(";", 1)
-        else:
-            kv = headers["set-cookie"]
-        self.cookies[key] = value
-    # ...
-```
-
-For now this code ignores expiration and all the other parameters, and
-it also ignores the fact that a server can actually send multiple
-`Set-Cookie` headers to set multiple cookies. It's a toy browser,
-people! I'm also storing all the cookies, from all of the servers, in
-one place. This is *not* a good idea, and we'll fix it later! For now,
-think of this as a one-server browser.
-
-::: {.todo}
-I've soured on this straw-man of implementing an insecure feature only
-to secure it later.
-:::
-
-Finally, we need to send the `Cookie` header with all of the current
-cookies. Let's add a `headers` argument to the `request` function so
-we can pass in the value of the `Cookie` header:
-
-``` {.python}
-def request(url, headers={}, payload=None):
-    # ...
-    for header, value in headers.items():
-        body += "{}: {}\r\n".format(header, value)
+    if "cookie" in headers:
+        token = headers["cookie"][len("token="):]
+    else:
+        token = str(random.random())[2:]
     # ...
 ```
 
-Now before calling `request` in `load`, let's construct the cookie
-string:
+This code should go after all the request headers are parsed, but
+before we actually handle the request in `do_request`.
 
-``` {.python expected=False}
-class Browser:
-    def cookie_string(self):
-        cookie_string = ""
-        for key, value in self.cookies.items():
-            cookie_string += "&" + key + "=" + value
-        return cookie_string[1:]
-    
-    def load(self, url, body=None):
-        req_headers = { "Cookie": self.cookie_string() }
-        # ...
-        headers, body = request(url, headers=req_headers, payload=body)
+Of course, if we just generated a random token, we need to tell the
+browser to remember it:
+
+``` {.python file=server}
+def handle_connection(conx):
+    # ...
+    if 'cookie' not in headers:
+        response += "Set-Cookie: token={}\r\n".format(token)
+    # ...
 ```
 
-Note that `load` calls `request` three times (for the HTML, CSS, and
-JS files). All of them should pass in that `Cookie` header.
+This code should go after `do_request`, when the server is assembling
+the HTTP response.
 
-Before we continue improving our cookie implementation, let's use them
-to add logins to the guest book server.
+We can use those identities to store information about each browser
+using our website. Let's do that on the server side,[^cookies-limited]
+in a variable called `SESSIONS`:
+
+[^cookies-limited]: Browsers and servers both limit header lengths, so
+    it's best not to store variable-sized data in cookies. Plus,
+    cookies are sent back and forth on every request, so long cookies
+    mean a lot of useless traffic.
+
+``` {.python file=server}
+SESSIONS = {}
+
+def handle_connection(conx):
+    # ...
+    session = SESSIONS.setdefault(token, {})
+    status, body = do_request(session, method, url, headers, body)
+    # ...
+```
+
+Note that I'm passing the user information as the first argument to
+`do_request`. Let's also make sure to pass that session information to
+individual pages like `show_comments` and `add_entry`:
+
+``` {.python file=server}
+def do_request(session, method, url, headers, body):
+    if method == "GET" and url == "/":
+        return "200 OK", show_comments(session)
+    # ...
+    elif method == "POST" and url == "/add":
+        params = form_decode(body)
+        return "200 OK", add_entry(session, params)
+    # ...
+```
+
+You'll also need to modify the `add_entry` and `show_comments`
+signatures, and also the call to `show_comments` inside `add_entry`.
+
+With the guest book server storing information about each user
+accessing the guest book, we can now build a login system.
 
 A login system
 ==============
@@ -138,318 +150,209 @@ A login system
 I want users to log in before posting to the guest book. Nothing
 complex, just the minimal functionality:
 
--   Users have to be logged in to add guest book entries.
--   The server will display who added which guest book entry.
--   Users will log in with a username and password on the `/login` page.
--   The server will hard-code a set of valid logins.
+- Users have to be logged in to add guest book entries.
+- The server will display who added which guest book entry.
+- Users will log in with a username and password.
+- The server will hard-code a set of valid logins.
 
 Let's start coding. First, we'll need to store usernames in `ENTRIES`:[^3]
 
 [^3]: The seed comments reference 1995's *Hackers*.
     [Hack the Planet!](https://xkcd.com/1337)
 
-
-``` {.python .browser expected=False}
+``` {.python file=server}
 ENTRIES = [
     ("No names. We are nameless!", "cerealkiller"),
     ("HACK THE PLANET!!!", "crashoverride"),
 ]
 ```
 
-
 When we print the guest book entries, print the username as well:
 
-``` {.python .browser expected=False}
-for entry, who in ENTRIES:
-    out += '<p>' + entry + " <i>from " + who + '</i></p>'
+``` {.python file=server}
+def show_comments(session):
+    # ...
+    for entry, who in ENTRIES:
+        out += '<p>' + entry + " <i>from " + who + '</i></p>'
+    # ...
 ```
 
-We'll also need a data structure to store usernames and passwords:
+We'll remember whether a user is logged in using the `user` key in the
+session data:
 
-``` {.python .browser expected=False}
-LOGINS = { "crashoverride": "0cool", "cerealkiller": "emmanuel" }
-```
-
-Next, let's add the `/login` URL:
-
-``` {.python expected=False}
-def handle_request(method, url, headers, body):
-    if method == 'POST':
-        # ...
+``` {.python file=server}
+def show_comments(session):
+    # ...
+    if "user" in session:
+        out += "<form action=add method=post>"
+        out +=   "<p><input name=guest></p>"
+        out +=   "<p><button>Sign the book!</button></p>"
+        out += "</form>"
     else:
-        # ...
-        elif url == "/login":
-            return login_form()
-
-def login_form():
-    body = "<!doctype html>"
-    body += "<form action=/ method=post>"
-    body += "<p>Username: <input name=username></p>"
-    body += "<p>Password: <input name=password type=password></p>"
-    body += "<p><button>Log in</button></p>"
-    body += "</form>"
-    return body
+        out += "<a href=/login>Sign in to write in the guest book</a>"
+    # ...
 ```
 
-To use the form, the user goes to `/login`, fills out their
-details,[^4] and submits the form. The login is sent to the main page
-(thanks to "`action=/`"), which needs to handle the request. I'll
-implement the login logic directly in `handle_request`:
+We'll require that users be logged in before they can post comments:
+
+``` {.python file=server}
+def add_entry(session, params):
+    if "user" in session and 'guest' in params and len(params['guest']) <= 100:
+        ENTRIES.append((params['guest'], session["user"]))
+    return show_comments(session)
+```
+
+Finally, let's work on actually logging in and out. To log in, users
+will go to the `/login` URL:
+
+``` {.python file=server}
+def do_request(session, method, url, headers, body):
+    # ...
+    elif method == "GET" and url == "/login":
+        return "200 OK", login_form(session)
+    # ...
+```
+
+That URL will show a form with a username and a password field:[^4]
 
 [^4]: I've given the `password` input area the type `password`, which
     in a real browser will draw stars or dots instead of showing what
     you've entered, though our browser doesn't do that.
 
-``` {.python expected=False}
-def handle_request(method, url, headers, body):
-    username = None
-    if method == 'POST' and url == "/":
+``` {.python file=server}
+def login_form(session):
+    body = "<!doctype html>"
+    body += "<form action=/login method=post>"
+    body += "<p>Username: <input name=username></p>"
+    body += "<p>Password: <input name=password type=password></p>"
+    body += "<p><button>Log in</button></p>"
+    body += "</form>"
+    return body 
+```
+
+Note that the form sends its data to `/login` as well, but using a
+`POST` request. Let's send those requests to a separate function:
+
+``` {.python file=server}
+def do_request(session, method, url, headers, body):
+    # ...
+    elif method == "POST" and url == "/login":
         params = form_decode(body)
-        if check_login(params.get("username"), params.get("password")):
-            username = params["username"]
+        return do_login(session, params)
     # ...
 ```
 
-The `check_login` method does exactly what you'd expect:
+That `do_login` function will check passwords and log people in by
+storing their user name in the session data:[^timing-attack]
 
-``` {.python expected=False}
-def check_login(username, pw):
-    return username in LOGINS and LOGINS[username] == pw
-```
+[^timing-attack]: Actually, using `==` to compare passwords like here
+    is a bad idea: Python's equality function for strings scans the
+    string from left to right, and exits as soon as it finds a
+    difference. So, *how long* it takes to check passwords gives you
+    clues about the password; this is called a "timing side channel".
+    I'm not worrying about that here, because this book is really
+    about the browser, not the server---but a secure web application
+    would have to fix it!
 
-The server now checks that the login was correct, but it should also set
-a cookie so that the browser actually remembers the login:[^5]
-
-[^5]: Like with the cookie jar, this is a transparently insecure design,
-    on purpose, so that I can demonstrate an attack.
-
-``` {.python expected=False}
-def handle_request(method, url, headers, body):
-    resp_headers = {}
-    
-    if method == "post" and url = "/":
-        # ...
-        if check_login(params.get("username"), params.get("password")):
-            # ...
-            resp_headers["Set-Cookie"] = "username=" + username
-    # ...
-```
-
-We'll need to send those headers in `handle_connection`, so first
-modify `handle_request` to return `resp_headers` in each case (there
-are lots!). Then, modify `handle_connection` to use them:
-
-``` {.python expected=False}
-def handle_connection(conx):
-    # ...
-    body, headers = handle_request(method, url, headers, body)
-    response = "HTTP/1.0 200 OK"
-    for header, value in headers.items():
-        response += "{}: {}\r\n".format(header, value)
-    # ...
-```
-
-Since we're now setting cookies we should also be reading them:[^6]
-
-[^6]: In reality there's also special syntax if you want an equal sign
-    in your cookie, but I'm ignoring that.
-
-``` {.python expected=False}
-def parse_cookies(s):
-    out = {}
-    for cookie in s.split("&"):
-        k, v = cookie.strip().split("=", 1)
-        out[k] = v
-    return out
-```
-
-That allows us to automatically log in users with the login cookie:
-
-``` {.python expected=False}
-def handle_request(method, url, headers, body):
-    resp_headers = {}
-    if method == "POST" and url = "/":
-        # ...
-    elif "cookie" in headers:
-        username = parse_cookies(headers["cookie"]).get("username")
-```
-
-That will log a user in if they have the right cookie. Now we need to
-make some changes to the existing guest book code to handle logins.
-
-We can pass `username` to `show_comments` and use it to either send
-the user the input form or to give them a login link:
-
-``` {.python expected=False}
-def show_comments(username):
-    # ...
-    if username:
-        # ...
+``` {.python file=server}
+def do_login(session, params):
+    username = params.get("username")
+    password = params.get("password")
+    if username in LOGINS and LOGINS[username] == password:
+        session["user"] = username
+        return "200 OK", show_comments(session)
     else:
-        out += "<p><a href=/login>Log in to add to the guest list</a></p>"
-    # ...
+        out = "<!doctype html>"
+        out += "<h1>Invalid password for {}</h1>".format(username)
+        return "401 Unauthorized", out
 ```
 
-When you post to the guest book, we'll also need to know your
-username:
-
-``` {.python expected=False}
-def add_entry(params, username):
-    if 'guest' in params and len(params['guest']) <= 100 and username:
-        ENTRIES.append((params['guest'], username))
-```
-
-We aren't showing the new guest book entry form to users who aren't
-logged in, but we still need to check `username` here, for the same
-reason that we need to check the length of entries on both the client
-and the server side: malicious users could construct their own POST
-requests instead of filling out the form in a browser.
-
-Try it out! You should be able to go to the main guest book page,
-click the link to log in, use one of the username/password pairs
-above, and post entries.^[The login flow slows down debugging. You
-might want to add the empty string as a username/password pair.]
-
-Of course, the code above has a whole slew of insecurities. It's hard
-to cover all of them,[^7] but let's cover three of the most glaring
-ones.
+Try it out in a normal web browser. You should be able to go to the
+main guest book page, click the link to log in, use one of the
+username/password pairs above, and post entries.^[The login flow slows
+down debugging. You might want to add the empty string as a
+username/password pair.] Of course, this login system has a whole slew
+of insecurities.[^7] But the focus of this book is the browser, not
+the server, so once you're sure it's all working, let's switch gears
+and implement cookies inside our own browser.
 
 [^7]: I should be hashing passwords! Using `bcrypt`! We should verify
-    email addresses! Over TLS! We should be comparing passwords in a
-    constant-time fashion!
-
-Changing your login
-===================
-
-Right now, the cookie just stores your username. It's not hard to
-change! Let's go back to our browser and hard-code the cookie value:
-
-``` {.python expected=False}
-self.cookies["username"] = "nameless"
-```
-
-Now if you start up your browser and point it at the main page, you
-should see the entry form, even though you never had to enter a
-login.[^real-too] How absurdly insecure!
-
-[^real-too]: You don't need a custom browser to do this. In a real
-    browser, popping open the developer console and changing
-    `document.cookie` is enough.
-
-The solution to this is to not store the username directly in the
-browser, where it can be changed by the user. Instead, let's store a
-"login token", a random value that is hard to guess, and have the
-server remember which login token is for which username.
-
-This is actually standard practice not just for security reasons but
-also for functional ones. Cookie names and values should be pretty
-short.[^8] So cookies don't usually store *data*; they store
-*references* to data on the server, which can be as big as you want.
-
-[^8]: Cookies are sent back and forth on every request, so long
-    cookies mean a lot of useless traffic. Plus, browsers and servers
-    both limit header lengths, though there isn't a uniform limit.
+    email addresses! Over TLS! We should run the server in a sandbox!
 
 
-Let's add login tokens in our guest book. I'll store the tokens in a
-global variable:
+Implementing cookies
+====================
 
-``` {.python expected=False}
-import random
-TOKENS = {}
-```
+Let's implement cookies. To start with, we need a place to store
+cookies; that database is traditionally called a *cookie jar*[^2]:
 
-Then where we set `Set-Cookie` we'll create a new token and remember
-its username:
-
-``` {.python expected=False}
-def handle_request(method, url, headers, body):
-    # ...
-    token = str(random.random())[2:]
-    TOKENS[token] = username
-    headers["Set-Cookie"] = "token=" + token
-    # ...
-```
-
-Then when we read the `Cookie` header, we'll use the token to retrieve
-the username:
-
-``` {.python expected=False}
-def handle_request(method, url, headers, body):
-    # ...
-    elif "cookie" in headers:
-        username = TOKENS.get(parse_cookies(headers["cookie"]).get("token"))
-    # ...
-```
-
-As long as the tokens are hard to guess,[^9] the only way to get one is
-from the server, and the server will only give you one with a valid
-login.
-
-[^9]: They're roughly-16-digit decimal numbers, so they have 53 bits
-    of randomness, which isn't great--- go for 256. Plus,
-    `random.random` is not a secure random number generator: observing
-    enough tokens, could allow you to predict future values and use
-    those to hijack accounts. That's not one of the security exploits
-    I'll fix in this chapter, but it is real and important.
-
-
-The same-origin policy
-======================
-
-Our browser does not keep our precious cookie safe. Right now, we have a
-single cookie jar in our browser, and every cookie from any website is
-sent to all other websites. This means that if you log in on our guest
-book, and then make a request to the `attack.evil` website, that website
-can see the token in the headers, record it, set its own browser cookie
-to your token, and then post as you on the guest book website. You see,
-cookies are web-site specific, but we're not storing them that way. It
-goes beyond security---if you have two servers that both set the `token`
-cookie, they'd overwrite each other and you'd constantly be getting
-logged out!
-
-<a name="same-origin-policy">
-
-Web browsers use the *same origin policy* to determine which cookies
-are sent where. The rule is: a cookie is only sent in HTTP requests to
-the same origin---where the origin is the scheme, host, and
-port---where it was set. Let's update our cookie policy to do this.
-I'll change the `cookies` field so it stores a map from origins to
-key-value pairs:
-
-``` {.python indent=4}
-def load(self, url, body=None):
-    # ...
-    if "set-cookie" in headers:
-        # ...
-        origin = url_origin(self.history[-1])
-        self.cookies.setdefault(origin, {})[key] = value
-```
-
-Then, in `cookie_string` instead of iterating over all cookies we'll
-do:
-
-``` {.python expected=False}
-def cookie_string(self):
-    cookie_string = ""
-    origin = url_origin(self.history[-1])
-    for key, value in self.cookies.get((host, port), {}).items():
-        # ...
-```
-
-In both functions, `url_origin` just extracts the scheme, host, and
-port for a URL:
+[^2]: Because once you have one silly name it's important to stay
+    on-brand.
 
 ``` {.python}
-def url_origin(url):
-    return "/".join(url.split("/")[:3])
+COOKIE_JAR = {}
 ```
 
-Now it's not quite so easy for a rogue web server to steal our cookies.
-It'd have to be on the same origin, and that can't happen, because
-this origin is already occupied up by *this* server.
+Note that the cookie jar is global, not limited to a particular tab.
+That makes sense: in a browser, if you're logged in to a website and
+you open a second tab, you're logged in on that tab as well.
 
-Right?
+Remember that cookies are site-specific. More specifically, a cookie
+is specific to a given combination of scheme, host, and port, which is
+called an origin; this is called the "same-origin policy". So our
+cookie jar will map origins to cookies.
+
+When the browser visits a page, it needs to send all the cookies it
+knows about. This means adding an extra header to the
+request:[^multi-cookies]
+
+[^multi-cookies]: Actually, a site can store multiple cookies at once,
+    using different key-value pairs. The browser is supposed to
+    separate them with semicolons. I'll leave that for an exercise.
+
+``` {.python}
+def request(url, payload=None):
+    # ...
+    origin = (scheme, host, port)
+    if origin in COOKIE_JAR:
+        body += "Cookie: {}\r\n".format(COOKIE_JAR[origin])
+    # ...
+```
+
+So that handles sending the `Cookie` header. Receiving the
+`Set-Cookie` header, meanwhile, should update the cookie
+jar:[^multiple-set-cookies]
+
+[^multiple-set-cookies]: A server can actually send multiple
+    `Set-Cookie` headers to set multiple cookies in one request. I'm
+    not implementing this here, but a good browser would.
+
+``` {.python}
+def request(url, payload=None):
+    # ...
+    if "set-cookie" in headers:
+        kv = headers["set-cookie"]
+        key, value = kv.split("=", 1)
+        COOKIE_JAR.setdefault(origin, {})[key] = value
+    # ...
+```
+
+This should work: you should now be able to use your toy browser to
+log in to the guest book and post to it. Moreover, you should be able
+to open the guest book in two browsers simultaneously---maybe your toy
+browser and a real browser as well---and log in and post as two
+different users.
+
+Note that `load` calls `request` three times (for the HTML, CSS, and
+JS files). Because we handle cookies inside `request`, this should
+automatically work correctly, with later requests transmitting cookies
+set by previous responses.
+
+------------------------------
+
+::: {.todo}
+Everything below here has not been edited and might not match perfectly.
+:::
 
 Cross-site scripting
 ====================

--- a/book/security.md
+++ b/book/security.md
@@ -332,8 +332,7 @@ def request(url, payload=None):
     # ...
     if "set-cookie" in headers:
         kv = headers["set-cookie"]
-        key, value = kv.split("=", 1)
-        COOKIE_JAR.setdefault(origin, {})[key] = value
+        COOKIE_JAR[origin] = kv
     # ...
 ```
 

--- a/book/security.md
+++ b/book/security.md
@@ -297,10 +297,9 @@ Note that the cookie jar is global, not limited to a particular tab.
 That makes sense: in a browser, if you're logged in to a website and
 you open a second tab, you're logged in on that tab as well.
 
-Remember that cookies are site-specific. More specifically, a cookie
-is specific to a given combination of scheme, host, and port, which is
-called an origin; this is called the "same-origin policy". So our
-cookie jar will map origins to cookies.
+Remember that cookies are site-specific---each cookie is bound to the
+host and port that set it. So our cookie jar will map host/port pairs
+to cookies.
 
 When the browser visits a page, it needs to send all the cookies it
 knows about. This means adding an extra header to the
@@ -313,7 +312,7 @@ request:[^multi-cookies]
 ``` {.python}
 def request(url, payload=None):
     # ...
-    origin = (scheme, host, port)
+    origin = (host, port)
     if origin in COOKIE_JAR:
         body += "Cookie: {}\r\n".format(COOKIE_JAR[origin])
     # ...

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -58,7 +58,7 @@ def request(url, payload=None):
     method = "POST" if payload else "GET"
     body = "{} {} HTTP/1.0\r\n".format(method, path)
     body += "Host: {}\r\n".format(host)
-    origin = (scheme, host, port)
+    origin = (host, port)
     if origin in COOKIE_JAR:
         body += "Cookie: {}\r\n".format(COOKIE_JAR[origin])
     if payload:

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -28,8 +28,10 @@ from lab8 import DocumentLayout
 
 def url_origin(url):
     return "/".join(url.split("/")[:3])
+        
+COOKIE_JAR = {}
 
-def request(url, headers={}, payload=None):
+def request(url, payload=None):
     scheme, url = url.split("://", 1)
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
@@ -56,8 +58,9 @@ def request(url, headers={}, payload=None):
     method = "POST" if payload else "GET"
     body = "{} {} HTTP/1.0\r\n".format(method, path)
     body += "Host: {}\r\n".format(host)
-    for header, value in headers.items():
-        body += "{}: {}\r\n".format(header, value)
+    origin = (scheme, host, port)
+    if origin in COOKIE_JAR:
+        body += "Cookie: {}\r\n".format(COOKIE_JAR[origin])
     if payload:
         content_length = len(payload.encode("utf8"))
         body += "Content-Length: {}\r\n".format(content_length)
@@ -75,6 +78,14 @@ def request(url, headers={}, payload=None):
         if line == "\r\n": break
         header, value = line.split(":", 1)
         headers[header.lower()] = value.strip()
+
+    if "set-cookie" in headers:
+        if ";" in headers["set-cookie"]:
+            kv, params = headers["set-cookie"].split(";", 1)
+        else:
+            kv = headers["set-cookie"]
+            params = {}
+        COOKIE_JAR[origin] = kv
 
     body = response.read()
     s.close()
@@ -138,7 +149,8 @@ class JSContext:
         self.tab.render()
 
     def cookie_string(self):
-        return self.tab.cookie_string()
+        # origin ???
+        raise NotImplemented
 
 
 SCROLL_STEP = 100
@@ -148,34 +160,15 @@ class Tab:
     def __init__(self):
         self.history = []
         self.focus = None
-        self.cookies = {}
 
         with open("browser8.css") as f:
             self.default_style_sheet = CSSParser(f.read()).parse()
-
-    def cookie_string(self):
-        origin = url_origin(self.history[-1])
-        cookie_string = ""
-        if not origin in self.cookies:
-            return cookie_string
-        for key, value in self.cookies[origin].items():
-            cookie_string += "&" + key + "=" + value
-        return cookie_string[1:]
 
     def load(self, url, body=None):
         self.scroll = 0
         self.url = url
         self.history.append(url)
-        req_headers = { "Cookie": self.cookie_string() }        
-        headers, body = request(url, headers=req_headers, payload=body)
-        if "set-cookie" in headers:
-            if ";" in headers["set-cookie"]:
-                kv, params = headers["set-cookie"].split(";", 1)
-            else:
-                kv = headers["set-cookie"]
-            key, value = kv.split("=", 1)
-            origin = url_origin(self.history[-1])
-            self.cookies.setdefault(origin, {})[key] = value
+        headers, body = request(url, payload=body)
 
         self.nodes = HTMLParser(body).parse()
 
@@ -186,8 +179,7 @@ class Tab:
                    and node.tag == "script"
                    and "src" in node.attributes]
         for script in scripts:
-            header, body = request(resolve_url(script, url),
-                headers=req_headers)
+            header, body = request(resolve_url(script, url))
             try:
                 print("Script returned: ", self.js.run(body))
             except dukpy.JSRuntimeError as e:
@@ -202,8 +194,7 @@ class Tab:
                  and node.attributes.get("rel") == "stylesheet"]
         for link in links:
             try:
-                header, body = request(resolve_url(link, url),
-                    headers=req_headers)
+                header, body = request(resolve_url(link, url))
             except:
                 continue
             self.rules.extend(CSSParser(body).parse())

--- a/src/server10.py
+++ b/src/server10.py
@@ -2,7 +2,7 @@ import socket
 import random
 
 def handle_connection(conx):
-    req = conx.makefile("rb")
+    req = conx.makefile("b")
     reqline = req.readline().decode('utf8')
     method, url, version = reqline.split(" ", 2)
     assert method in ["GET", "POST"]

--- a/src/server10.py
+++ b/src/server10.py
@@ -34,6 +34,7 @@ def handle_connection(conx):
         len(body.encode("utf8")))
     if 'cookie' not in headers:
         response += "Set-Cookie: token={}\r\n".format(token)
+    response += "Content-Security-Policy: default-src http://localhost:8000\r\n"
     response += "\r\n" + body
     conx.send(response.encode('utf8'))
     conx.close()
@@ -88,6 +89,7 @@ def show_comments(session):
     out += "<link rel=stylesheet src=/comment.css>"
     out += "<label></label>"
     out += "<script src=/comment.js></script>"
+    out += "<script src=https://example.com/evil.js></script>"
     return out
 
 def login_form(session):

--- a/src/server10.py
+++ b/src/server10.py
@@ -1,5 +1,8 @@
 import socket
+import urllib.parse
 import random
+
+SESSIONS = {}
 
 def handle_connection(conx):
     req = conx.makefile("b")
@@ -18,18 +21,23 @@ def handle_connection(conx):
     else:
         body = None
 
-    status, body, headers = do_request(method, url, headers, body)
+    if "cookie" in headers:
+        token = headers["cookie"][len("token="):]
+    else:
+        token = str(random.random())[2:]
+
+    session = SESSIONS.setdefault(token, {})
+
+    status, body = do_request(session, method, url, headers, body)
     response = "HTTP/1.0 {}\r\n".format(status)
-    for header, value in headers.items():
-        response += "{}: {}\r\n".format(header, value)
-    response += "Content-Length: {}\r\n".format(len(body.encode("utf8")))
+    response += "Content-Length: {}\r\n".format(
+        len(body.encode("utf8")))
+    if 'cookie' not in headers:
+        response += "Set-Cookie: token={}\r\n".format(token)
     response += "\r\n" + body
     conx.send(response.encode('utf8'))
     conx.close()
-
-TOKENS = {}
-NONCES = {}
-
+    
 ENTRIES = [
     ("No names. We are nameless!", "cerealkiller"),
     ("HACK THE PLANET!!!", "crashoverride"),
@@ -37,104 +45,80 @@ ENTRIES = [
 
 LOGINS = { "crashoverride": "0cool", "cerealkiller": "emmanuel" }
 
-def check_login(username, pw):
-    return username in LOGINS and LOGINS[username] == pw
-
-def parse_cookies(s):
-    out = {}
-    if (len(s) == 0):
-        return out
-    for cookie in s.split(";"):
-        k, v = cookie.strip().split("=", 1)
-        out[k] = v
-    return out
-
-def do_request(method, url, headers, body):
-    resp_headers = {}
-   
-    username = ""
-    if method == 'POST' and url == "/":
+def do_request(session, method, url, headers, body):
+    if method == "GET" and url == "/":
+        return "200 OK", show_comments(session)
+    elif method == "GET" and url == "/comment.js":
+        with open("comment9.js") as f:
+            return "200 OK", f.read()
+    elif method == "GET" and url == "/comment.css":
+        with open("comment9.css") as f:
+            return "200 OK", f.read()
+    elif method == "GET" and url == "/login":
+        return "200 OK", login_form(session)
+    elif method == "POST" and url == "/add":
         params = form_decode(body)
-        if check_login(params.get("username"), params.get("password")):
-            username = params["username"]
-            token = str(random.random())[2:]
-            TOKENS[token] = username
-            resp_headers["Set-Cookie"] = "token=" + token
-    elif "cookie" in headers:
-        username = TOKENS.get(parse_cookies(headers["cookie"]).get("token"))
+        return "200 OK", add_entry(session, params)
+    elif method == "POST" and url == "/login":
+        params = form_decode(body)
+        return do_login(session, params)
+    else:
+        return "404 Not Found", not_found(url, method)
 
-    if method == "GET":
-        if url == "/":
-            return "200 OK", show_comments(username), resp_headers
-        elif url == "/login":
-            return "200 OK", login_form(), resp_headers
-        elif url == "/comment.js":
-            with open("comment9.js") as f:
-                return "200 OK", f.read(), resp_headers
-        elif url == "/comment.css":
-            with open("comment9.css") as f:
-                return "200 OK", f.read(), resp_headers
-    elif method == "POST":
-        if url == "/add":
-            params = form_decode(body)
-            return "200 OK", add_entry(params, username), resp_headers
-        else:
-            return "200 OK", show_comments(username), resp_headers
+def form_decode(body):
+    params = {}
+    for field in body.split("&"):
+        name, value = field.split("=", 1)
+        params[name] = urllib.parse.unquote(value)
+    return params
 
-    return "404 Not Found", not_found(url, method), resp_headers
-
-def login_form():
-    body = "<!doctype html>"
-    body += "<form action=/ method=post>"
-    body += "<p>Username: <input name=username></p>"
-    body += "<p>Password: <input name=password type=password></p>"
-    body += "<p><button>Log in</button></p>"
-    body += "</form>"
-    return body
-
-def html_escape(text):
-    return text.replace("&", "&amp;").replace("<", "&lt;")
-
-def show_comments(username):
+def show_comments(session):
     out = "<!doctype html>"
-    if username:
-        nonce = str(random.random())[2:]
-        NONCES[username] = nonce
+    if "user" in session:
         out += "<form action=add method=post>"
-        out +=   "<p><input name=nonce type=hidden value=" + nonce + "></p>"
         out +=   "<p><input name=guest></p>"
         out +=   "<p><button>Sign the book!</button></p>"
         out += "</form>"
     else:
-        out += "<p><a href=/login>Log in to add to the guest list</a></p>"
+        out += "<a href=/login>Sign in to write in the guest book</a>"
 
     for entry, who in ENTRIES:
-        out += "<p>" + html_escape(entry)
-        out += " <i>from " + who + "</i></p>"
+        out += "<p>" + entry + " <i>by " + who + "</i></p>"
+
+    out += "<link rel=stylesheet src=/comment.css>"
+    out += "<label></label>"
     out += "<script src=/comment.js></script>"
     return out
 
-def check_nonce(params, username):
-    if 'nonce' not in params: return False
-    if username not in NONCES: return False
-    return params['nonce'] == NONCES[username]
+def login_form(session):
+    body = "<!doctype html>"
+    body += "<form action=/login method=post>"
+    body += "<p>Username: <input name=username></p>"
+    body += "<p>Password: <input name=password type=password></p>"
+    body += "<p><button>Log in</button></p>"
+    body += "</form>"
+    return body 
+
+def do_login(session, params):
+    username = params.get("username")
+    password = params.get("password")
+    if username in LOGINS and LOGINS[username] == password:
+        session["user"] = username
+        return "200 OK", show_comments(session)
+    else:
+        out = "<!doctype html>"
+        out += "<h1>Invalid password for {}</h1>".format(username)
+        return "401 Unauthorized", out
 
 def not_found(url, method):
     out = "<!doctype html>"
     out += "<h1>{} {} not found!</h1>".format(method, url)
     return out
 
-def add_entry(params, username):
-    if 'guest' in params and len(params["guest"]) <= 100 and username:
-        ENTRIES.append((params['guest'], username))
-    return show_comments(username)
-
-def form_decode(body):
-    params = {}
-    for field in body.split("&"):
-        name, value = field.split("=", 1)
-        params[name] = value.replace("%20", " ")
-    return params
+def add_entry(session, params):
+    if "user" in session and 'guest' in params and len(params['guest']) <= 100:
+        ENTRIES.append((params['guest'], session["user"]))
+    return show_comments(session)
 
 if __name__ == "__main__":
     s = socket.socket(
@@ -145,7 +129,7 @@ if __name__ == "__main__":
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(('', 8000))
     s.listen()
-
+    
     while True:
         conx, addr = s.accept()
         print("Received connection from", addr)

--- a/src/server10.py
+++ b/src/server10.py
@@ -69,7 +69,7 @@ def form_decode(body):
     params = {}
     for field in body.split("&"):
         name, value = field.split("=", 1)
-        params[name] = urllib.parse.unquote(value)
+        params[name] = urllib.parse.unquote_plus(value)
     return params
 
 def show_comments(session):

--- a/src/server8.py
+++ b/src/server8.py
@@ -2,7 +2,7 @@ import socket
 import urllib.parse
 
 def handle_connection(conx):
-    req = conx.makefile("rb")
+    req = conx.makefile("b")
     reqline = req.readline().decode('utf8')
     method, url, version = reqline.split(" ", 2)
     assert method in ["GET", "POST"]

--- a/src/server8.py
+++ b/src/server8.py
@@ -39,7 +39,7 @@ def form_decode(body):
     params = {}
     for field in body.split("&"):
         name, value = field.split("=", 1)
-        params[name] = urllib.parse.unquote(value)
+        params[name] = urllib.parse.unquote_plus(value)
     return params
 
 ENTRIES = [ 'Pavel was here' ]

--- a/src/server9.py
+++ b/src/server9.py
@@ -46,7 +46,7 @@ def form_decode(body):
     params = {}
     for field in body.split("&"):
         name, value = field.split("=", 1)
-        params[name] = urllib.parse.unquote(value)
+        params[name] = urllib.parse.unquote_plus(value)
     return params
 
 ENTRIES = [ 'Pavel was here' ]

--- a/src/server9.py
+++ b/src/server9.py
@@ -2,7 +2,7 @@ import socket
 import urllib.parse
 
 def handle_connection(conx):
-    req = conx.makefile("rb")
+    req = conx.makefile("b")
     reqline = req.readline().decode('utf8')
     method, url, version = reqline.split(" ", 2)
     assert method in ["GET", "POST"]


### PR DESCRIPTION
This PR rewrites the XSS portion of Chapter 10 to focus on `Content-Security-Policy` rather than escaping (though escaping is still mentioned!) It depends on #223, but I think the text of the XSS section can be reviewed separately. The CSP implementation is, luckily, pretty slim, because I focus only on the `default-src` policy and only full url sources.