### PR TITLE
Add linting and tests for example code

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1021,12 +1021,11 @@ that page refers to premultiplied alpha colors. Skia does not
 use premultiplied color representations.
 
 
-``` {.python.example}
-# Composites |source_color| into |backdrop_color| with simple
-# alpha compositing.
-# Each of the inputs are skia.Color4f objects.
-def composite(source_color, backdrop_color, mode):
-    if blend_mode == "source-over":
+``` {.python file=examples}
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
+def composite(source_color, backdrop_color, compositing_mode):
+    if compositing_mode == "source-over":
         (source_r, source_g, source_b, source_a) = \
             tuple(source_color)
         (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
@@ -1097,6 +1096,8 @@ def restore(source_surface, backdrop_surface,
 and blend is implemented like this:
 
 ``` {.python file=examples}
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def blend(source_color, backdrop_color, blend_mode):
     (source_r, source_g, source_b, source_a) = tuple(source_color)
     (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
@@ -1120,15 +1121,15 @@ and "difference", which subtracts the darker color from the ligher one. The
 default is "normal", which means to ignore the backdrop color.
 
 ``` {.python file=examples}
-# Note: this code assumes a floating-point color channel value.
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def apply_blend(source_color_channel,
                 backdrop_color_channel, blend_mode):
     if blend_mode == "multiply":
         return source_color_channel * backdrop_color_channel
     elif blend_mode == "difference":
         return abs(backdrop_color_channel - source_color_channel)
-    else:
-        # Assume "normal" blend mode.
+    elif blend_mode == "normal":
         return source_color_channel
 ```
 
@@ -1284,6 +1285,8 @@ thing we want to clip, so destination-in fits perfectly.
 Here is `composite` with destination-in compositing added:
 
 ``` {.python file=examples}
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def composite(source_color, backdrop_color, compositing_mode):
     # ...
     elif compositing_mode == "destination-in":
@@ -1295,8 +1298,6 @@ def composite(source_color, backdrop_color, compositing_mode):
             backdrop_a * source_a * backdrop_g,
             backdrop_a * source_a * backdrop_b,
             backdrop_a * source_a)
-    else:
-
 ```
 
 Now let's implement `CircleMask`  in terms of destination-in compositing. It

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1031,9 +1031,12 @@ def composite(source_color, backdrop_color, compositing_mode):
         (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
             tuple(backdrop_color)
         return skia.Color4f(
-            backdrop_r * (1-source_a) * backdrop_a + source_r * source_a,
-            backdrop_g * (1-source_a) * backdrop_a + source_g * source_a,
-            backdrop_b * (1-source_a) * backdrop_a + source_b * source_a,
+            backdrop_r * (1-source_a) * backdrop_a + \
+                source_r * source_a,
+            backdrop_g * (1-source_a) * backdrop_a + \
+                source_g * source_a,
+            backdrop_b * (1-source_a) * backdrop_a + \
+                source_b * source_a,
             1 - (1 - source_a) * (1 - backdrop_a))
 ```
 
@@ -1051,6 +1054,8 @@ a `getPixel` method that returns a `skia.Color4f` and a `setPixel` one that
 sets a pixel color):[^real-life-reading-pixels]
 
 ``` {.python.example}
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def restore(source_surface, backdrop_surface, width, height, opacity):
     for x in range(0, width):
         for y in range(0, height):
@@ -1079,8 +1084,9 @@ Python code for `restore` to incorporate blending looks like this:
 [^vs-blending-2]: Again, see [here](#compositing-blending) for compositing vs
 blending.
 
-
 ``` {.python.example}
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def restore(source_surface, backdrop_surface,
             width, height, opacity, blend_mode):
     # ...

--- a/config.json
+++ b/config.json
@@ -17,7 +17,7 @@
         "scripts.md": { "disabled": false, "lab": "lab9.py", "server": "server9.py", "runtime": "runtime9.js" },
         "security.md": { "disabled": false, "lab": "lab10.py", "server": "server10.py", "runtime": "runtime10.js" },
 
