### PR TITLE
Pass on first section of Chapter 11

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -194,9 +194,26 @@ Now our browser is creating an SDL window can draw to it via Skia. But
 most of the browser codebase is still using Tkinter drawing commands,
 which we now need to replace. Skia is a bit more verbose than Tkinter,
 so let's abstract over some details with helper functions.[^skia-docs]
+First, a helper function to convert colors to Skia colors:
 
-[skia-docs]: Consult the [Skia][skia] and [Skia-Python][skia-python]
+[^skia-docs]: Consult the [Skia][skia] and [Skia-Python][skia-python]
 documentation for more on the Skia API.
+
+``` {.python}
+def color_to_sk_color(color):
+    if color == "white":
+        return skia.ColorWHITE
+    elif color == "lightblue":
+        return skia.ColorSetARGB(0xFF, 0xAD, 0xD8, 0xE6)
+    # ...
+    else:
+        return skia.ColorBLACK
+```
+
+You can add more "elif" blocks to support your favorite color names;
+modern browsers support [quite a lot][css-colors].
+
+[css-colors]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
 
 To draw a line, you use Skia's `Path` object:
 

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -44,7 +44,7 @@ Python bindings like so:
 As elsewhere in this book, you may need to use `pip`, `easy_install`,
 or `python3 -m pip` instead of `pip3` as your installer, or use your
 IDE's package installer. If you're on Linux, you'll need to install
-additional dependencies, like OpenGL, fontconfig. Also, you may not be
+additional dependencies, like OpenGL and fontconfig. Also, you may not be
 able to install `pysdl2-dll`; you'll need to find SDL in your system
 package manager instead. Consult the [`skia-python`][skia-python] and
 [`pysdl2`][sdl-python] web pages for more details.
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # ...
 ```
 
-Next, we need create an SDL window, instead of a Tkinter window,
+Next, we need to create an SDL window, instead of a Tkinter window,
 inside the Browser, and set up Skia to draw to it. Here's the SDL
 incantation to create a window:
 
@@ -98,7 +98,7 @@ colors). A surface may or may not be bound to the actual pixels on the
 screen via a window, and there can be many surfaces. A *canvas* is an
 API interface that allows you to draw into a surface with higher-level
 commands such as for rectangles or text. Our browser uses separate
-Skia and SDL surface for simplicity, but in a highly optimized
+Skia and SDL surfaces for simplicity, but in a highly optimized
 browser, minimizing the number of surfaces is important for good
 performance.
 
@@ -118,7 +118,7 @@ place to another:
 
 ``` {.python}
 class Browser:
-    def commit_canvas(self):
+    def draw_to_screen(self):
         # Raster the results and copy to the SDL surface:
         skia_image = self.skia_surface.makeImageSnapshot()
         skia_bytes = skia_image.tobytes()
@@ -339,7 +339,7 @@ Once this is done, we need to copy from the Skia surface to the SDL window:
 class Browser:
     def draw(self):
         # ...
