### PR TITLE
Fix dark mode

### DIFF
--- a/book/chrome.md
+++ b/book/chrome.md
@@ -653,10 +653,10 @@ then draw the tab name:
 ``` {.python}
 for i, tab in enumerate(self.tabs):
     # ...
-    self.canvas.create_line(x1, 0, x1, 40)
-    self.canvas.create_line(x2, 0, x2, 40)
-    self.canvas.create_text(
-        x1 + 10, 10, text=name, font=tabfont, anchor="nw")
+    self.canvas.create_line(x1, 0, x1, 40, fill="black")
+    self.canvas.create_line(x2, 0, x2, 40, fill="black")
+    self.canvas.create_text(x1 + 10, 10, anchor="nw", text=name,
+        font=tabfont, fill="black")
 ```
 
 Finally, to identify which tab is the active tab, we've got to make
@@ -666,8 +666,8 @@ that file folder shape with the current tab sticking up:
 for i, tab in enumerate(self.tabs):
     # ...
     if i == self.active_tab:
-        self.canvas.create_line(0, 40, x1, 40)
-        self.canvas.create_line(x2, 40, WIDTH, 40)
+        self.canvas.create_line(0, 40, x1, 40, fill="black")
+        self.canvas.create_line(x2, 40, WIDTH, 40, fill="black")
 ```
 
 The whole point of tab support is to have more than one tab around,
@@ -679,9 +679,10 @@ class Browser:
     def draw(self):
         # ...
         buttonfont = get_font(30, "normal", "roman")
-        self.canvas.create_rectangle(10, 10, 30, 30, width=1)
-        self.canvas.create_text(
-            11, 0, font=buttonfont, text="+", anchor="nw")
+        self.canvas.create_rectangle(10, 10, 30, 30,
+            outline="black", width=1)
+        self.canvas.create_text(11, 0, anchor="nw", text="+",
+            font=buttonfont, fill="black")
 ```
 
 If you run this code, you'll see a small problem: the page contents
@@ -715,8 +716,8 @@ them:
 class Browser:
     def draw(self):
         self.tabs[self.active_tab].draw(self.canvas)
-        self.canvas.create_rectangle(
-            0, 0, WIDTH, CHROME_PX, fill="white")
+        self.canvas.create_rectangle(0, 0, WIDTH, CHROME_PX,
+            fill="white", outline="black")
         # ...
 ```
 
@@ -804,10 +805,11 @@ address bar that shows the current URL would help a lot.
 class Browser:
     def draw(self):
         # ...
-        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90, width=1)
+        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90,
+            outline="black", width=1)
         url = self.tabs[self.active_tab].url
-        self.canvas.create_text(
-            55, 55, anchor='nw', text=url, font=buttonfont)
+        self.canvas.create_text(55, 55, anchor='nw', text=url,
+            font=buttonfont, fill="black")
 ```
 
 To keep up appearances, the address bar needs a "back" button nearby.
@@ -817,7 +819,8 @@ I'll start by drawing the back button itself:
 class Browser:
     def draw(self):
         # ...
-        self.canvas.create_rectangle(10, 50, 35, 90, width=1)
+        self.canvas.create_rectangle(10, 50, 35, 90,
+            outline="black", width=1)
         self.canvas.create_polygon(
             15, 70, 30, 55, 30, 85, fill='black')
 ```
@@ -959,11 +962,11 @@ class Browser:
         if self.focus == "address bar":
             self.canvas.create_text(
                 55, 55, anchor='nw', text=self.address_bar,
-                font=buttonfont)
+                font=buttonfont, fill="black")
         else:
             url = self.tabs[self.active_tab].url
-            self.canvas.create_text(
-                55, 55, anchor='nw', text=url, font=buttonfont)
+            self.canvas.create_text(55, 55, anchor='nw', text=url,
+                font=buttonfont, fill="black")
 ```
 
 When the user is typing in the address bar, let's also draw a cursor.
