### PR TITLE
Pass on the "Pixels" and "Stacking contexts" section of Chapter 11

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -154,7 +154,7 @@ trickier][speculative] to implement efficiently.
 [speculative]: https://developer.mozilla.org/en-US/docs/Glossary/speculative_parsing
 
 Exporting functions
-=====================
+===================
 
 Right now our browser just prints the last expression in a script; but
 in a real browser scripts must call the `console.log` function to
@@ -286,7 +286,7 @@ deal with slow user scripts.
 [rtc]: https://en.wikipedia.org/wiki/Run_to_completion_scheduling
 [webworkers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API
 
-Handling Crashes
+Handling crashes
 ================
 
 Crashes in JavaScript code are frustrating to debug. You can cause a

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -430,7 +430,7 @@ You probably already know that computer screens are a 2D array of
 pixels. Each pixel contains red, green and blue lights,[^lcd-design]
 or _color channels_, that can shine with an intensity between 0 (off)
 and 1 (fully on). By mixing red, green, and blue, which is formally
-known as the [sRGB color space][srgb], any color can be
+known as the [sRGB color space][srgb], any color in that space's _gamut_ can be
 made.[^other-spaces]
 
 [^lcd-design]: Actually, some screens contain [pixels besides red,

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -539,7 +539,7 @@ To handle this properly, browsers apply blending not to individual
 shapes but to a tree of [*stacking contexts*][stacking-context]. Each
 stacking context is rastered into a single 2D array of pixels and then
 blended into its parent stacking context. Note that to raster a
-stacking context you first need to raster in and child stacking
+stacking context you first need to raster it *and* its child stacking
 contexts, so they can be blended into the stacking context. In other
 words, rastering a web page requires a bottom-up traversal of the tree
 of stacking contexts.

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -23,22 +23,25 @@ fast visual effects routines is fun, but it's outside the scope of
 this book, so we need a new graphics library. Let's use [Skia][skia],
 the library that Chromium uses. Unlike Tkinter, Skia doesn't handle
 inputs or create graphical windows, so we'll pair it with the
-[SDL][sdl] GUI library.
+[SDL][sdl] GUI library. We'll also add the [Pillow][pillow] library
+for handling images.
 
 [skia]: https://skia.org
 [sdl]: https://www.libsdl.org/
+[pillow]: https://python-pillow.org
 
 [^tkinter-before-gpu]: That's because Tk, the graphics library that
 Tkinter uses, dates from the early 90s, before high-performance
 graphics cards and GPUs became widespread.
 
-Start by installing [Skia's][skia-python] and [SDL's][sdl-python]
-Python bindings like so:
+Start by installing [Pillow][install-pillow] and [Skia's][skia-python]
+and [SDL's][sdl-python] Python bindings like so:
 
-    pip3 install skia-python pysdl2 pysdl2-dll
+    pip3 install skia-python pysdl2 pysdl2-dll pillow
 
 [skia-python]: https://github.com/kyamagu/skia-python
 [sdl-python]: https://pypi.org/project/PySDL2/
+[install-pillow]: https://pillow.readthedocs.io/en/stable/installation.html
 
 ::: {.install}
 As elsewhere in this book, you may need to use `pip`, `easy_install`,
@@ -46,8 +49,9 @@ or `python3 -m pip` instead of `pip3` as your installer, or use your
 IDE's package installer. If you're on Linux, you'll need to install
 additional dependencies, like OpenGL and fontconfig. Also, you may not be
 able to install `pysdl2-dll`; you'll need to find SDL in your system
-package manager instead. Consult the [`skia-python`][skia-python] and
-[`pysdl2`][sdl-python] web pages for more details.
+package manager instead. Consult the [`pillow`][install-pillow],
+[`skia-python`][skia-python], and [`pysdl2`][sdl-python] web pages for
+more details.
 :::
 
 Once installed, remove `tkinter` from your Python imports and replace them with:
@@ -56,6 +60,7 @@ Once installed, remove `tkinter` from your Python imports and replace them with:
 import ctypes
 import sdl2
 import skia
+import PIL.Image
 ```
 
 If any of these imports fail, you probably need to check that Skia and
@@ -1743,16 +1748,6 @@ memory than the encoded representation. For a web page with a lot
 of images, it's easy to accidentally use up too much memory unless you're very
 careful.
 
-Skia doesn't come with image decoders built-in. In Python, the Pillow library is
-a convenient way to decode images.
-
-::: {.installation}
-`pip3 install Pillow` should install Pillow. See [here][install-pillow] for
-more details.
-:::
-
-[install-pillow]: https://pillow.readthedocs.io/en/stable/installation.html
-
 Here's how to load, decode and convert images into a `skia.Image` object.
 Note that there are two `Image` classes, which is a little confusing.
 The Pillow `Image` class's role is to decode the image, and the Skia `Image`
@@ -1769,7 +1764,7 @@ def get_image(image_url, base_url):
         resolve_url(image_url, base_url), base_url)
     picture_stream = io.BytesIO(body_bytes)
 
-    pil_image = Image.open(picture_stream)
+    pil_image = PIL.Image.open(picture_stream)
     if pil_image.mode == "RGBA":
         pil_image_bytes = pil_image.tobytes()
     else:

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -467,7 +467,7 @@ color of the top shape. But now we need more nuance.
 
 Many objects in nature are partially transparent: frosted glass,
 clouds, or colored paper, for example. Looking through one, you see
-two colors *blended* together. That's also why computer screens work:
+multiple colors *blended* together. That's also why computer screens work:
 the red, green, and blue lights [blend together][mixing] and appear to
 our eyes as another color. Designers use this effect[^mostly-models]
 in overlays, shadows, and tooltips, so our browser needs to support

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -482,7 +482,7 @@ difficult, or perhaps impossible, in real-world physics.
 
 The most important type of color mixing is transparency. Skia, SDL,
 and many other color libraries account for transparency with a fourth
-channel *alpha*.[^alpha-history] An alpha of 0 means the pixel is
+*alpha* channel.[^alpha-history] An alpha of 0 means the pixel is
 fully transparent (meaning, no matter what the colors are, you can't
 see them anyway), and an alpha of 1 means a fully opaque like the ones
 we've been working with so far. When a pixel with alpha overlaps

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -451,7 +451,7 @@ made.[^other-spaces]
 [^other-spaces]: The sRGB color space dates back to [CRT
 displays][CRT]. New technologies like LCD, LED, and OLED can display
 more colors, so CSS now includes [new syntax][color-spec] for
-expressing these new colors.
+expressing these new colors. All color spaces have a limited gamut of expressible colors.
 
 The job of a rasterization library is to determine the red, green, and
 blue intensity of each pixel on the screen, based on the

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -562,7 +562,8 @@ mistake.[^also-containing-block] The reason is that inside a modern
 browser, scrolling is done on the GPU by offsetting two surfaces.
 Without a stacking context the browser might (depending on the web
 page structure) have to move around multiple independent surfaces with
-complex paint orders, in lockstep, to achieve scrolling.
+complex paint orders, in lockstep, to achieve scrolling. Fixed- and sticky-positioned elements also form a stacking
+context because of their interaction with scrolling.
 :::
 
 [^also-containing-block]: While we're at it, perhaps scrollable

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -10,10 +10,10 @@ import io
 import math
 import sdl2
 import skia
+import PIL.Image
 import socket
 import ssl
 import urllib.parse
-from PIL import Image
 from lab4 import print_tree
 from lab4 import Element
 from lab4 import Text

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -851,7 +851,7 @@ def get_image(image_url, base_url):
         resolve_url(image_url, base_url), base_url)
     picture_stream = io.BytesIO(body_bytes)
 
-    pil_image = Image.open(picture_stream)
+    pil_image = PIL.Image.open(picture_stream)
     if pil_image.mode == "RGBA":
         pil_image_bytes = pil_image.tobytes()
     else:


### PR DESCRIPTION
This PR does a pass over the "Pixels, colors, raster" section of Chapter 11. This was pretty slow-going because there's a lot of content here! I mostly tried to compress things, but I also split this section into two, with pixels, color, and alpha in one and stacking contexts in the other. I also expanded the content on color perception into a "Go Further" block.