### PR TITLE
Catch same-origin-based errors from the widget, and explain them to the user

### DIFF
--- a/src/lab7.py
+++ b/src/lab7.py
@@ -250,10 +250,10 @@ class Tab:
             self.default_style_sheet = CSSParser(f.read()).parse()
 
     def load(self, url):
+        headers, body = request(url)
         self.scroll = 0
         self.url = url
         self.history.append(url)
-        headers, body = request(url)
         self.nodes = HTMLParser(body).parse()
 
         rules = self.default_style_sheet.copy()


### PR DESCRIPTION
Right now, when users of the widget-ified browser can click on a link to "twitter.com/browserbook" and the browser mysteriously fails to do anything. This PR changes it so that an `alert()` is raised to the user explaining the issue.

One problem is that the browser does not necessarily land in a good state if the `request` function fails, because if that happens in Python the whole program crashes, while in the widget we want to ignore the error and continue. This is a tough problem in general, but for our lab7 browser it seems to disappear if we make the `request` call in `Tab.load` before we change any tab state. Probably a similar change would work for other chapters—I believe ch10 already requires it.