-        self.commit_canvas()
+        self.draw_to_screen()
 ```
 
 We've only got a few minor changes left elsewhere in the browser.
@@ -385,7 +385,7 @@ behave just as it did in previous chapters, and it'll probably feel
 faster, because Skia and SDL are faster than Tkinter.
 
 ::: {.further}
-Implement high-quality raster libraries is very interesting in its own
+Implementing high-quality raster libraries is very interesting in its own
 right. These days, it's especially important to leverage GPUs when
 they're available, and browsers often push the envelope. Browser teams
 typically include raster library experts: Skia for Chromium and [Core

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -5,69 +5,50 @@ prev: security
 next: rendering-architecture
 ...
 
-Right now our browser can draw text and rectangles of various colors. But that's
-pretty boring: our guest book demo, for example, does cool stuff but doesn't
-*look* very impressive. Real browsers have all sorts of great ways to make
- content look good on the screen, of course. These are called *visual
- effects*---visual because they affect how it looks, but not functionality per
- se, or layout. Therefore these effects are extensions to the *paint*
- and *draw* parts of rendering.
+Right now our browser's visual capabilities are pretty boring, just
+colored rectangles and text. Real browsers, one the other hand,
+support all kinds of *visual effects* that affect how elements look.
+Before we add these to our browser, we'll need to learn a bit about
+pixels, colors, and blending on computer screens. We'll then be able
+to implement these effects using the Skia graphics library, and you'll
+see a bit of how Skia is implemented under the hood.
 
-But to understand how this visual effects really work, you'll need to learn a
-bit about colors and pixels on computer screens, and what happens when canvases
-draw multiple times into the same pixel. Then we can proceed to implementing
-some visual effects, but the first step (even before colors and pixels) will be
-to replace Tkinter with Skia, a newer rendering library with sufficient
-capabilities.
+Installing Skia and SDL
+=======================
 
-You'll see that implementing these effects in Skia won't be too hard, and with
-prior understanding in hand, you'll know more about *how* Skia implements them
-under the hood.
+Before we get any further, we'll need to upgrade our graphics system.
+While Tkinter is great for basic shapes and handling input, it lacks
+built-in visual effects routines.[^tkinter-before-gpu] Implementing
+fast visual effects routines is fun, but it's outside the scope of
+this book, so we need a new graphics library. Let's use [Skia][skia],
+the library that Chromium uses. Unlike Tkinter, Skia doesn't handle
+inputs or create graphical windows, so we'll pair it with the
+[SDL][sdl] GUI library.
 
-Then we'll be able to use these to make the guest book look more fun, by adding
-an interactive "account info" menu similar to ones present on many real sites
-today.
+[skia]: https://skia.org
+[sdl]: https://www.libsdl.org/
 
-Skia replaces Tkinter
-=====================
+[^tkinter-before-gpu]: That's because Tk, the graphics library that
+Tkinter uses, dates from the early 90s, before high-performance
+graphics cards and GPUs became widespread.
 
-Before we get any further defining and implementing compositing and blend modes,
-we'll need to upgrade our graphics system. While Tkinter is great for basic
-painting and handling input, it has no built-in support at all for implementing
-many visual effects.[^tkinter-before-gpu] And just as implementing the details
-of text rendering or drawing rectangles is outside the scope of this book, so
-is implementing visual effects---our focus should be on how to represent and
-execute visual effects for web pages specifically.
+Start by installing [Skia's][skia-python] and [SDL's][sdl-python]
+Python bindings like so:
 
-[^tkinter-before-gpu]: That's because Tk, the library Tkinter uses to implement
-its graphics, was built back in the early 90s, before high-performance graphics
-cards and GPUs, and their software equivalents, became widespread.
+    pip3 install skia-python pysdl2 pysdl2-dll
 
-So we need a new library that can implement visual effects. We'll use
-[Skia](https://skia.org), the library that Chromium uses. However, Skia is just
-a library for rastering content on the CPU and GPU, so we'll also use
-[SDL](https://www.libsdl.org/) to provide windows, input events, and OS-level
-integration.
+[skia-python]: https://github.com/kyamagu/skia-python
+[sdl-python]: https://pypi.org/project/PySDL2/
 
-::: {.further}
-While this book is about browsers, and not how to implement high-quality
-raster libraries, that topic is very interesting in its own right.
-In addition, it is very important these days for browsers to work smoothly with
-the advanced GPUs in today's devices, and often browsers are pushing the
-envelope of graphics technology. So in practice browser teams include experts
-in these areas: Skia for Chromium and [Core Graphics][core-graphics] for Webkit,
-for example. In both cases these libraries are used outside of the
-browser---Core Graphics is used for iOS and macOS apps, and Skia for Android.
+::: {.install}
+As elsewhere in this book, you may need to use `pip`, `easy_install`,
+or `python3 -m pip` instead of `pip3` as your installer, or use your
+IDE's package installer. If you're on Linux, you'll need to install
+additional dependencies, like OpenGL, fontconfig. Also, you may not be
+able to install `pysdl2-dll`; you'll need to find SDL in your system
+package manager instead. Consult the [`skia-python`][skia-python] and
+[`pysdl2`][sdl-python] web pages for more details.
 :::
-
-[core-graphics]: https://developer.apple.com/documentation/coregraphics
-
-To install Skia, you'll need to install the
-[`skia-python`](https://github.com/kyamagu/skia-python)
-library (via `pip3 install skia-python`); as explained on the linked site, you
-might need to install additional dependencies. Instructions
-[here](https://pypi.org/project/PySDL2/) explain how to install SDL on your
-computer (short version: `pip3 install PySDL2` and `pip3 install pysdl2-dll`).
 
 Once installed, remove `tkinter` from your Python imports and replace them with:
 
@@ -77,186 +58,72 @@ import sdl2
 import skia
 ```
 
