### PR TITLE
Add support for background-size:contain

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1740,15 +1740,81 @@ class ClipRect:
 Note how the background image is painted *before* children, just like
 `background-color`.[^paint-order]
 
+Ok, we can now put background images on an element of any size, and the image
+will be clipped if it's too big (and it'll reveal the background color or
+backdrop if it's too small). But as soon as you're trying to make a web page
+(such as an extension to the guest book to show an avatar image), the
+fact that you can't resize the image to fit the size of the element is pretty
+annoying---the only way to fix is is to resize the image with a utility program
+and store an additonal resolution of it on the server.
+
+To fix this situation, let's add support for
+[`background-size:contain`][background-size], which
+means "scale the image so it fits in the size of the element". This is super
+easy to implement in Skia, by uisng the `drawImageRect` method. This method
+takes two extra `skia.Rect` arguments: a source rect and a destination rect.
+It takes the parts of the image bitmap within the source rect and rescales
+them as necesary to fit into the destination rect.
+
+[background-size]: https://developer.mozilla.org/en-US/docs/Web/CSS/background-size
+
+This modified example:
+
+    <div style="width:100px; height:100px;background-image:
+        url('/avatar.png');background-size:contain">
+    </div>
+
+Paints like:
+
+<div style="width:100px; height:100px;
+    background-image:url('/avatar.png');background-size:contain">
+</div>
+
+The code to add it requires a slight tweak to `paint_background` (note how
+we were able to optimize away the save and clip):
+
+``` {.python}
+def paint_background(node, display_list, rect):
+    # ...
+    if background_image:
+        background_size = node.style.get("background-size")
+        if background_size and background_size == "contain":
+            display_list.append(DrawImageRect(node.background_image, rect))
+        else:
+            display_list.append(Save(rect))
+            display_list.append(ClipRect(rect))
+            display_list.append(DrawImage(node.background_image,
+                rect))
+            display_list.append(Restore(rect))
+```
+
+and a new display list command:
+
+``` {.python}
+class DrawImageRect:
+    def __init__(self, image, rect):
+        self.image = image
+        self.rect = rect
+
+    def execute(self, scroll, surface):
+        with surface as canvas:
+            source_rect = skia.Rect.Make(self.image.bounds())
+            dest_rect = skia.Rect.MakeLTRB(
+                self.rect.left(),
+                self.rect.top() - scroll,
+                self.rect.right(),
+                self.rect.bottom() - scroll)
+            canvas.drawImageRect(
+                self.image, source_rect, dest_rect)
+```
+
 ::: {.further}
-As we've seen, background images may not have the same
-[*intrinsic size*][intrinsic-size] as the element it's associated with. There
-are a lot of options in the specification for the different ways to account for
-this, via CSS properties like [`background-size`][background-size] and
+
+There are a lot more options in the specification for the different ways to
+account for this, via additional CSS properties like 
 [`background-repeat`][background-repeat].
 
 [intrinsic-size]: https://developer.mozilla.org/en-US/docs/Glossary/Intrinsic_Size