@@ -974,7 +977,7 @@ cursor) makes the software easier to use:
 if self.focus == "address bar":
     # ...
     w = buttonfont.measure(self.address_bar)
-    self.canvas.create_line(55 + w, 55, 55 + w, 85)
+    self.canvas.create_line(55 + w, 55, 55 + w, 85, fill="black")
 ```
 
 Next, when the address bar is focused, we need to support typing in a

--- a/book/styles.md
+++ b/book/styles.md
@@ -943,12 +943,31 @@ class DrawText:
 Phew! That was a lot of coordinated changes, so test everything and
 make sure it works. You should now see links on this page appear in
 blue---and you might also notice that the rest of the text has become
-slightly lighter.[^book-css]
+slightly lighter.[^book-css] Also, now that we're explicitly setting
+the text color, we should explicitly set the background color as
+well:[^dark-mode]
 
 [^book-css]: The book's main body text [is colored](book.css) `#333`,
     or roughly 97% black after [gamma correction][gamma-correct].
     
 [gamma-correct]: https://en.wikipedia.org/wiki/SRGB#From_sRGB_to_CIE_XYZ
+
+[^dark-mode]: My Linux machine sets the default background color to a
+    light gray, while my macOS laptop has a "Dark Mode" where the
+    default background color becomes a dark gray. Setting the
+    background color explicitly avoids the browser looking strange in
+    these situations.
+
+``` {.python}
+class Browser:
+    def __init__(self):
+        # ...
+        self.canvas = tkinter.Canvas(
+            # ...
+            bg="white",
+        )
+        # ...
+```
 
 These changes obsolete all the code in `InlineLayout` that handles
 specific tags, like the `style`, `weight`, and `size` properties and

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -10,6 +10,7 @@ import tkinter
 import tkinter.font
 import urllib.parse
 import dukpy
+from lab3 import get_font
 from lab4 import print_tree
 from lab4 import Element
 from lab4 import Text

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -388,42 +388,44 @@ class Browser:
     def draw(self):
         self.canvas.delete("all")
         self.tabs[self.active_tab].draw(self.canvas)
-        self.canvas.create_rectangle(
-            0, 0, WIDTH, CHROME_PX, fill="white")
+        self.canvas.create_rectangle(0, 0, WIDTH, CHROME_PX,
+            fill="white", outline="black")
 
-        tabfont = tkinter.font.Font(size=20)
+        tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
-            self.canvas.create_line(x1, 0, x1, 40)
-            self.canvas.create_line(x2, 0, x2, 40)
-            self.canvas.create_text(
-                x1 + 10, 10, text=name, font=tabfont, anchor="nw")
+            self.canvas.create_line(x1, 0, x1, 40, fill="black")
+            self.canvas.create_line(x2, 0, x2, 40, fill="black")
+            self.canvas.create_text(x1 + 10, 10, anchor="nw", text=name,
+                font=tabfont, fill="black")
             if i == self.active_tab:
-                self.canvas.create_line(0, 40, x1, 40)
-                self.canvas.create_line(x2, 40, WIDTH, 40)
+                self.canvas.create_line(0, 40, x1, 40, fill="black")
+                self.canvas.create_line(x2, 40, WIDTH, 40, fill="black")
 
-        buttonfont = tkinter.font.Font(size=30)
-        self.canvas.create_rectangle(10, 10, 30, 30, width=1)
-        self.canvas.create_text(
-            11, 0, font=buttonfont, text="+", anchor="nw")
+        buttonfont = get_font(30, "normal", "roman")
+        self.canvas.create_rectangle(10, 10, 30, 30,
+            outline="black", width=1)
+        self.canvas.create_text(11, 0, anchor="nw", text="+",
+            font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90, width=1)
+        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90,
+            outline="black", width=1)
         if self.focus == "address bar":
             self.canvas.create_text(
                 55, 55, anchor='nw', text=self.address_bar,
-                font=buttonfont)
+                font=buttonfont, fill="black")
             w = buttonfont.measure(self.address_bar)
