### PR TITLE
Browser compositor

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1344,23 +1344,22 @@ bounds.
 ``` {.python}
 class Browser:
     def draw(self):
-        with self.root_surface as root_canvas:
-            root_canvas = self.root_surface.getCanvas()
-            root_canvas.clear(skia.ColorWHITE)
-            
-            root_canvas.save()
-            root_canvas.clipRect(skia.Rect.MakeLTRB(
-                0, CHROME_PX, WIDTH, HEIGHT))
-            root_canvas.translate(
-                0, CHROME_PX- self.tabs[self.active_tab].scroll)
-            self.tab_surface.draw(root_canvas, 0, 0)
-            root_canvas.restore()
+        root_canvas = self.root_surface.getCanvas()
+        root_canvas.clear(skia.ColorWHITE)
+        
+        root_canvas.save()
+        root_canvas.clipRect(skia.Rect.MakeLTRB(
+            0, CHROME_PX, WIDTH, HEIGHT))
+        root_canvas.translate(
+            0, CHROME_PX- self.tabs[self.active_tab].scroll)
+        self.tab_surface.draw(root_canvas, 0, 0)
+        root_canvas.restore()
 
-            root_canvas.save()
-            root_canvas.clipRect(skia.Rect.MakeLTRB(
-                0, 0, WIDTH, CHROME_PX))
-            self.chrome_surface.draw(root_canvas, 0, 0)
-            root_canvas.restore()
+        root_canvas.save()
+        root_canvas.clipRect(skia.Rect.MakeLTRB(
+            0, 0, WIDTH, CHROME_PX))
+        self.chrome_surface.draw(root_canvas, 0, 0)
+        root_canvas.restore()
 
         # Copy the results to the SDL surface:
         # ...
@@ -1393,9 +1392,9 @@ class Browser:
                 math.ceil(tab_bounds.right()),
                 math.ceil(tab_bounds.bottom()))
 
-        with self.tab_surface as tab_canvas:
-            tab_canvas.clear(skia.ColorWHITE)
-            active_tab.raster(tab_canvas)
+        tab_canvas = self.tab_surface.getCanvas()
+        tab_canvas.clear(skia.ColorWHITE)
+        active_tab.raster(tab_canvas)
 
         self.raster_browser_chrome()
 

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -25,11 +25,13 @@ Opacity can be applied.
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_opacity_url)
     >>> browser.tab_surface.printTabCommands()
+    clear(color=ffffffff)
     saveLayer(color=80000000, alpha=128)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawString(text=Text, x=13.0, y=136.10546875, color=ff000000)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawString(text=Text, x=13.0, y=36.10546875, color=ff000000)
     restore()
+    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
 
 So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
 
@@ -43,17 +45,19 @@ So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_mix_blend_mode_url)
     >>> browser.tab_surface.printTabCommands()
+    clear(color=ffffffff)
     saveLayer(color=ff000000, blend_mode=BlendMode.kMultiply)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawString(text=Mult, x=13.0, y=136.10546875, color=ff000000)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawString(text=Mult, x=13.0, y=36.10546875, color=ff000000)
     restore()
-    drawString(text=), x=13.0, y=158.44921875, color=ff000000)
+    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
     saveLayer(color=ff000000, blend_mode=BlendMode.kDifference)
-    drawRect(rect=Rect(13, 162.688, 787, 185.031), color=ff0000ff)
-    drawRect(rect=Rect(13, 162.688, 787, 185.031), color=ff0000ff)
-    drawString(text=Diff, x=13.0, y=180.79296875, color=ff000000)
+    drawRect(rect=Rect(13, 62.6875, 787, 85.0312), color=ff0000ff)
+    drawRect(rect=Rect(13, 62.6875, 787, 85.0312), color=ff0000ff)
+    drawString(text=Diff, x=13.0, y=80.79296875, color=ff000000)
     restore()
+    drawString(text=), x=13.0, y=103.13671875, color=ff000000)
 
 Non-rectangular clips via `clip-path:circle` are supported.
 
@@ -70,14 +74,16 @@ make a canvas in which to draw the circular clip mask.
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_clip_path_url)
     >>> browser.tab_surface.printTabCommands()
+    clear(color=ffffffff)
     saveLayer(color=ff000000)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawString(text=Clip, x=13.0, y=136.10546875, color=ff000000)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawString(text=Clip, x=13.0, y=36.10546875, color=ff000000)
     saveLayer(color=ff000000, blend_mode=BlendMode.kDstIn)
-    drawCircle(cx=400.0, cy=129.171875, radius=219.0114596388166, color=ffffffff)
+    drawCircle(cx=400.0, cy=29.171875, radius=219.0114596388166, color=ffffffff)
     restore()
     restore()
+    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
 
 `border-radius` clipping is also supported.
 
@@ -94,12 +100,14 @@ radius equal to the `20px` radius specified above.
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_border_radius_url)
     >>> browser.tab_surface.printTabCommands()
+    clear(color=ffffffff)
     save()
-    clipRRect(bounds=Rect(13, 118, 787, 140.344), radius=Point(11.1719, 11.1719))
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
-    drawString(text=Border-radius, x=13.0, y=136.10546875, color=ff000000)
+    clipRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(11.1719, 11.1719))
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawRect(rect=Rect(13, 18, 787, 40.3438), color=ff0000ff)
+    drawString(text=Border-radius, x=13.0, y=36.10546875, color=ff000000)
     restore()
+    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
 
 Now let's test the example compositing and blend mode functions.
 

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -24,7 +24,7 @@ Opacity can be applied.
 
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_opacity_url)
-    >>> browser.skia_surface.printTabCommands()
+    >>> browser.tab_surface.printTabCommands()
     saveLayer(color=80000000, alpha=128)
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
@@ -42,7 +42,7 @@ So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
 
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_mix_blend_mode_url)
-    >>> browser.skia_surface.printTabCommands()
+    >>> browser.tab_surface.printTabCommands()
     saveLayer(color=ff000000, blend_mode=BlendMode.kMultiply)
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
@@ -69,7 +69,7 @@ make a canvas in which to draw the circular clip mask.
 
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_clip_path_url)
-    >>> browser.skia_surface.printTabCommands()
+    >>> browser.tab_surface.printTabCommands()
     saveLayer(color=ff000000)
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)
@@ -93,7 +93,7 @@ radius equal to the `20px` radius specified above.
 
     >>> browser = lab11.Browser()
     >>> browser.load(size_and_border_radius_url)
-    >>> browser.skia_surface.printTabCommands()
+    >>> browser.tab_surface.printTabCommands()
     save()
     clipRRect(bounds=Rect(13, 118, 787, 140.344), radius=Point(11.1719, 11.1719))
     drawRect(rect=Rect(13, 118, 787, 140.344), color=ff0000ff)

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -1079,9 +1079,9 @@ class Browser:
                 math.ceil(tab_bounds.right()),
                 math.ceil(tab_bounds.bottom()))
 
-        with self.tab_surface as tab_canvas:
-            tab_canvas.clear(skia.ColorWHITE)
-            active_tab.raster(tab_canvas)
+        tab_canvas = self.tab_surface.getCanvas()
+        tab_canvas.clear(skia.ColorWHITE)
+        active_tab.raster(tab_canvas)
 
         self.raster_browser_chrome()
 

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -1123,23 +1123,23 @@ class Browser:
         canvas.drawPath(path, paint)
 
     def draw(self):
-        with self.root_surface as root_canvas:
-            root_canvas = self.root_surface.getCanvas()
-            root_canvas.clear(skia.ColorWHITE)
-            
-            root_canvas.save()
-            root_canvas.clipRect(skia.Rect.MakeLTRB(
-                0, CHROME_PX, WIDTH, HEIGHT))
-            root_canvas.translate(
-                0, CHROME_PX- self.tabs[self.active_tab].scroll)
-            self.tab_surface.draw(root_canvas, 0, 0)
-            root_canvas.restore()
+        root_canvas = self.root_surface.getCanvas()
+        root_canvas = self.root_surface.getCanvas()
+        root_canvas.clear(skia.ColorWHITE)
+        
+        root_canvas.save()
+        root_canvas.clipRect(skia.Rect.MakeLTRB(
+            0, CHROME_PX, WIDTH, HEIGHT))
+        root_canvas.translate(
+            0, CHROME_PX- self.tabs[self.active_tab].scroll)
+        self.tab_surface.draw(root_canvas, 0, 0)
+        root_canvas.restore()
 
-            root_canvas.save()
-            root_canvas.clipRect(skia.Rect.MakeLTRB(
-                0, 0, WIDTH, CHROME_PX))
-            self.chrome_surface.draw(root_canvas, 0, 0)
-            root_canvas.restore()
+        root_canvas.save()
+        root_canvas.clipRect(skia.Rect.MakeLTRB(
+            0, 0, WIDTH, CHROME_PX))
+        self.chrome_surface.draw(root_canvas, 0, 0)
+        root_canvas.restore()
 
         # Copy the results to the SDL surface:
         skia_image = self.root_surface.makeImageSnapshot()

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -1076,7 +1076,8 @@ class Browser:
                 tab_bounds.bottom() != self.tab_surface.height() or \
                 tab_bounds.right() != self.tab_surface.width():
             self.tab_surface = skia.Surface(
-                math.ceil(tab_bounds.right()), math.ceil(tab_bounds.bottom()))
+                math.ceil(tab_bounds.right()),
+                math.ceil(tab_bounds.bottom()))
 
         with self.tab_surface as tab_canvas:
             tab_canvas.clear(skia.ColorWHITE)

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -1124,7 +1124,6 @@ class Browser:
 
     def draw(self):
         root_canvas = self.root_surface.getCanvas()
-        root_canvas = self.root_surface.getCanvas()
         root_canvas.clear(skia.ColorWHITE)
         
         root_canvas.save()

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -130,21 +130,21 @@ class SaveLayer:
         self.sk_paint = sk_paint
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.saveLayer(paint=self.sk_paint)
 
 class Save:
     def __init__(self, rect):
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.save()
 
 class Restore:
     def __init__(self, rect):
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.restore()
 
 class CircleMask:
@@ -154,11 +154,11 @@ class CircleMask:
         self.radius = radius
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.saveLayer(paint=skia.Paint(
             Alphaf=1.0, BlendMode=skia.kDstIn))
         canvas.drawCircle(
-            self.cx, self.cy - scroll,
+            self.cx, self.cy,
             self.radius, skia.Paint(Color=skia.ColorWHITE))
         canvas.restore()
 
@@ -172,10 +172,10 @@ class Translate:
         self.y = y
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         paint_rect = skia.Rect.MakeLTRB(
-            self.rect.left(), self.rect.top() - scroll,
-            self.rect.right(), self.rect.bottom() - scroll)
+            self.rect.left(), self.rect.top(),
+            self.rect.right(), self.rect.bottom())
         canvas.translate(self.x, self.y)
 
 class DrawText:
@@ -189,8 +189,8 @@ class DrawText:
         self.text = text
         self.color = color
 
-    def execute(self, scroll, canvas):
-        draw_text(canvas, self.left, self.top - scroll,
+    def execute(self, canvas):
+        draw_text(canvas, self.left, self.top,
             self.text, self.font)
 
     def __repr__(self):
@@ -205,10 +205,10 @@ class DrawRect:
         self.right = rect.right()
         self.color = color
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         draw_rect(canvas,
-            self.left, self.top - scroll,
-            self.right, self.bottom - scroll,
+            self.left, self.top,
+            self.right, self.bottom,
             fill=self.color, width=0)
 
     def __repr__(self):
@@ -245,24 +245,24 @@ class ClipRect:
     def __init__(self, rect):
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.clipRect(skia.Rect.MakeLTRB(
-            self.rect.left(), self.rect.top() - scroll,
-            self.rect.right(), self.rect.bottom() - scroll))
+            self.rect.left(), self.rect.top(),
+            self.rect.right(), self.rect.bottom()))
 
 class ClipRRect:
     def __init__(self, rect, radius):
         self.rect = rect
         self.radius = radius
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.clipRRect(
             skia.RRect.MakeRectXY(
                 skia.Rect.MakeLTRB(
                     self.rect.left(),
-                    self.rect.top() - scroll,
+                    self.rect.top(),
                     self.rect.right(),
-                    self.rect.bottom() - scroll),
+                    self.rect.bottom()),
                 self.radius, self.radius))
 
 class DrawImage:
@@ -270,23 +270,23 @@ class DrawImage:
         self.image = image
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         canvas.drawImage(
             self.image, self.rect.left(),
-            self.rect.top() - scroll)
+            self.rect.top())
 
 class DrawImageRect:
     def __init__(self, image, rect):
         self.image = image
         self.rect = rect
 
-    def execute(self, scroll, canvas):
+    def execute(self, canvas):
         source_rect = skia.Rect.Make(self.image.bounds())
         dest_rect = skia.Rect.MakeLTRB(
             self.rect.left(),
-            self.rect.top() - scroll,
+            self.rect.top(),
             self.rect.right(),
-            self.rect.bottom() - scroll)
+            self.rect.bottom())
         canvas.drawImageRect(
             self.image, source_rect, dest_rect)
 
@@ -848,6 +848,7 @@ class Tab:
         self.history = []
         self.focus = None
         self.url = None
+        self.scroll = 0
 
         with open("browser8.css") as f:
             self.default_style_sheet = CSSParser(f.read()).parse()
@@ -924,19 +925,23 @@ class Tab:
         self.display_list = []
         self.document.paint(self.display_list)
 
-    def draw(self, canvas):
+    def raster(self, canvas):
         for cmd in self.display_list:
-            if cmd.rect.top() > self.scroll + HEIGHT - CHROME_PX: continue
-            if cmd.rect.bottom() < self.scroll: continue
-            cmd.execute(self.scroll - CHROME_PX, canvas)
+            cmd.execute(canvas)
 
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
                    if obj.node == self.focus][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measureText(text)
-            y = obj.y - self.scroll + CHROME_PX
+            y = obj.y
             draw_line(canvas, x, y, x, y + obj.height)
+
+    def display_list_bounds(self):
+        bounds = skia.Rect()
+        for cmd in self.display_list:
+            bounds.join(cmd.rect)
+        return bounds
 
     def scrolldown(self):
         max_y = self.document.height - HEIGHT
@@ -1007,7 +1012,9 @@ class Browser:
         self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
             sdl2.SDL_WINDOWPOS_CENTERED, sdl2.SDL_WINDOWPOS_CENTERED,
             WIDTH, HEIGHT, sdl2.SDL_WINDOW_SHOWN)
-        self.skia_surface = skia.Surface(WIDTH, HEIGHT)
+        self.root_surface = skia.Surface(WIDTH, HEIGHT)
+        self.chrome_surface = skia.Surface(WIDTH, HEIGHT)
+        self.tab_surface = None
 
         self.tabs = []
         self.active_tab = None
@@ -1055,13 +1062,31 @@ class Browser:
         new_tab.load(url)
         self.active_tab = len(self.tabs)
         self.tabs.append(new_tab)
+        self.raster()
         self.draw()
 
-    def draw(self):
-        canvas = self.skia_surface.getCanvas()
-        canvas.clear(skia.ColorWHITE)
+    def raster(self):
+        active_tab = self.tabs[self.active_tab]
 
-        self.tabs[self.active_tab].draw(canvas)
+        # Re-allocate the tab surface if its size changes.
+        tab_bounds = active_tab.display_list_bounds()
+        assert tab_bounds.top() >= 0
+        assert tab_bounds.left() >= 0
+        if not self.tab_surface or \
+                tab_bounds.bottom() != self.tab_surface.height() or \
+                tab_bounds.right() != self.tab_surface.width():
+            self.tab_surface = skia.Surface(
+                math.ceil(tab_bounds.right()), math.ceil(tab_bounds.bottom()))
+
+        with self.tab_surface as tab_canvas:
+            tab_canvas.clear(skia.ColorWHITE)
+            active_tab.raster(tab_canvas)
+
+        self.raster_browser_chrome()
+
+    def raster_browser_chrome(self):
+        canvas = self.chrome_surface.getCanvas()
+        canvas.clear(skia.ColorWHITE)
     
         # Draw the tabs UI:
         tabfont = skia.Font(skia.Typeface('Arial'), 20)
@@ -1096,11 +1121,27 @@ class Browser:
         paint = skia.Paint(Color=skia.ColorBLACK, Style=skia.Paint.kFill_Style)
         canvas.drawPath(path, paint)
 
-        self.draw_to_screen()
+    def draw(self):
+        with self.root_surface as root_canvas:
+            root_canvas = self.root_surface.getCanvas()
+            root_canvas.clear(skia.ColorWHITE)
+            
+            root_canvas.save()
+            root_canvas.clipRect(skia.Rect.MakeLTRB(
+                0, CHROME_PX, WIDTH, HEIGHT))
+            root_canvas.translate(
+                0, CHROME_PX- self.tabs[self.active_tab].scroll)
+            self.tab_surface.draw(root_canvas, 0, 0)
+            root_canvas.restore()
 
-    def draw_to_screen(self):
-        # Raster the results and copy to the SDL surface:
-        skia_image = self.skia_surface.makeImageSnapshot()
+            root_canvas.save()
+            root_canvas.clipRect(skia.Rect.MakeLTRB(
+                0, 0, WIDTH, CHROME_PX))
+            self.chrome_surface.draw(root_canvas, 0, 0)
+            root_canvas.restore()
+
+        # Copy the results to the SDL surface:
+        skia_image = self.root_surface.makeImageSnapshot()
         skia_bytes = skia_image.tobytes()
         rect = sdl2.SDL_Rect(0, 0, WIDTH, HEIGHT)
 

--- a/src/test11.py
+++ b/src/test11.py
@@ -215,10 +215,10 @@ class MockSkiaSurface:
         count = 0
         total = len(self.canvas.commands)
         for command in self.canvas.commands:
-            if count == total - 12:
-                break
-            if count > 0:
-                print(command)
+            print(command)
             count = count + 1
+
+    def draw(self, canvas, x, y):
+        pass
 
 skia.Surface = MockSkiaSurface


### PR DESCRIPTION
This PR adds:

* A new section about browser compositing, with how to use it to separate browser chrome from web contents
* Accompanying implementation that uses three surfaces, and stops baking scroll offsets and browser chrome offsets into the display lists