-[background-size]: https://developer.mozilla.org/en-US/docs/Web/CSS/background-size
 [background-repeat]: https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat
 
 In addition to these considerations, there are also cases where we want to scale

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -782,6 +782,14 @@ def parse_transform(transform_str):
         return (None, None)
 ```
 
+Also add the "," character to the list of characters in a CSS word:
+
+``` {.python}
+class CSSParser:
+    # ...
+            if cur.isalnum() or cur in ",/#-.%()\"'" \
+```
+
 Then we need paint it into the display list (we need to `Save` before rotating,
 to only rotate the element and its subtree, not the rest of the output). For
 that, introduce a new method `paint_visual_efects` that is called by
@@ -1533,7 +1541,7 @@ otherwise, not.[^only-single-quote]
 double quotes are accepted in real CSS. Single and double quotes can be
 interchanged in CSS and JavaScript, just like in Python.
 
-``` {.python}
+``` {.python expected=False}
 class CSSParser:
     # ...
     def word(self):

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1743,19 +1743,19 @@ Note how the background image is painted *before* children, just like
 Ok, we can now put background images on an element of any size, and the image
 will be clipped if it's too big (and it'll reveal the background color or
 backdrop if it's too small). But as soon as you're trying to make a web page
-(such as an extension to the guest book to show an avatar image), the
-fact that you can't resize the image to fit the size of the element is pretty
-annoying---the only way to fix is is to resize the image with a utility program
-and store an additonal resolution of it on the server.
+(such as an extension to the guest book to show an avatar image), the fact that
+you can't resize the image to fit the size of the element is pretty annoying,
+because the only way to fix it is to manually resize the image with a utility
+program and store an additional image of the new size on the server.
 
 To fix this situation, let's add support for
 [`background-size:contain`][background-size], which
 means "scale the image so it fits in the size of the element". This is super
-easy to implement in Skia, by uisng the `drawImageRect` method. This method
+easy to implement in Skia, by using the `drawImageRect` method. This method
 takes two extra `skia.Rect` arguments: a source rect and a destination rect.
 It takes the parts of the image bitmap within the source rect and rescales
-them as necesary to fit into the destination rect.
-
+it as necessary to fit into the destination rect.
+p
 [background-size]: https://developer.mozilla.org/en-US/docs/Web/CSS/background-size
 
 This modified example:

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -185,8 +185,8 @@ For 2D rotation, there is as translate to adjust for
 transform origin, then the rotation, then a reverse translation to go from
 the transform origin back to the original origin.
 
-    >>> size_and_transform_url = 'http://test.test/size_and_transform'
-    >>> test.socket.respond(size_and_transform_url, b"HTTP/1.0 200 OK\r\n" +
+    >>> size_and_rotate_url = 'http://test.test/size_and_transform'
+    >>> test.socket.respond(size_and_rotate_url, b"HTTP/1.0 200 OK\r\n" +
     ... b"content-type: text/html\r\n\r\n" +
     ... b"<link rel=stylesheet href='styles.css'>" +
     ... b"<div style=\"transform:rotate(45deg)\"><div>Rotate</div></div>)")
@@ -196,12 +196,30 @@ because transform matrices get applied in backwards order when rendering to
 the screen.
 
     >>> browser = lab11.Browser({})
-    >>> browser.load(size_and_transform_url)
+    >>> browser.load(size_and_rotate_url)
     >>> browser.skia_surface.printTabCommands()
     save()
     translate(x=38.0, y=143.0)
     rotate(degrees=45.0)
     translate(x=-38.0, y=-143.0)
+    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawString(text=Rotate, x=13.0, y=136.10546875, color=ff000000)
+    restore()
+
+For translation transforms, on the other hand, there is need to adjust for the
+origin.
+
+    >>> size_and_translate_url = 'http://test.test/size_and_translate'
+    >>> test.socket.respond(size_and_translate_url, b"HTTP/1.0 200 OK\r\n" +
+    ... b"content-type: text/html\r\n\r\n" +
+    ... b"<link rel=stylesheet href='styles.css'>" +
+    ... b"<div style=\"transform:translate(5px,6px)\"><div>Rotate</div></div>)")
+    >>> browser = lab11.Browser({})
+    >>> browser.load(size_and_translate_url)
+    >>> browser.skia_surface.printTabCommands()
+    save()
+    translate(x=5.0, y=6.0)
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
     drawString(text=Rotate, x=13.0, y=136.10546875, color=ff000000)

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -57,6 +57,22 @@ color.
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
     drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
 
+Specifying `background-size: contain`is supported.
+
+    >>> size_and_image_and_size_url = 'http://test.test/size_and_image_and_size'
+    >>> test.socket.respond(size_and_image_and_size_url, b"HTTP/1.0 200 OK\r\n" +
+    ... b"content-type: text/html\r\n\r\n" +
+    ... b"<link rel=stylesheet href='styles.css'>" +
+    ... b"<div style=\"background-image:url('image.png');background-size:contain\"><div>Text</div></div>)")
+
+    >>> browser = lab11.Browser({})
+    >>> browser.load(size_and_image_and_size_url)
+    >>> browser.skia_surface.printTabCommands()
+    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawImageRect(<image>, src=Rect(0, 0, 1, 1), dst=Rect(13, 118, 63, 168)
+    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
+
 Also note that urls can be non-relative. Since non-relative urls start with
 "http://" or "https://", we needed some extra logic in the CSS parser to avoid
 getting confused and thinking the colon is a property-value delimiter. Let's

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -285,6 +285,22 @@ class DrawImage:
                 self.image, self.rect.left(),
                 self.rect.top() - scroll)
 
+class DrawImageRect:
+    def __init__(self, image, rect):
+        self.image = image
+        self.rect = rect
+
+    def execute(self, scroll, surface):
+        with surface as canvas:
+            source_rect = skia.Rect.Make(self.image.bounds())
+            dest_rect = skia.Rect.MakeLTRB(
+                self.rect.left(),
+                self.rect.top() - scroll,
+                self.rect.right(),
+                self.rect.bottom() - scroll)
+            canvas.drawImageRect(
+                self.image, source_rect, dest_rect)
+
 INPUT_WIDTH_PX = 200
 
 class LineLayout:
@@ -511,11 +527,15 @@ def paint_background(node, display_list, rect):
 
     background_image = node.style.get("background-image")
     if background_image:
-        display_list.append(Save(rect))
-        display_list.append(ClipRect(rect))
-        display_list.append(DrawImage(node.background_image,
-            rect))
-        display_list.append(Restore(rect))
+        background_size = node.style.get("background-size")
+        if background_size and background_size == "contain":
+            display_list.append(DrawImageRect(node.background_image, rect))
+        else:
+            display_list.append(Save(rect))
+            display_list.append(ClipRect(rect))
+            display_list.append(DrawImage(node.background_image,
+                rect))
+            display_list.append(Restore(rect))
 
 class BlockLayout:
     def __init__(self, node, parent, previous):

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -749,7 +749,7 @@ class CSSParser:
             cur = self.s[self.i]
             if cur == "'":
                 in_quote = not in_quote
-            if cur.isalnum() or cur in "/#-.%()\"'" \
+            if cur.isalnum() or cur in ",/#-.%()\"'" \
                 or (in_quote and cur == ':'):
                 self.i += 1
             else:

--- a/src/test11.py
+++ b/src/test11.py
@@ -184,6 +184,11 @@ class MockCanvas:
         self.commands.append("drawImage(<image>, left={left}, top={top}".format(
             left=left, top=top))
 
+    def drawImageRect(self, image, src, dst):
+        self.commands.append(
+            "drawImageRect(<image>, src={src}, dst={dst}".format(
+                src=src, dst=dst))
+
     def restore(self):
         self.commands.append("restore()")
 


### PR DESCRIPTION
This will be useful for the demo, and setup up an exercise for implementing the img element.

This PR also fixes a bug where we failed to allow commas in translate transform CSS property values.