-            self.canvas.create_line(55 + w, 55, 55 + w, 85)
+            self.canvas.create_line(55 + w, 55, 55 + w, 85, fill="black")
         else:
             url = self.tabs[self.active_tab].url
-            self.canvas.create_text(
-                55, 55, anchor='nw', text=url, font=buttonfont)
+            self.canvas.create_text(55, 55, anchor='nw', text=url,
+                font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(10, 50, 35, 90, width=1)
+        self.canvas.create_rectangle(10, 50, 35, 90,
+            outline="black", width=1)
         self.canvas.create_polygon(
             15, 70, 30, 55, 30, 85, fill='black')
-
 
 if __name__ == "__main__":
     import sys

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -326,7 +326,8 @@ class Browser:
         self.canvas = tkinter.Canvas(
             self.window,
             width=WIDTH,
-            height=HEIGHT
+            height=HEIGHT,
+            bg="white",
         )
         self.canvas.pack()
 

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -373,7 +373,8 @@ class Browser:
         self.canvas = tkinter.Canvas(
             self.window,
             width=WIDTH,
-            height=HEIGHT
+            height=HEIGHT,
+            bg="white",
         )
         self.canvas.pack()
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -316,7 +316,8 @@ class Browser:
         self.canvas = tkinter.Canvas(
             self.window,
             width=WIDTH,
-            height=HEIGHT
+            height=HEIGHT,
+            bg="white",
         )
         self.canvas.pack()
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -374,39 +374,42 @@ class Browser:
     def draw(self):
         self.canvas.delete("all")
         self.tabs[self.active_tab].draw(self.canvas)
-        self.canvas.create_rectangle(
-            0, 0, WIDTH, CHROME_PX, fill="white")
+        self.canvas.create_rectangle(0, 0, WIDTH, CHROME_PX,
+            fill="white", outline="black")
 
         tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
-            self.canvas.create_line(x1, 0, x1, 40)
-            self.canvas.create_line(x2, 0, x2, 40)
-            self.canvas.create_text(
-                x1 + 10, 10, text=name, font=tabfont, anchor="nw")
+            self.canvas.create_line(x1, 0, x1, 40, fill="black")
+            self.canvas.create_line(x2, 0, x2, 40, fill="black")
+            self.canvas.create_text(x1 + 10, 10, anchor="nw", text=name,
+                font=tabfont, fill="black")
             if i == self.active_tab:
-                self.canvas.create_line(0, 40, x1, 40)
-                self.canvas.create_line(x2, 40, WIDTH, 40)
+                self.canvas.create_line(0, 40, x1, 40, fill="black")
+                self.canvas.create_line(x2, 40, WIDTH, 40, fill="black")
 
         buttonfont = get_font(30, "normal", "roman")
-        self.canvas.create_rectangle(10, 10, 30, 30, width=1)
-        self.canvas.create_text(
-            11, 0, font=buttonfont, text="+", anchor="nw")
+        self.canvas.create_rectangle(10, 10, 30, 30,
+            outline="black", width=1)
+        self.canvas.create_text(11, 0, anchor="nw", text="+",
+            font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90, width=1)
+        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90,
+            outline="black", width=1)
         if self.focus == "address bar":
             self.canvas.create_text(
                 55, 55, anchor='nw', text=self.address_bar,
-                font=buttonfont)
+                font=buttonfont, fill="black")
             w = buttonfont.measure(self.address_bar)
-            self.canvas.create_line(55 + w, 55, 55 + w, 85)
+            self.canvas.create_line(55 + w, 55, 55 + w, 85, fill="black")
         else:
             url = self.tabs[self.active_tab].url