-The additional `ctypes` module is for interfacing between Python types and C
-types.
+If any of these imports fail, you probably need to check that Skia and
+SDL were installed correctly. Note that the `ctypes` module comes
+standard in Python; it helps convert between Python and C types.
 
-The main loop of the browser first needs some boilerplate to get SDL started:
+Skia replaces Tkinter
+=====================
+
+The main loop of the browser first needs some boilerplate to get SDL
+started:
 
 ``` {.python}
 if __name__ == "__main__":
-    # ...
+    import sys
     sdl2.SDL_Init(sdl2.SDL_INIT_VIDEO)
-    sdl_window = sdl2.SDL_CreateWindow(b"Browser",
-        sdl2.SDL_WINDOWPOS_CENTERED, sdl2.SDL_WINDOWPOS_CENTERED,
-        WIDTH, HEIGHT, sdl2.SDL_WINDOW_SHOWN)
-
-    browser = Browser(sdl_window)
+    browser = Browser()
     browser.load(sys.argv[1])
-```
-
-In SDL, you have to implement the event loop yourself (rather than calling
-`tkinter.mainloop()`). This loop also has to handle input events:
-
-``` {.python}
-    running = True
-    event = sdl2.SDL_Event()
-    while running:
-        while sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
-            if event.type == sdl2.SDL_MOUSEBUTTONUP:
-                browser.handle_click(event.button)
-            if event.type == sdl2.SDL_KEYDOWN:
-                if event.key.keysym.sym == sdl2.SDLK_RETURN:
-                    browser.handle_enter()
-                if event.key.keysym.sym == sdl2.SDLK_DOWN:
-                    browser.handle_down()
-            if event.type == sdl2.SDL_TEXTINPUT:
-                browser.handle_key(event.text.text.decode('utf8'))
-            if event.type == sdl2.SDL_QUIT:
-                running = False
-                break
-
-    sdl2.SDL_DestroyWindow(sdl_window)
-    sdl2.SDL_Quit()
-```
-
-Next factor a bunch of the tasks of drawing into helper methods. The
-implementation in Skia should be relatively self-explanatory (there is also
-more complete documentation[here](https://kyamagu.github.io/skia-python/) or at
-the [Skia site](https://skia.org)):
-
-``` {.python}
-def draw_polyline(surface, x1, y1, x2, y2, x3=None,
-    y3=None, fill=False):
-    path = skia.Path()
-    path.moveTo(x1, y1)
-    path.lineTo(x2, y2)
-    if x3:
-        path.lineTo(x3, y3)
-    paint = skia.Paint()
-    paint.setColor(skia.ColorBLACK)
-    if fill:
-        paint.setStyle(skia.Paint.kFill_Style)
-    else:
-        paint.setStyle(skia.Paint.kStroke_Style)
-    paint.setStrokeWidth(1);
-    with surface as canvas:
-        canvas.drawPath(path, paint)
-
-class Browser:
     # ...
-    def draw_text(self, x, y, text, font, color=None):
-        paint = skia.Paint(
-            AntiAlias=True, Color=color_to_sk_color(color))
-        with self.skia_surface as canvas:
-            canvas.drawString(
-                text, x, y - font.getMetrics().fAscent,
-                font, paint)
-
-    def draw_rect(self, rect, fill=None, width=1):
-        paint = skia.Paint()
-        if fill:
-            paint.setStrokeWidth(width);
-            paint.setColor(color_to_sk_color(fill))
-        else:
-            paint.setStyle(skia.Paint.kStroke_Style)
-            paint.setStrokeWidth(1);
-            paint.setColor(skia.ColorBLACK)
-        with self.skia_surface as canvas:
-            canvas.drawRect(rect, paint)
 ```
 
-Change `DrawText` and `DrawRect` to use the surface in a straightforward
-way. For example, here is `DrawText.execute`:
-
-``` {.python}
-    def execute(self, scroll, surface):
-        paint = skia.Paint(
-            AntiAlias=True, Color=color_to_sk_color(self.color))
-        with surface as canvas:
-            canvas.drawString(
-                self.text, self.rect.left(),
-                self.rect.top() -  scroll - self.font.getMetrics().fAscent,
-                self.font, paint)
-```
-
-Now integrate with the `Browser` class. We need a surface[^surface] for
-drawing to the window, and a surface into which Skia will draw.
+Next, we need create an SDL window, instead of a Tkinter window,
+inside the Browser, and set up Skia to draw to it. Here's the SDL
+incantation to create a window:
 
 ``` {.python}
 class Browser:
-    def __init__(self, sdl_window):
+    def __init__(self):
+        self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
+            sdl2.SDL_WINDOWPOS_CENTERED, sdl2.SDL_WINDOWPOS_CENTERED,
+            WIDTH, HEIGHT, sdl2.SDL_WINDOW_SHOWN)
+```
+
+To set up Skia to draw to this window, we need to create two
+"surfaces":[^surface]
+
+[^surface]: In Skia and SDL, a *surface* is a representation of a
+graphics buffer into which you can draw "pixels" (bits representing
+colors). A surface may or may not be bound to the actual pixels on the
+screen via a window, and there can be many surfaces. A *canvas* is an
+API interface that allows you to draw into a surface with higher-level
+commands such as for rectangles or text. Our browser uses separate
+Skia and SDL surface for simplicity, but in a highly optimized
+browser, minimizing the number of surfaces is important for good
+performance.
+
+
+``` {.python}
+class Browser:
+    def __init__(self):
         self.window_surface = sdl2.SDL_GetWindowSurface(
             self.sdl_window)
         self.skia_surface = skia.Surface(WIDTH, HEIGHT)
 ```
 
-Next, re-implement the `draw` method on `Browser` using Skia. I'll
-walk through it step-by-step. First clear the canvas and and draw the current
-`Tab` into it:
+Typically, we'lll draw to the Skia surface, and then once we're done
+with it we'll copy it to the SDL surface to display on the screen.
+This looks a little hairy but really it's just copying pixels from one
+place to another:
 
 ``` {.python}
-    def draw(self):
-        with self.skia_surface as canvas:
-            canvas.clear(skia.ColorWHITE)
-
-        self.tabs[self.active_tab].draw(self.skia_surface)
-```
-
-Then draw the browser UI elements:
-
-``` {.python}
-        # Draw the tabs UI:
-        tabfont = skia.Font(skia.Typeface('Arial'), 20)
-        for i, tab in enumerate(self.tabs):
-            name = "Tab {}".format(i)
-            x1, x2 = 40 + 80 * i, 120 + 80 * i
-            draw_polyline(self.skia_surface, x1, 0, x1, 40)
-            draw_polyline(self.skia_surface, x2, 0, x2, 40)
-            self.draw_text(x1 + 10, 10, name, tabfont)
-            if i == self.active_tab:
-                draw_polyline(self.skia_surface, 0, 40, x1, 40)
-                draw_polyline(self.skia_surface, x2, 40, WIDTH, 40)
-
-        # Draw the plus button to add a tab:
-        buttonfont = skia.Font(skia.Typeface('Arial'), 30)
-        self.draw_rect(skia.Rect.MakeLTRB(10, 10, 30, 30))
-        self.draw_text(11, 0, "+", buttonfont)
-
-        # Draw the URL address bar:
-        self.draw_rect(
-            skia.Rect.MakeLTRB(40, 50, WIDTH - 10, 90))
-        if self.focus == "address bar":
-            self.draw_text(55, 55, self.address_bar, buttonfont)
-            w = buttonfont.measureText(self.address_bar)
-            draw_polyline(self.skia_surface, 55 + w, 55, 55 + w, 85)
-        else:
-            url = self.tabs[self.active_tab].url
-            self.draw_text(55, 55, url, buttonfont)
-
-        # Draw the back button:
-        self.draw_rect(skia.Rect.MakeLTRB(10, 50, 35, 90))
-        draw_polyline(
-            self.skia_surface, 15, 70, 30, 55, 30, 85, True)
-```
-
-Finally perform the incantations to save off a rastered bitmap and copy it
-from the Skia surface to the SDL surface:
-
-``` {.python}
+class Browser:
+    def commit_canvas(self):
         # Raster the results and copy to the SDL surface:
         skia_image = self.skia_surface.makeImageSnapshot()
         skia_bytes = skia_image.tobytes()
         rect = sdl2.SDL_Rect(0, 0, WIDTH, HEIGHT)
-        skia_surface = Browser.to_sdl_surface(skia_bytes)
-        sdl2.SDL_BlitSurface(
-            skia_surface, rect, self.window_surface, rect)
-        sdl2.SDL_UpdateWindowSurface(self.sdl_window)
-```
 
-And here is the `to_sdl_surface` method:
-
-``` {.python}
-    def to_sdl_surface(skia_bytes):
         depth = 32 # 4 bytes per pixel
         pitch = 4 * WIDTH # 4 * WIDTH pixels per line on-screen
         # Skia uses an ARGB format - alpha first byte, then
@@ -265,52 +132,269 @@ And here is the `to_sdl_surface` method:
         red_mask = 0x00ff0000
         green_mask = 0x0000ff00
         blue_mask = 0x000000ff
-        return sdl2.SDL_CreateRGBSurfaceFrom(
+        sdl_surface = sdl2.SDL_CreateRGBSurfaceFrom(
             skia_bytes, WIDTH, HEIGHT, depth, pitch,
             red_mask, green_mask, blue_mask, alpha_mask)
+
+        sdl2.SDL_BlitSurface(
+            sdl_surface, rect, self.window_surface, rect)
+        sdl2.SDL_UpdateWindowSurface(self.sdl_window)
 ```
 
-Finally, `handle_enter` and `handle_down` no longer need an event parameter.
-
-[^surface]: In Skia and SDL, a *surface* is a representation of a graphics buffer
-into which you can draw "pixels" (bits representing colors). A surface may or
-may not be bound to the actual pixels on the screen via a window, and there can
-be many surfaces. A *canvas* is an API interface that allows you to draw
-into a surface with higher-level commands such as for rectangles or text. In
-our implementation, we'll start with separate surfaces for Skia and SDL for
-simplicity. In a highly optimized browser, minimizing the number of surfaces
-is important for good performance.
-
-In the `Tab` class, the differences in `draw` is the new `surface` parameter
-that gets passed around, and using the Skia API to measure font metrics. Skia's
-`measureText` method on a font is the same as the `measure` method on a Tkinter
-font.
+SDL doesn't have a `mainloop` or `bind` method; we have to implement
+it ourselves:
 
 ``` {.python}
-    def draw(self, surface):
+if __name__ == "__main__":
+    # ...
+    event = sdl2.SDL_Event()
+    while True:
+        while sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
+            if event.type == sdl2.SDL_QUIT:
+                browser.handle_quit()
+                sdl2.SDL_Quit()
+                sys.exit(0)
+            # ...
+```
+
+The details of `ctypes` and `PollEvent` aren't too important here, but
+note that `SDL_QUIT` is an event, sent when the user closes the last
+open window. The `handle_quit` method it calls just cleans up the
+window object:
+
+``` {.python}
+class Browser:
+    def handle_quit(self):
+        sdl2.SDL_DestroyWindow(self.sdl_window)
+```
+
+We'll also need to handle all of the other events in this
+loop---clicks, typing, and so on:
+
+``` {.python}
+if __name__ == "__main__":
+    while True:
+        while sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
+            # ...
+            elif event.type == sdl2.SDL_MOUSEBUTTONUP:
+                browser.handle_click(event.button)
+            elif event.type == sdl2.SDL_KEYDOWN:
+                if event.key.keysym.sym == sdl2.SDLK_RETURN:
+                    browser.handle_enter()
+                elif event.key.keysym.sym == sdl2.SDLK_DOWN:
+                    browser.handle_down()
+            elif event.type == sdl2.SDL_TEXTINPUT:
+                browser.handle_key(event.text.text.decode('utf8'))
+```
+
+You can now remove all of the `bind` calls in the `Browser`
+constructor; this main loop replaces them. Also note that I've changed
+the signatures of the various `handle_xxx` methods; you'll need to
+make analogous changes in `Browser` where they are defined.
+
+Now our browser is creating an SDL window can draw to it via Skia. But
+most of the browser codebase is still using Tkinter drawing commands,
+which we now need to replace. Skia is a bit more verbose than Tkinter,
+so let's abstract over some details with helper functions.[^skia-docs]
+
+[skia-docs]: Consult the [Skia][skia] and [Skia-Python][skia-python]
+documentation for more on the Skia API.
+
+To draw a line, you use Skia's `Path` object:
+
+``` {.python}
+def draw_line(surface, x1, y1, x2, y2):
+    path = skia.Path().moveTo(x1, y1).lineTo(x2, y2)
+    paint = skia.Paint(Color=skia.ColorBLACK)
+    paint.setStyle(skia.Paint.kStroke_Style)
+    paint.setStrokeWidth(1);
+    with surface as canvas:
+        canvas.drawPath(path, paint)
+```
+
+To draw text, you use `drawString`:
+
+``` {.python}
+def draw_text(surface, x, y, text, font, color=None):
+    sk_color = color_to_sk_color(color)
+    paint = skia.Paint(AntiAlias=True, Color=sk_color)
+    with surface as canvas:
+        canvas.drawString(
+            text, x, y - font.getMetrics().fAscent,
+            font, paint)
+```
+
+Finally, for drawing rectangles we use `drawRect`:
+
+``` {.python}
+def draw_rect(surface, l, t, r, b, fill=None, width=1):
+    paint = skia.Paint()
+    if fill:
+        paint.setStrokeWidth(width);
+        paint.setColor(color_to_sk_color(fill))
+    else:
+        paint.setStyle(skia.Paint.kStroke_Style)
+        paint.setStrokeWidth(1);
+        paint.setColor(skia.ColorBLACK)
+    rect = skia.Rect.MakeLTRB(l, t, r, b)
+    with surface as canvas:
+        canvas.drawRect(rect, paint)
+```
+
+If you look at the details of these helper methods, you'll see that
+they all use a Skia `Paint` object to describe a shape's borders and
+colors. We'll be seeing a lot more features of `Paint` in this chapter.
+
+With these helper methods we can now upgrade our browser's drawing
+commands to use Skia:
+
+``` {.python}
+class DrawText:
+    def execute(self, scroll, surface):
+        draw_text(surface, self.left, self.top - scroll, font)
+
+class DrawRect:
+    def execute(self, scroll, surface):
+        draw_rect(surface,
+            self.left, self.top, self.right, self.bottom,
+            fill=self.color, width=0)
+```
+
+Finally, the `Browser` class also uses Tkinter commands in its `draw`
+method, which we'll also need to change to use Skia. It's a long
+method, so we'll need to go step by step.
+
+First, clear the canvas and and draw the current `Tab` into it:
+
+``` {.python}
+class Browser:
+    def draw(self):
+        with self.skia_surface as canvas:
+            canvas.clear(skia.ColorWHITE)
+
+        self.tabs[self.active_tab].draw(self.skia_surface)
+```
+
+Then draw the browser UI elements. First, the tabs:
+
+``` {.python}
+class Browser:
+    def draw(self):
         # ...
+        tabfont = skia.Font(skia.Typeface('Arial'), 20)
+        for i, tab in enumerate(self.tabs):
+            name = "Tab {}".format(i)
+            x1, x2 = 40 + 80 * i, 120 + 80 * i
+            draw_line(self.skia_surface, x1, 0, x1, 40)
+            draw_line(self.skia_surface, x2, 0, x2, 40)
+            draw_text(self.skia_surface, x1 + 10, 10, name, tabfont)
+            if i == self.active_tab:
+                draw_line(self.skia_surface, 0, 40, x1, 40)
+                draw_line(self.skia_surface, x2, 40, WIDTH, 40)
+```
+
+Next, the plus button for adding a new tab:
+
+``` {.python}
+class Browser:
+    def draw(self):
+        # ...
+        buttonfont = skia.Font(skia.Typeface('Arial'), 30)
+        draw_rect(self.skia_surface, 10, 10, 30, 30)
+        draw_text(self.skia_surface, 11, 0, "+", buttonfont)
+```
+
+Then the address bar, including text and cursor:
+
+``` {.python}
+class Browser:
+    def draw(self):
+        # ...
+        draw_rect(self.skia_surface, 40, 50, WIDTH - 10, 90)
+        if self.focus == "address bar":
+            draw_text(self.skia_surface, 55, 55, self.address_bar, buttonfont)
+            w = buttonfont.measureText(self.address_bar)
+            draw_line(self.skia_surface, 55 + w, 55, 55 + w, 85)
+        else:
+            url = self.tabs[self.active_tab].url
+            draw_text(self.skia_surface, 55, 55, url, buttonfont)
+```
+
+And finally the "back" button:
+
+``` {.python}
+class Browser:
+    def draw(self):
+        # ...
+        draw_rect(self.skia_surface, 10, 50, 35, 90)
+        path = skia.Path().moveTo(15, 70).lineTo(30, 55).lineTo(30, 85)
+        paint = skia.Paint(Color=skia.ColorBlack, Style=skia.Paint.kFill_Style)
+        with surface as canvas:
+            canvas.drawPath(path, paint)
+```
+
+Once this is done, we need to copy from the Skia surface to the SDL window:
+
+``` {.python}
+class Browser:
+    def draw(self):
+        # ...
+        self.commit_canvas()
+```
+
+We've only got a few minor changes left elsewhere in the browser.
+`Tab` also has a `draw` method and draws a cursor; it needs to use
+`draw_line` for that:
+
+``` {.python}
+class Tab:
+    def draw(self, surface):
+        is self.focus:
+            # ...
             x = obj.x + obj.font.measureText(text)
+            y = obj.y - self.scroll + CHROME_PX
+            draw_line(surface, x, y, x, y + obj.height)
 ```
 
-Update all the other places that `measure` was called to use the Skia method
-(and also create Skia fonts instead of Tkinter ones, of course).
+Note that I've renamed `draw`'s argument from `surface` to `canvas`
+and I've also replace the Tkinter `measure` call with Skia's
+`measureText` equivalent.
 
-Skia font metrics are accessed via the `getMetrics` method on a font. Then metrics
-like ascent and descent are accessible via:
+On that note, we'll need to create Skia fonts instead of Tkinter ones.
+Update all the other places that `measure` was called to use
+`measureText`. We also need to change everywhere `metrics` is called
+to instead use Skia's `getMetrics`, which works a little differently.
+In Skia, ascent and descent are accessible via:
+
 ``` {.python expected=False}
-    font.getMetrics().fAscent
+    -font.getMetrics().fAscent
 ```
+
 and
+
 ``` {.python expected=False}
     font.getMetrics().fDescent
 ```
 
-Note that in Skia, ascent and descent are baseline-relative---positive if they
-go downward and negative if upward, so ascents will normally be negative.
+Note the negative sign when accessing the ascent. In Skia, ascent and
+descent positive if they go downward and negative if they go upward,
+so ascents will normally be negative, the opposite of Tkinter.
 
-Now you should be able to run the browser just as it did in previous chapters,
-and have all of the same visuals. It'll probably also feel faster, because
-Skia and SDL are highly optimized libraries written in C & C++.
+You should now be able to run the browser again. It should look and
+behave just as it did in previous chapters, and it'll probably feel
+faster, because Skia and SDL are faster than Tkinter.
+
+::: {.further}
+Implement high-quality raster libraries is very interesting in its own
+right. These days, it's especially important to leverage GPUs when
+they're available, and browsers often push the envelope. Browser teams
+typically include raster library experts: Skia for Chromium and [Core
+Graphics][core-graphics] for Webkit, for example. Both of these
+libraries are used outside of the browser, too: Core Graphics in iOS
+and macOS, and Skia in Android.
+:::
+
+[core-graphics]: https://developer.apple.com/documentation/coregraphics
 
 Pixels, Color, Raster
 =====================

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -22,7 +22,7 @@ Elements can override their size...
     ... b"<link rel=stylesheet href='styles.css'>" +
     ... b"<div><div>Text</div></div>)")
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_url)
     >>> browser.skia_surface.printTabCommands()
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
@@ -46,7 +46,7 @@ color.
     ... b"<link rel=stylesheet href='styles.css'>" +
     ... b"<div style=\"background-image:url('image.png')\"><div>Text</div></div>)")
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_image_url)
     >>> browser.skia_surface.printTabCommands()
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
@@ -65,7 +65,7 @@ Specifying `background-size: contain`is supported.
     ... b"<link rel=stylesheet href='styles.css'>" +
     ... b"<div style=\"background-image:url('image.png');background-size:contain\"><div>Text</div></div>)")
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_image_and_size_url)
     >>> browser.skia_surface.printTabCommands()
     drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