-        "visual-effects.md": { "disabled": true, "lab": "lab11.py" },
+        "visual-effects.md": { "disabled": true, "lab": "lab11.py", "examples": "examples11.py" },
         "scheduling-and-threading.md": { "disabled": true, "lab": "lab12.py" },
         "reflow.md": { "disabled": true, "lab": "lab13.py" },
 

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -166,6 +166,7 @@ if __name__ == "__main__":
             for chapter, metadata in data["chapters"].items():
                 failure += test_entry(chapter, metadata, "lab", "python", None)
                 failure += test_entry(chapter, metadata, "server", "python", "server")
+                failure += test_entry(chapter, metadata, "examples", "python", "examples")
                 failure += test_entry(chapter, metadata, "stylesheet", "css", None)
                 failure += test_entry(chapter, metadata, "runtime", "javascript", None)
     else:

--- a/src/examples11.py
+++ b/src/examples11.py
@@ -1,5 +1,7 @@
 import skia
 
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def composite(source_color, backdrop_color, compositing_mode):
     if compositing_mode == "source-over":
         (source_r, source_g, source_b, source_a) = \
@@ -21,17 +23,19 @@ def composite(source_color, backdrop_color, compositing_mode):
             backdrop_a * source_a * backdrop_b,
             backdrop_a * source_a)
 
-# Note: this code assumes a floating-point color channel value.
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def apply_blend(source_color_channel,
                 backdrop_color_channel, blend_mode):
     if blend_mode == "multiply":
         return source_color_channel * backdrop_color_channel
     elif blend_mode == "difference":
         return abs(backdrop_color_channel - source_color_channel)
-    else:
-        # Assume "normal" blend mode.
+    elif blend_mode == "normal":
         return source_color_channel
 