-            self.canvas.create_text(
-                55, 55, anchor='nw', text=url, font=buttonfont)
+            self.canvas.create_text(55, 55, anchor='nw', text=url,
+                font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(10, 50, 35, 90, width=1)
+        self.canvas.create_rectangle(10, 50, 35, 90,
+            outline="black", width=1)
         self.canvas.create_polygon(
             15, 70, 30, 55, 30, 85, fill='black')
 

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -396,7 +396,8 @@ class Browser:
         self.canvas = tkinter.Canvas(
             self.window,
             width=WIDTH,
-            height=HEIGHT
+            height=HEIGHT,
+            bg="white",
         )
         self.canvas.pack()
 

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -458,39 +458,42 @@ class Browser:
     def draw(self):
         self.canvas.delete("all")
         self.tabs[self.active_tab].draw(self.canvas)
-        self.canvas.create_rectangle(
-            0, 0, WIDTH, CHROME_PX, fill="white")
+        self.canvas.create_rectangle(0, 0, WIDTH, CHROME_PX,
+            fill="white", outline="black")
 
         tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
-            self.canvas.create_line(x1, 0, x1, 40)
-            self.canvas.create_line(x2, 0, x2, 40)
-            self.canvas.create_text(
-                x1 + 10, 10, text=name, font=tabfont, anchor="nw")
+            self.canvas.create_line(x1, 0, x1, 40, fill="black")
+            self.canvas.create_line(x2, 0, x2, 40, fill="black")
+            self.canvas.create_text(x1 + 10, 10, anchor="nw", text=name,
+                font=tabfont, fill="black")
             if i == self.active_tab:
-                self.canvas.create_line(0, 40, x1, 40)
-                self.canvas.create_line(x2, 40, WIDTH, 40)
+                self.canvas.create_line(0, 40, x1, 40, fill="black")
+                self.canvas.create_line(x2, 40, WIDTH, 40, fill="black")
 
         buttonfont = get_font(30, "normal", "roman")
-        self.canvas.create_rectangle(10, 10, 30, 30, width=1)
-        self.canvas.create_text(
-            11, 0, font=buttonfont, text="+", anchor="nw")
+        self.canvas.create_rectangle(10, 10, 30, 30,
+            outline="black", width=1)
+        self.canvas.create_text(11, 0, anchor="nw", text="+",
+            font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90, width=1)
+        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90,
+            outline="black", width=1)
         if self.focus == "address bar":
             self.canvas.create_text(
                 55, 55, anchor='nw', text=self.address_bar,
-                font=buttonfont)
+                font=buttonfont, fill="black")
             w = buttonfont.measure(self.address_bar)
-            self.canvas.create_line(55 + w, 55, 55 + w, 85)
+            self.canvas.create_line(55 + w, 55, 55 + w, 85, fill="black")
         else:
             url = self.tabs[self.active_tab].url