@@ -90,7 +90,7 @@ Opacity can be applied.
     ... b"<link rel=stylesheet href='styles.css'>" +
     ... b"<div style=\"opacity:0.5\"><div>Text</div></div>)")
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_opacity_url)
     >>> browser.skia_surface.printTabCommands()
     saveLayer(color=80000000, alpha=128)
@@ -108,7 +108,7 @@ So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
     ... b"<div style=\"mix-blend-mode:multiply\"><div>Mult</div></div>)" +
     ... b"<div style=\"mix-blend-mode:difference\"><div>Diff</div></div>)")
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_mix_blend_mode_url)
     >>> browser.skia_surface.printTabCommands()
     saveLayer(color=ff000000, blend_mode=BlendMode.kMultiply)
@@ -135,7 +135,7 @@ There will be two save layers in this case---one to isolate the
 div and its children so the clip only applies ot it, and one to
 make a canvas in which to draw the circular clip mask.
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_clip_path_url)
     >>> browser.skia_surface.printTabCommands()
     saveLayer(color=ff000000)
@@ -159,7 +159,7 @@ In this case there will be a `save`, but no `saveLayer`, since the latter
 is implicit/an implementation detail of Skia, and a `clipRRect` call with a
 radius equal to the `20px` radius specified above.
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_border_radius_url)
     >>> browser.skia_surface.printTabCommands()
     save()