+# Note: this is sample code to explain the concept, it is not part
+# of the actual browser.
 def blend(source_color, backdrop_color, blend_mode):
     (source_r, source_g, source_b, source_a) = tuple(source_color)
     (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \

--- a/src/examples11.py
+++ b/src/examples11.py
@@ -1,0 +1,49 @@
+import skia
+
+def composite(source_color, backdrop_color, compositing_mode):
+    if compositing_mode == "source-over":
+        (source_r, source_g, source_b, source_a) = \
+        tuple(source_color)
+        (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
+            tuple(backdrop_color)
+        return skia.Color4f(
+            backdrop_r * (1-source_a) * backdrop_a + source_r * source_a,
+            backdrop_g * (1-source_a) * backdrop_a + source_g * source_a,
+            backdrop_b * (1-source_a) * backdrop_a + source_b * source_a,
+            1 - (1 - source_a) * (1 - backdrop_a))
+    elif compositing_mode == "destination-in":
+        (source_r, source_g, source_b, source_a) = tuple(source_color)
+        (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
+             tuple(backdrop_color)
+        return skia.Color4f(
+            backdrop_a * source_a * backdrop_r,
+            backdrop_a * source_a * backdrop_g,
+            backdrop_a * source_a * backdrop_b,
+            backdrop_a * source_a)
+
+# Note: this code assumes a floating-point color channel value.
+def apply_blend(source_color_channel,
+                backdrop_color_channel, blend_mode):
+    if blend_mode == "multiply":
+        return source_color_channel * backdrop_color_channel
+    elif blend_mode == "difference":
+        return abs(backdrop_color_channel - source_color_channel)
+    else:
+        # Assume "normal" blend mode.
+        return source_color_channel
+
+def blend(source_color, backdrop_color, blend_mode):
+    (source_r, source_g, source_b, source_a) = tuple(source_color)
+    (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
+        tuple(backdrop_color)
+    return skia.Color4f(
+        (1 - backdrop_a) * source_r +
+            backdrop_a * apply_blend(
+                source_r, backdrop_r, blend_mode),
+        (1 - backdrop_a) * source_g +
+            backdrop_a * apply_blend(
+                source_g, backdrop_g, blend_mode),
+        (1 - backdrop_a) * source_b +
+            backdrop_a * apply_blend(
+                source_b, backdrop_b, blend_mode),
+        source_a)

--- a/src/examples11.py
+++ b/src/examples11.py
@@ -9,9 +9,12 @@ def composite(source_color, backdrop_color, compositing_mode):
         (backdrop_r, backdrop_g, backdrop_b, backdrop_a) = \
             tuple(backdrop_color)
         return skia.Color4f(
-            backdrop_r * (1-source_a) * backdrop_a + source_r * source_a,
-            backdrop_g * (1-source_a) * backdrop_a + source_g * source_a,
-            backdrop_b * (1-source_a) * backdrop_a + source_b * source_a,
+            backdrop_r * (1-source_a) * backdrop_a + \
+                source_r * source_a,
+            backdrop_g * (1-source_a) * backdrop_a + \
+                source_g * source_a,
+            backdrop_b * (1-source_a) * backdrop_a + \
+                source_b * source_a,
             1 - (1 - source_a) * (1 - backdrop_a))
     elif compositing_mode == "destination-in":
         (source_r, source_g, source_b, source_a) = tuple(source_color)

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -191,7 +191,7 @@ the screen.
     drawString(text=Rotate, x=13.0, y=136.10546875, color=ff000000)
     restore()
 
-Now let's test the example compositing and blend mode functions
+Now let's test the example compositing and blend mode functions.
 
     >>> import examples11
     >>> import skia
@@ -211,7 +211,7 @@ And the other way around yields red.
     >>> blue_semitransparent = skia.Color4f(0.0, 0.0, 1.0, 0.5)
     >>> red_semitransparent = skia.Color4f(1.0, 0.0, 0.0, 0.5)
 
-Compositing a semitransparent lbue on top of an opaque red yields a part-blue,
+Compositing a semitransparent blue on top of an opaque red yields a part-blue,
 part-red color with an opaque alpha channel.
 
     >>> examples11.composite(blue_semitransparent, red_opaque, "source-over")
@@ -228,13 +228,13 @@ colors. Likewise, the final alpha is a bit different than you might think.
 Destination-in compositing ignores the source color except for its alpha
 channel, and multiplies the color of the backdrop by that alpha.
 
-This means that compositing any opaque color on top of a backdrop yields the
-backdrop.
+This means that compositing any opaque color on top of a backdrop with
+destination-in compositing yields the backdrop.
 
     >>> examples11.composite(blue_opaque, red_opaque, "destination-in")
     Color4f(1, 0, 0, 1)
 
-But transparent multiplies.
+But transparency multiplies.
 
     >>> examples11.composite(blue_semitransparent, red_opaque, "destination-in")
     Color4f(0.5, 0, 0, 0.5)
@@ -247,7 +247,7 @@ And of course, a fully transparent source color yields a full-zero result.
 
 Now for blending. Let's start by testing the `apply_blend` function, which
 takes as input a source and backdrop color channel, and a blend mode, It applies
-the blend ot the colors.
+the blend to the color.
 
     >>> examples11.apply_blend(0.6, 0.0, "normal")
     0.6
@@ -258,7 +258,7 @@ the blend ot the colors.
     >>> examples11.apply_blend(0.0, 0.6, "difference")
     0.6
 
-Now let's test the full `blend` method
+Now let's test the full `blend` method.
 
     >>> examples11.blend(blue_opaque, red_opaque, "normal") == blue_opaque
     True
@@ -269,15 +269,15 @@ Now let's test the full `blend` method
     >>> examples11.blend(red_semitransparent, blue_semitransparent, "normal") == red_semitransparent
     True
 
-    'multiply' multiplies each channel, so like colors may combine but dislike
-    colors cancel each other out.
+'multiply' multiplies each channel, so like colors may remain brighter but
+ dislike colors tend to darken each other each other out.
 
     >>> examples11.blend(blue_opaque, red_opaque, "multiply")
     Color4f(0, 0, 0, 1)
     >>> examples11.blend(blue_opaque, blue_semitransparent, "multiply")
     Color4f(0, 0, 1, 1)
 
-    'difference' only keeps around the differences
+'difference' only keeps around the differences.
 
     >>> examples11.blend(blue_opaque, red_opaque, "difference")
     Color4f(1, 0, 1, 1)

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -190,3 +190,96 @@ the screen.
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
     drawString(text=Rotate, x=13.0, y=136.10546875, color=ff000000)
     restore()
+
+Now let's test the example compositing and blend mode functions
+
+    >>> import examples11
+    >>> import skia
+    >>> blue_opaque = skia.Color4f(0.0, 0.0, 1.0, 1.0)
+    >>> red_opaque = skia.Color4f(1.0, 0.0, 0.0, 1.0)
+
+Source-over compositing of blue over red yields blue.
+
+    >>> examples11.composite(blue_opaque, red_opaque, "source-over") == blue_opaque
+    True
+
+And the other way around yields red.
+
+    >>> examples11.composite(red_opaque, blue_opaque, "source-over") == red_opaque
+    True
+
+    >>> blue_semitransparent = skia.Color4f(0.0, 0.0, 1.0, 0.5)
+    >>> red_semitransparent = skia.Color4f(1.0, 0.0, 0.0, 0.5)
+
+Compositing a semitransparent lbue on top of an opaque red yields a part-blue,
+part-red color with an opaque alpha channel.
+
+    >>> examples11.composite(blue_semitransparent, red_opaque, "source-over")
+    Color4f(0.5, 0, 0.5, 1)
+
+Compositing the blue over red if they are both half-transparent yields a result
+that is less red then blue. This is because the definition of source-over
+compositing applies a bit differently to the background and foreground
+colors. Likewise, the final alpha is a bit different than you might think.
+
+    >>> examples11.composite(blue_semitransparent, red_semitransparent, "source-over")
+    Color4f(0.25, 0, 0.5, 0.75)
+
+Destination-in compositing ignores the source color except for its alpha
+channel, and multiplies the color of the backdrop by that alpha.
+
+This means that compositing any opaque color on top of a backdrop yields the
+backdrop.
+
+    >>> examples11.composite(blue_opaque, red_opaque, "destination-in")
+    Color4f(1, 0, 0, 1)
+
+But transparent multiplies.
+
+    >>> examples11.composite(blue_semitransparent, red_opaque, "destination-in")
+    Color4f(0.5, 0, 0, 0.5)
+
+And of course, a fully transparent source color yields a full-zero result.
+
+    >>> green_full_transparent = skia.Color4f(0.0, 1.0, 0.0, 0.0)
+    >>> examples11.composite(green_full_transparent, red_opaque, "destination-in")
+    Color4f(0, 0, 0, 0)
+
+Now for blending. Let's start by testing the `apply_blend` function, which
+takes as input a source and backdrop color channel, and a blend mode, It applies
+the blend ot the colors.
+
+    >>> examples11.apply_blend(0.6, 0.0, "normal")
+    0.6
+    >>> examples11.apply_blend(0.6, 0.0, "multiply")
+    0.0
+    >>> examples11.apply_blend(0.6, 0.0, "difference")
+    0.6
+    >>> examples11.apply_blend(0.0, 0.6, "difference")
+    0.6
+
+Now let's test the full `blend` method
+
+    >>> examples11.blend(blue_opaque, red_opaque, "normal") == blue_opaque
+    True
+    >>> examples11.blend(red_opaque, blue_opaque, "normal") == red_opaque
+    True
+    >>> examples11.blend(blue_semitransparent, red_semitransparent, "normal") == blue_semitransparent
+    True
+    >>> examples11.blend(red_semitransparent, blue_semitransparent, "normal") == red_semitransparent
+    True
+
+    'multiply' multiplies each channel, so like colors may combine but dislike
+    colors cancel each other out.
+
+    >>> examples11.blend(blue_opaque, red_opaque, "multiply")
+    Color4f(0, 0, 0, 1)
+    >>> examples11.blend(blue_opaque, blue_semitransparent, "multiply")
+    Color4f(0, 0, 1, 1)
+
+    'difference' only keeps around the differences
+
+    >>> examples11.blend(blue_opaque, red_opaque, "difference")
+    Color4f(1, 0, 1, 1)
+    >>> examples11.blend(blue_opaque, blue_semitransparent, "difference")
+    Color4f(0, 0, 0.5, 1)


### PR DESCRIPTION
Chapter 11 has some example python code for the purpose of describing the compositing and blend mode operators.

This PR adds the actual code and tests it. In the process I found a few typos and fixed them.