### PR TITLE
Fix event handling map key in chapter 10

### DIFF
--- a/src/lab10.py
+++ b/src/lab10.py
@@ -127,7 +127,7 @@ class JSContext:
         self.interp.evaljs(code)
 
     def dispatch_event(self, type, elt):
-        handle = self.node_to_handle.get(elt, -1)
+        handle = self.node_to_handle.get(id(elt), -1)
         do_default = self.interp.evaljs(
             EVENT_DISPATCH_CODE, type=type, handle=handle)
         return not do_default

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -114,7 +114,7 @@ class JSContext:
             self.querySelectorAll)
         self.interp.export_function("getAttribute",
             self.getAttribute)
-        self.interp.export_function("innerHTML", self.innerHTML)
+        self.interp.export_function("innerHTML_set", self.innerHTML_set)
         self.interp.export_function("XMLHttpRequest_send",
             self.XMLHttpRequest_send)
         with open("runtime10.js") as f:
@@ -152,7 +152,7 @@ class JSContext:
         elt = self.handle_to_node[handle]
         return elt.attributes.get(attr, None)
 
-    def innerHTML(self, handle, s):
+    def innerHTML_set(self, handle, s):
         doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
         new_nodes = doc.children[0].children
         elt = self.handle_to_node[handle]

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -127,7 +127,7 @@ class JSContext:
         self.interp.evaljs(code)
 
     def dispatch_event(self, type, elt):
-        handle = self.node_to_handle.get(id(elt), -1)
+        handle = self.node_to_handle.get(elt, -1)
         do_default = self.interp.evaljs(
             EVENT_DISPATCH_CODE, type=type, handle=handle)
         return not do_default
@@ -135,7 +135,7 @@ class JSContext:
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
             handle = len(self.node_to_handle)
-            self.node_to_handle[id(elt)] = handle
+            self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt
         else:
             handle = self.node_to_handle[elt]


### PR DESCRIPTION
The key needs to be consistently using id() or not. I'm not sure why lab10 uses id() but lab9 and earlier
do not though. Do you remember?

This CL also fixes the innerHTML method to be called innerHTML_set, like runtime10.js requires.