@@ -195,7 +195,7 @@ Note that the negative transform-origin translation happens last, not first,
 because transform matrices get applied in backwards order when rendering to 
 the screen.
 
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_rotate_url)
     >>> browser.skia_surface.printTabCommands()
     save()
@@ -215,7 +215,7 @@ origin.
     ... b"content-type: text/html\r\n\r\n" +
     ... b"<link rel=stylesheet href='styles.css'>" +
     ... b"<div style=\"transform:translate(5px,6px)\"><div>Rotate</div></div>)")
-    >>> browser = lab11.Browser({})
+    >>> browser = lab11.Browser()
     >>> browser.load(size_and_translate_url)
     >>> browser.skia_surface.printTabCommands()
     save()

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -1169,9 +1169,9 @@ class Browser:
         with surface as canvas:
             canvas.drawPath(path, paint)
 
-        self.commit_canvas()
+        self.draw_to_screen()
 
-    def commit_canvas(self):
+    def draw_to_screen(self):
         # Raster the results and copy to the SDL surface:
         skia_image = self.skia_surface.makeImageSnapshot()
         skia_bytes = skia_image.tobytes()

--- a/src/test11.py
+++ b/src/test11.py
@@ -205,11 +205,8 @@ class MockSkiaSurface:
         self.canvas = MockCanvas()
         pass
 
