### PR TITLE
Remove non-essential features

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -578,8 +578,6 @@ complicated to handle in real browsers.
 Surfaces and canvases
 =====================
 
-<a name="surfaces-canvases"></a>
-
 The 2D pixel array for a group is called a *surface*.[^or-texture] Conceptually,
 each layout object will now have its own surface,[^more-than-one] and perform a
 blending operation when being drawn into the surface for its parent.
@@ -1201,7 +1199,7 @@ For this, we'll need new `Save` and `Restore` display list
 commands. [^refer-back-save]
 
 [^refer-back-save]: Recall from the [Surfaces and canvases]
-[#surfaces-canvases] section the difference between `Save` and `SaveLayer`.
+[#surfaces-and-canvases] section the difference between `Save` and `SaveLayer`.
 
 ``` {.python}
 class Save:

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -575,7 +575,7 @@ complicated to handle in real browsers.
 
 [containing-block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block
 
-Surfaces and Canvases
+Surfaces and canvases
 =====================
 
 <a name="surfaces-canvases"></a>
@@ -1200,7 +1200,7 @@ def paint_visual_effects(node, display_list, rect):
 For this, we'll need new `Save` and `Restore` display list
 commands. [^refer-back-save]
 
-[^refer-back-save]: Recall from the [Surfaces and Canvases]
+[^refer-back-save]: Recall from the [Surfaces and canvases]
 [#surfaces-canvases] section the difference between `Save` and `SaveLayer`.
 
 ``` {.python}

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -12,75 +12,7 @@ test the bitmap outputs directly, but instead the display lists generated.
     >>> styles = 'http://test.test/styles.css'
     >>> test.socket.respond(styles, b"HTTP/1.0 200 OK\r\n" +
     ... b"content-type: text/css\r\n\r\n" +
-    ... b"div { background-color:blue; width:50px; height:50px}")
-
-Elements can override their size...
-
-    >>> size_url = 'http://test.test/size'
-    >>> test.socket.respond(size_url, b"HTTP/1.0 200 OK\r\n" +
-    ... b"content-type: text/html\r\n\r\n" +
-    ... b"<link rel=stylesheet href='styles.css'>" +
-    ... b"<div><div>Text</div></div>)")
-
-    >>> browser = lab11.Browser()
-    >>> browser.load(size_url)
-    >>> browser.skia_surface.printTabCommands()
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
-
-Images can be specified as backgrounds. The test image below is a 1x1 solid
-color.
-
-    >>> image_url = 'http://test.test/image.png'
-    >>> test.socket.respond(image_url, b"HTTP/1.0 200 OK\r\n" +
-    ... b"content-type: image/png\r\n\r\n" +
-    ... b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00"
-    ... b"\x01\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x01sRGB\x00\xae\xce"
-    ... b"\x1c\xe9\x00\x00\x00\x0cIDAT\x18Wcx\xf7u+\x00\x05m\x02\x99\x8a'"
-    ... b"\x9d\x1d\x00\x00\x00\x00IEND\xaeB`\x82")
-
-    >>> size_and_image_url = 'http://test.test/size_and_image'
-    >>> test.socket.respond(size_and_image_url, b"HTTP/1.0 200 OK\r\n" +
-    ... b"content-type: text/html\r\n\r\n" +
-    ... b"<link rel=stylesheet href='styles.css'>" +
-    ... b"<div style=\"background-image:url('image.png')\"><div>Text</div></div>)")
-
-    >>> browser = lab11.Browser()
-    >>> browser.load(size_and_image_url)
-    >>> browser.skia_surface.printTabCommands()
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    save()
-    clipRect(rect=Rect(13, 118, 63, 168))
-    drawImage(<image>, left=13.0, top=118.0
-    restore()
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
-
-Specifying `background-size: contain`is supported.
-
-    >>> size_and_image_and_size_url = 'http://test.test/size_and_image_and_size'
-    >>> test.socket.respond(size_and_image_and_size_url, b"HTTP/1.0 200 OK\r\n" +
-    ... b"content-type: text/html\r\n\r\n" +
-    ... b"<link rel=stylesheet href='styles.css'>" +
-    ... b"<div style=\"background-image:url('image.png');background-size:contain\"><div>Text</div></div>)")
-
-    >>> browser = lab11.Browser()
-    >>> browser.load(size_and_image_and_size_url)
-    >>> browser.skia_surface.printTabCommands()
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawImageRect(<image>, src=Rect(0, 0, 1, 1), dst=Rect(13, 118, 63, 168)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
-
-Also note that urls can be non-relative. Since non-relative urls start with
-"http://" or "https://", we needed some extra logic in the CSS parser to avoid
-getting confused and thinking the colon is a property-value delimiter. Let's
-test that that works:
-
-    >>> lab11.CSSParser(
-    ...    "div { background-image:url('http://test.com/test.png') }").parse()
-    [(TagSelector(tag=div, priority=1), {'background-image': "url('http://test.com/test.png')"})]
+    ... b"div { background-color:blue}")
 
 Opacity can be applied.
 
@@ -94,8 +26,8 @@ Opacity can be applied.
     >>> browser.load(size_and_opacity_url)
     >>> browser.skia_surface.printTabCommands()
     saveLayer(color=80000000, alpha=128)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
     restore()
 
@@ -112,15 +44,15 @@ So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
     >>> browser.load(size_and_mix_blend_mode_url)
     >>> browser.skia_surface.printTabCommands()
     saveLayer(color=ff000000, blend_mode=BlendMode.kMultiply)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawString(text=Mult, x=13.0, y=136.10546875, color=ff000000)
     restore()
-    drawString(text=), x=13.0, y=186.10546875, color=ff000000)
+    drawString(text=), x=13.0, y=158.44921875, color=ff000000)
     saveLayer(color=ff000000, blend_mode=BlendMode.kDifference)
-    drawRect(rect=Rect(13, 190.344, 63, 240.344), color=ff0000ff)
-    drawRect(rect=Rect(13, 190.344, 63, 240.344), color=ff0000ff)
-    drawString(text=Diff, x=13.0, y=208.44921875, color=ff000000)
+    drawRect(rect=Rect(13, 162.688, 787, 185.031), color=ff0000ff)
+    drawRect(rect=Rect(13, 162.688, 787, 185.031), color=ff0000ff)
+    drawString(text=Diff, x=13.0, y=180.79296875, color=ff000000)
     restore()
 
 Non-rectangular clips via `clip-path:circle` are supported.
@@ -139,11 +71,11 @@ make a canvas in which to draw the circular clip mask.
     >>> browser.load(size_and_clip_path_url)
     >>> browser.skia_surface.printTabCommands()
     saveLayer(color=ff000000)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawString(text=Clip, x=13.0, y=136.10546875, color=ff000000)
     saveLayer(color=ff000000, blend_mode=BlendMode.kDstIn)
-    drawCircle(cx=38.0, cy=143.0, radius=20.0, color=ffffffff)
+    drawCircle(cx=400.0, cy=129.171875, radius=219.0114596388166, color=ffffffff)
     restore()
     restore()
 
@@ -163,66 +95,10 @@ radius equal to the `20px` radius specified above.
     >>> browser.load(size_and_border_radius_url)
     >>> browser.skia_surface.printTabCommands()
     save()
-    clipRRect(bounds=Rect(13, 118, 63, 168), radius=Point(20, 20))
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
+    clipRRect(bounds=Rect(13, 118, 787, 140.344), radius=Point(11.1719, 11.1719))
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
+    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawString(text=Border-radius, x=13.0, y=136.10546875, color=ff000000)
-    restore()
-
-Finally, there are transforms--translation and 3D rotation. Let's start with 
-parsing them:
-
-    >>> lab11.parse_transform("translate(2px,3px)")
-    ((2.0, 3.0), None)
-
-    >>> lab11.parse_transform("rotate(30deg)")
-    (None, 30.0)
-
-    >>> lab11.parse_transform("Nonsense")
-    (None, None)
-
-For 2D rotation, there is as translate to adjust for
-transform origin, then the rotation, then a reverse translation to go from
-the transform origin back to the original origin.
-
-    >>> size_and_rotate_url = 'http://test.test/size_and_transform'
-    >>> test.socket.respond(size_and_rotate_url, b"HTTP/1.0 200 OK\r\n" +
-    ... b"content-type: text/html\r\n\r\n" +
-    ... b"<link rel=stylesheet href='styles.css'>" +
-    ... b"<div style=\"transform:rotate(45deg)\"><div>Rotate</div></div>)")
-
-Note that the negative transform-origin translation happens last, not first,
-because transform matrices get applied in backwards order when rendering to 
-the screen.
-
-    >>> browser = lab11.Browser()
-    >>> browser.load(size_and_rotate_url)
-    >>> browser.skia_surface.printTabCommands()
-    save()
-    translate(x=38.0, y=143.0)
-    rotate(degrees=45.0)
-    translate(x=-38.0, y=-143.0)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawString(text=Rotate, x=13.0, y=136.10546875, color=ff000000)
-    restore()
-
-For translation transforms, on the other hand, there is need to adjust for the
-origin.
-
-    >>> size_and_translate_url = 'http://test.test/size_and_translate'
-    >>> test.socket.respond(size_and_translate_url, b"HTTP/1.0 200 OK\r\n" +
-    ... b"content-type: text/html\r\n\r\n" +
-    ... b"<link rel=stylesheet href='styles.css'>" +
-    ... b"<div style=\"transform:translate(5px,6px)\"><div>Rotate</div></div>)")
-    >>> browser = lab11.Browser()
-    >>> browser.load(size_and_translate_url)
-    >>> browser.skia_surface.printTabCommands()
-    save()
-    translate(x=5.0, y=6.0)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 63, 168), color=ff0000ff)
-    drawString(text=Rotate, x=13.0, y=136.10546875, color=ff000000)
     restore()
 
 Now let's test the example compositing and blend mode functions.


### PR DESCRIPTION
This PR moves transform and size to exercises. They increase the length of the chapter, and don't add enough value to the core concepts.

It also removes background images, since they are unconnected to the core concepts. I think it would make sense to put it in a future chapter on replaced elements: images, video and iframes.


