### PR TITLE
Fixes and optimizations to compiler

### DIFF
--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -282,14 +282,22 @@ deduplicate the code a bit:
     import { request } from "./lab1.js";
     >>> assert "request" in LAB_IMPORT_FNS
     >>> Test.stmt("from lab2 import HSTEP")
-    import { HSTEP } from "./lab2.js";
+    import { constants as lab2_constants } from "./lab2.js";
+    constants.HSTEP = lab2_constants.HSTEP;
     >>> assert "HSTEP" in LAB_IMPORT_CONSTANTS
     >>> Test.stmt("from lab4 import Element")
     import { Element } from "./lab4.js";
-    >>> assert "HSTEP" in LAB_IMPORT_CLASSES
+    >>> assert "Element" in LAB_IMPORT_CLASSES
     >>> Test.stmt("from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP")
-    import { WIDTH, HEIGHT, HSTEP, VSTEP } from "./lab2.js";
+    import { constants as lab2_constants } from "./lab2.js";
+    constants.WIDTH = lab2_constants.WIDTH;
+    constants.HEIGHT = lab2_constants.HEIGHT;
+    constants.HSTEP = lab2_constants.HSTEP;
+    constants.VSTEP = lab2_constants.VSTEP;
     >>> assert "WIDTH" in LAB_IMPORT_CONSTANTS
+    
+Note that `from ... import` statements for constants are complex, due
+to the use of a global collector object for constants.
 
 Functions become function definitions:
 

--- a/src/lab6.hints
+++ b/src/lab6.hints
@@ -2,6 +2,5 @@
 {"code": "'://' in url", "type": "str"},
 {"code": "self.s[self.i] in chars", "type": "list"},
 {"code": "'style' in node.attributes", "type": "dict"},
-{"code": "child.tag in BLOCK_ELEMENTS", "type": "list"},
 {"code": "'href' in node.attributes", "type": "dict"}
 ]

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -147,9 +147,8 @@ class DescendantSelector:
         return False
 
     def __repr__(self):
-        return ("DescendantSelector(ancestor={}, " +
-            "descendant={}, priority={}").format(
-            self.ancestor, self.descendant, self.priority)
+        return ("DescendantSelector(ancestor={}, descendant={}, priority={}") \
+            .format(self.ancestor, self.descendant, self.priority)
 
 INHERITED_PROPERTIES = {
     "font-size": "16px",

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -13,8 +13,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
-from lab6 import DocumentLayout, BlockLayout, InlineLayout, DrawText
-from lab6 import CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
 
 class LineLayout:
     def __init__(self, node, parent, previous):

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -223,6 +223,8 @@ static tkinter(options) {
             this.style = params.style ?? "normal";
             this.string = (this.style == "roman" ? "normal" : this.style) + 
                 " " + this.weight + " " + this.size * rt_constants.ZOOM + "px serif";
+
+            this.$metrics = null;
         }
 
         measure(text) {
@@ -232,28 +234,30 @@ static tkinter(options) {
         }
 
         metrics(field) {
-            let ctx = rt_constants.TKELEMENT.getContext('2d');
-            ctx.textBaseline = "alphabetic";
-            ctx.font = this.string;
-            let m = ctx.measureText("Hxy");
-            let asc, desc;
+            if (!this.$metrics) {
+                let ctx = rt_constants.TKELEMENT.getContext('2d');
+                ctx.textBaseline = "alphabetic";
+                ctx.font = this.string;
+                let m = ctx.measureText("Hxy");
+                let asc, desc;
 
-            // Only Safari provides emHeight properties as of 2021-04
-            // We fake them in the other browsers by guessing that emHeight = font.size
-            // This is not quite right but is close enough for many fonts...
-            if (m.emHeightAscent && m.emHeightDescent) {
-                asc = ctx.measureText("Hxy").emHeightAscent / rt_constants.ZOOM;
-                desc = ctx.measureText("Hxy").emHeightDescent / rt_constants.ZOOM;
-            } else {
-                asc = ctx.measureText("Hxy").actualBoundingBoxAscent / rt_constants.ZOOM;
-                desc = ctx.measureText("Hxy").actualBoundingBoxDescent / rt_constants.ZOOM;
-                let gap = this.size - (asc + desc)
-                asc += gap / 2;
-                desc += gap / 2;
+                // Only Safari provides emHeight properties as of 2021-04
+                // We fake them in the other browsers by guessing that emHeight = font.size
+                // This is not quite right but is close enough for many fonts...
+                if (m.emHeightAscent && m.emHeightDescent) {
+                    asc = ctx.measureText("Hxy").emHeightAscent / rt_constants.ZOOM;
+                    desc = ctx.measureText("Hxy").emHeightDescent / rt_constants.ZOOM;
+                } else {
+                    asc = ctx.measureText("Hxy").actualBoundingBoxAscent / rt_constants.ZOOM;
+                    desc = ctx.measureText("Hxy").actualBoundingBoxDescent / rt_constants.ZOOM;
+                    let gap = this.size - (asc + desc)
+                    asc += gap / 2;
+                    desc += gap / 2;
+                }
+                this.$metrics = { ascent: asc, descent: desc, linespace: asc + desc, fixed: 0 };
             }
-            let obj = { ascent: asc, descent: desc, linespace: asc + desc, fixed: 0 };
-            if (field) return obj[field]
-            else return obj;
+            if (field) return this.$metrics[field]
+            else return this.$metrics;
         }
     }
 


### PR DESCRIPTION
This PR makes the compiler work even if you import constants. This had been broken.

It also commits a major optimization for Font.metrics, at least in Chrome and likely in other browsers.