-            self.canvas.create_text(
-                55, 55, anchor='nw', text=url, font=buttonfont)
+            self.canvas.create_text(55, 55, anchor='nw', text=url,
+                font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(10, 50, 35, 90, width=1)
+        self.canvas.create_rectangle(10, 50, 35, 90,
+            outline="black", width=1)
         self.canvas.create_polygon(
             15, 70, 30, 55, 30, 85, fill='black')
 

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -210,7 +210,8 @@ class Browser:
         self.canvas = tkinter.Canvas(
             self.window,
             width=WIDTH,
-            height=HEIGHT
+            height=HEIGHT,
+            bg="white",
         )
         self.canvas.pack()
 

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -271,42 +271,44 @@ class Browser:
     def draw(self):
         self.canvas.delete("all")
         self.tabs[self.active_tab].draw(self.canvas)
-        self.canvas.create_rectangle(
-            0, 0, WIDTH, CHROME_PX, fill="white")
+        self.canvas.create_rectangle(0, 0, WIDTH, CHROME_PX,
+            fill="white", outline="black")
 
         tabfont = get_font(20, "normal", "roman")
         for i, tab in enumerate(self.tabs):
             name = "Tab {}".format(i)
             x1, x2 = 40 + 80 * i, 120 + 80 * i
-            self.canvas.create_line(x1, 0, x1, 40)
-            self.canvas.create_line(x2, 0, x2, 40)
-            self.canvas.create_text(
-                x1 + 10, 10, text=name, font=tabfont, anchor="nw")
+            self.canvas.create_line(x1, 0, x1, 40, fill="black")
+            self.canvas.create_line(x2, 0, x2, 40, fill="black")
+            self.canvas.create_text(x1 + 10, 10, anchor="nw", text=name,
+                font=tabfont, fill="black")
             if i == self.active_tab:
-                self.canvas.create_line(0, 40, x1, 40)
-                self.canvas.create_line(x2, 40, WIDTH, 40)
+                self.canvas.create_line(0, 40, x1, 40, fill="black")
+                self.canvas.create_line(x2, 40, WIDTH, 40, fill="black")
 
         buttonfont = get_font(30, "normal", "roman")
-        self.canvas.create_rectangle(10, 10, 30, 30, width=1)
-        self.canvas.create_text(
-            11, 0, font=buttonfont, text="+", anchor="nw")
+        self.canvas.create_rectangle(10, 10, 30, 30,
+            outline="black", width=1)
+        self.canvas.create_text(11, 0, anchor="nw", text="+",
+            font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90, width=1)
+        self.canvas.create_rectangle(40, 50, WIDTH - 10, 90,
+            outline="black", width=1)
         if self.focus == "address bar":
             self.canvas.create_text(
                 55, 55, anchor='nw', text=self.address_bar,
-                font=buttonfont)
+                font=buttonfont, fill="black")
             w = buttonfont.measure(self.address_bar)
-            self.canvas.create_line(55 + w, 55, 55 + w, 85)
+            self.canvas.create_line(55 + w, 55, 55 + w, 85, fill="black")
         else:
             url = self.tabs[self.active_tab].url
-            self.canvas.create_text(
-                55, 55, anchor='nw', text=url, font=buttonfont)
+            self.canvas.create_text(55, 55, anchor='nw', text=url,
+                font=buttonfont, fill="black")
 
-        self.canvas.create_rectangle(10, 50, 35, 90, width=1)
+        self.canvas.create_rectangle(10, 50, 35, 90,
+            outline="black", width=1)
         self.canvas.create_polygon(
             15, 70, 30, 55, 30, 85, fill='black')
-
 
 if __name__ == "__main__":
     import sys

--- a/src/test.py
+++ b/src/test.py
@@ -97,16 +97,16 @@ class SilentCanvas:
     def __init__(self, *args, **kwargs):
         pass
 
-    def create_text(self, x, y, text, font=None, anchor=None, fill=None):
+    def create_text(self, x, y, text, **kwargs):
         pass
 
-    def create_rectangle(self, x1, y1, x2, y2, width=None, fill=None):
+    def create_rectangle(self, x1, y1, x2, y2, **kwargs):
         pass
 
-    def create_line(self, x1, y1, x2, y2):
+    def create_line(self, x1, y1, x2, y2, **kwargs):
         pass
 
-    def create_line(self, x1, y1, x2, y2):
+    def create_line(self, x1, y1, x2, y2, **kwargs):
         pass
 
     def create_polygon(self, *args, **kwargs):
@@ -124,7 +124,7 @@ class MockCanvas:
     def __init__(self, *args, **kwargs):
         pass
 
-    def create_text(self, x, y, text, font=None, anchor=None):
+    def create_text(self, x, y, text, font=None, anchor=None, **kwargs):
         if font or anchor:
             print("create_text: x={} y={} text={} font={} anchor={}".format(
                 x, y, text, font, anchor))


### PR DESCRIPTION
Right now our browser does not work with macOS's Dark Mode, because we inconsistently sometimes rely on Tk's defaults (which change with OS theme) and sometimes explicitly assign colors (which don't). Luckily we don't need to write much text to explain this: we just need to fix the background color as white in Chapter 6 (when we add explicit colors for text) and then explicitly write out outline/background colors in Chapter 7 (when we draw the browser chrome). The browser then looks the same no matter what the OS theme is.