-    def __enter__(self):
+    def getCanvas(self):
         return self.canvas
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
 
     def makeImageSnapshot(self):
         return MockSkiaImage()


### PR DESCRIPTION
I'm doing a heavy pass on Chapter 11, and this PR covers the first section (on installing Skia and SDL, and porting the existing browser code over to it). Besides rephrasing a lot of things to try to make it shorter, I also made some major code changes. My main principles here are to avoid duplication and to keep things the same as last chapter when possible.

- I moved the `SDL_CreateWindow` call into `Browser`, so that it's more similar to last chapter. This requires moving the `SDL_DestroyWindow` call into `Browser` as well, in a new `handle_quit` method. I also split the discussion of the mainloop into multiple code blocks.
- Merge `to_sdl_canvas` with the `SDL_BlitSurface` call and related code. I called the combined method `commit_canvas` but perhaps we should call it `blit` or something else instead. (Chris, you will know the right terminology.) I also moved where in the text this is introduced.
- I made `draw_line`, `draw_text`, and `draw_rect` global helper functions. This allowed `DrawText` and `DrawRect` to call them directly, instead of duplicating their contents. This required passing a `surface` to each draw helper method. (See question 1 below) I also added some foreshadowing for the `Paint` object.
-  I also removed the polyline feature in `draw_polyline`, in favor of just inlining that code where we draw the back button. (See question 2 below.)
- I changed the `DrawRect` and `DrawText` commands not to store their bounds in a Skia `Rect`, just to keep things more similar to the last chapter.
- I split up the part where we port `Browser.draw` into several chunks
- To underscore that ascents are typically negative in Skia, I added a negation when describing how to access it.

Some simplifications I thought we should do, but I didn't quite know if it would work:

1. Instead of passing around the Skia `surface`, can we pass around the Skia `canvas` object? It would reduce the number of `with` blocks and related line noise, and also reduce the number of times we need to change argument names from `canvas` to `surface`. As far as I can see from the documentation and some experiments I ran, this should work fine: every time you get a `Canvas` from a `Surface` you get the same one.
2. Instead of drawing a triangle for a back button, what if we just draw a less than sign `<`? This would let us use the text helper method instead of manually drawing a polyline. We could do this in previous chapters too, which would simplify them too, but for now we can do just this one. We could also use the `DrawXXX` commands to draw the browser chrome; then we wouldn't need the helper methods at all.

Before this PR is ready I'll update the lab code and tests, but I've requested your review before I do that to parallelize.