### PR TITLE
Pass over "Summary", "Outline", and "Exercises" in Chapter 11

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1676,14 +1676,18 @@ are almost endless.
 Summary
 =======
 
-So there you have it. Now we don't have just a boring browser that can only
-draw simple input boxes plus text. It now supports:
+So there you have it: our browser can draw not only boring
+black-on-white text but also:
 
-* Opacity
-* Blending
-* Rounded-corner clips via destination-in blending or direct clipping
-* Surfaces for scrolling and animations
-* Optimizations to avoid surfaces
+- Partial transparency via an alpha channel
+- User-configurable blending modes via `mix-blend-mode`
+- Rounded rectangle clipping via destination-in blending or direct clipping
+- Optimizations to avoid surfaces when possible
+- Surfaces for scrolling and animations
+
+Besides the new features, we've upgraded from Tkinter to SDL and Skia,
+which makes our browser faster and more responsive and sets a
+foundation for more work on browser performance to come.
 
 ::: {.further}
 [This blog post](https://ciechanow.ski/alpha-compositing/) gives a really nice
@@ -1692,6 +1696,17 @@ plus way more content about how a library such as Skia might implement features
 like raster sampling of vector graphics for lines and text, and interpolation
 of surfaces when their pixel arrays don't match resolution or orientation. I
 highly recommend it.
+:::
+
+
+Outline
+=======
+
+The complete set of functions, classes, and methods in our browser 
+should now look something like this:
+
+::: {.cmd .python .outline html=True}
+    python3 infra/outlines.py --html src/lab11.py
 :::
 
 

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1709,74 +1709,54 @@ should now look something like this:
     python3 infra/outlines.py --html src/lab11.py
 :::
 
-
 Exercises
 =========
 
-*z-index*: Right now, the order of paint is a depth-first traversal of the
- layout tree. By using the `z-index` CSS property, pages can change that order.
- An element with lower `z-index` than another one paints before it. Elements
- with the same z-index paint in depth-first order. Elements with no `z-index`
- specified paint at the same time as z-index 0. And lastly, `z-index` only
- applies to elements that have a `position` value other than the default
- (meaning `relative`, for our browser's partial implementation). Implement this
- CSS property. You don't need to add support for nested z-index (an element
-with z-index that has an ancestor also witih z-index), unless you do the next
-exercise also.
-
-*Z-order stacking contexts*: (this exercise builds on z-index) A
-stacking context is a painting feature allowing^[Or
-forcing, depending on your perspective...] web pages to specify groups of
-elements that paint contiguously. Because they paint continguously, it won't
-be possible for `z-index` specified on other elements not in the group to
-paint somewhere within the group---only before the entire group or after it.
-An element induces a stacking context if one or more of the conditions listed
-[here][stacking-context] apply to it. Any descendants (up to stacking
-context-inducing descendants) with `z-index` have paint order relative to each 
-other, but not elements not in the stacking context. The stacking
-context-inducing element itself may have a `z-index`, but that only changes
-the paint order of the whole stacking context relative to other contributors to
-its parent stacking context.
-
-(Note: in addition, the true paint order for stacking contexts is quite
-[elaborate][elaborate]. You don't need to implement all those details.)
-
- [stacking-context]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-
- [elaborate]: https://www.w3.org/TR/CSS2/zindex.html
-
-*Filters*: The `filter` CSS property allows specifying various kinds of more
- [complex effects][filter-css], such as grayscale or blur. Try to implement as
- many of these as you can. A number of them (including blur and drop shadow)
- have built-in support in Skia.
-
-*Width and height*: Add support for setting the [width][width-css] and
-[height][height-css] of block elements. This should be a straightforward
-modification of the `layout` method to override the `width` and `height`
-properties on a `LayoutBlock`.
-
-[width-css]: https://developer.mozilla.org/en-US/docs/Web/CSS/width
-
-[height-css]: https://developer.mozilla.org/en-US/docs/Web/CSS/height
-
-[filter-css]: https://developer.mozilla.org/en-US/docs/Web/CSS/filter
-
-*Overflow scrolling*: (this exercise builds on overflow clipping) Implement a
- very basic version of the `scroll` value of the `overflow` CSS property.
- You'll need to have a way to actually process input to cause scrolling, and
- also keep track of the total height (and width, for horizontal scrolling) of
- the [*layout overflow*][overflow-doc]. (Hint: one way to allow the user to
- scroll is to use built-in arrow key handlers that apply when the
- `overflow:scroll` element has focus.)
-
- [overflow-doc]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow
-
-*CSS transforms*: Add support for the 2D transforms of content, via the
- [transform][transform-css] CSS property.[^3d] Scrolling can be seen as a
- special case of transform, and adding support is relatively straightforward.
+*CSS transforms*: Add support for the [transform][transform-css] CSS
+property, specifically the `translate` and `rotate` transforms.[^3d]
+Skia has built-in support for these via canvas state.
 
 [transform-css]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
 
 [^3d]: There is a lot more complexity to 3D transforms
 having to do with the definition of 3D spaces, flatting, backfaces, and plane
 intersections.
+
+*Filters*: The `filter` CSS property allows specifying various kinds
+of more [complex effects][filter-css], such as grayscale or blur.
+These are fun to implement, and a number of them have built-in support
+in Skia. Implement, for example, the `blur` filter. Think carefully
+about when filters occur, relative to other effects like transparency,
+clipping, and blending.
+
+[filter-css]: https://developer.mozilla.org/en-US/docs/Web/CSS/filter
+
+*Hit testing*: If you have an element with a `border-radius`, it's
+possible to click outside the element but inside its containing
+rectangle, by clicking in the part of the corner that is "rounded
+off". This shouldn't result in clicking on the element, but in our
+browser it currently does. Modify the `click` method to take border
+radii into account.
+
+*Interest region*: Our browser now draws the whole web page to a
+single surface, and then shows parts of that surface as the user
+scrolls. That means a very long web page (like this one!) can create a
+large surface, thereby using a lot of memory. Modify the browser so
+that the size of that surface is limited, say to `4 * HEIGHT` rows.
+The (limited) region of the page drawn to this surface is called the
+interest region; you'll need to track what part of the interest region
+is being shown on the screen, and reraster the interest region when
+the user attempts to scroll outside of it.
+
+*Overflow scrolling*: An element with the `overflow` property set to
+`scroll` and a fixed pixel `height` is scrollable. (You'll want to
+implement the width/height exercise from [Chapter
+6](styles.md#exercises) so that `height` is supported.) Implement some
+version of `overflow: scroll`. I recommend the following user
+interaction: the user clicks within a scrollable element to focus it,
+and then can press the arrow keys to scroll up and down. You'll need
+to keep track of the *[layout overflow][overflow-doc]*. For an extra
+challenge, make sure you support scrollable elements nested within
+other scrollable elements.
+
+ [overflow-doc]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1677,7 +1677,7 @@ Summary
 =======
 
 So there you have it: our browser can draw not only boring
-black-on-white text but also:
+text and boxes but also:
 
 - Partial transparency via an alpha channel
 - User-configurable blending modes via `mix-blend-mode`
@@ -1686,7 +1686,7 @@ black-on-white text but also:
 - Surfaces for scrolling and animations
 
 Besides the new features, we've upgraded from Tkinter to SDL and Skia,
-which makes our browser faster and more responsive and sets a
+which makes our browser faster and more responsive, and also sets a
 foundation for more work on browser performance to come.
 
 ::: {.further}
@@ -1747,6 +1747,23 @@ The (limited) region of the page drawn to this surface is called the
 interest region; you'll need to track what part of the interest region
 is being shown on the screen, and reraster the interest region when
 the user attempts to scroll outside of it.
+
+*Z-index*: Right now, elements later in the HTML document are drawn
+"on top" of earlier ones. The `z-index` CSS property changes that
+order: an element with the larger `z-index` draws on top (with ties
+broken by the current order, and with the default `z-index` being 0).
+For `z-index` to have any effect, the element's `position` property
+must be set to something other than `static` (the default). Add
+support for `z-index`. One thing you'll run into is that with our
+browser's minimal layout features, you might not be able to *create*
+any overlapping elements to test this feature! However, lots of
+exercises throughout the book allow you to create overlapping
+elements, including `transform` and `width`/`height`. For an extra
+challenge, add support for [nested elements][stacking-context] with
+`z-index` properties.
+
+[stacking-context]:  https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+
 
 *Overflow scrolling*: An element with the `overflow` property set to
 `scroll` and a fixed pixel `height` is scrollable. (You'll want to

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -22,6 +22,7 @@ from lab6 import resolve_url
 from lab6 import style
 from lab6 import tree_to_list
 from lab6 import CSSParser
+from lab6 import TagSelector, DescendantSelector
 from lab6 import DrawText
 from lab7 import LineLayout
 from lab7 import TextLayout

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -22,78 +22,11 @@ from lab6 import layout_mode
 from lab6 import resolve_url
 from lab6 import tree_to_list
 from lab6 import INHERITED_PROPERTIES
-from lab6 import compute_style
-from lab6 import TagSelector
-from lab6 import DescendantSelector
-from lab10 import url_origin
-from lab10 import JSContext
+from lab6 import CSSParser, compute_style, style
+from lab6 import TagSelector, DescendantSelector
+from lab10 import request, url_origin, JSContext
 
 COOKIE_JAR = {}
-
-def request(url, top_level_url, payload=None):
-    scheme, url = url.split("://", 1)
-    assert scheme in ["http", "https"], \
-        "Unknown scheme {}".format(scheme)
-
-    host, path = url.split("/", 1)
-    path = "/" + path
-    port = 80 if scheme == "http" else 443
-
-    if ":" in host:
-        host, port = host.split(":", 1)
-        port = int(port)
-
-    s = socket.socket(
-        family=socket.AF_INET,
-        type=socket.SOCK_STREAM,
-        proto=socket.IPPROTO_TCP,
-    )
-    s.connect((host, port))
-
-    if scheme == "https":
-        ctx = ssl.create_default_context()
-        s = ctx.wrap_socket(s, server_hostname=host)
-
-    method = "POST" if payload else "GET"
-    body = "{} {} HTTP/1.0\r\n".format(method, path)
-    body += "Host: {}\r\n".format(host)
-    if host in COOKIE_JAR:
-        cookie, params = COOKIE_JAR[host]
-        allow_cookie = True
-        if top_level_url and params.get("samesite", "none") == "lax":
-            _, _, top_level_host, _ = top_level_url.split("/", 3)
-            allow_cookie = (host == top_level_host or method == "GET")
-        if allow_cookie:
-            body += "Cookie: {}\r\n".format(cookie)
-    if payload:
-        content_length = len(payload.encode("utf8"))
-        body += "Content-Length: {}\r\n".format(content_length)
-    body += "\r\n" + (payload or "")
-    s.send(body.encode("utf8"))
-
-    response = s.makefile("b")
-
-    statusline = response.readline().decode("utf8")
-    version, status, explanation = statusline.split(" ", 2)
-    assert status == "200", "{}: {}".format(status, explanation)
-
-    headers = {}
-    while True:
-        line = response.readline().decode("utf8")
-        if line == "\r\n": break
-        header, value = line.split(":", 1)
-        headers[header.lower()] = value.strip()
-
-    if headers.get(
-        'content-type',
-        'application/octet-stream').startswith("text"):
-        body = response.read().decode("utf8")
-    else:
-        body = response.read()
-
-    s.close()
-
-    return headers, body
 
 def get_font(size, weight, style):
     if weight == "bold":
@@ -133,12 +66,6 @@ def parse_blend_mode(blend_mode_str):
         return skia.BlendMode.kDifference
     else:
         return skia.BlendMode.kSrcOver
-
-def parse_clip_path(clip_path_str):
-    if clip_path_str.startswith("circle"):
-        return float(clip_path_str[7:][:-3])
-    else:
-        return None
 
 def linespace(font):
     metrics = font.getMetrics()
@@ -286,8 +213,7 @@ class BlockLayout:
             self.children.append(next)
             previous = next
 
-        self.width = style_length(
-            self.node, "width", self.parent.width)
+        self.width = self.parent.width
         self.x = self.parent.x
 
         if self.previous:
@@ -298,9 +224,7 @@ class BlockLayout:
         for child in self.children:
             child.layout()
 
-        self.height = style_length(
-            self.node, "height",
-            sum([child.height for child in self.children]))
+        self.height = sum([child.height for child in self.children])
 
     def paint(self, display_list):
         cmds = []
@@ -341,8 +265,7 @@ class InlineLayout:
         self.display_list = None
 
     def layout(self):
-        self.width = style_length(
-            self.node, "width", self.parent.width)
+        self.width = self.parent.width
 
         self.x = self.parent.x
 
@@ -357,9 +280,7 @@ class InlineLayout:
         for line in self.children:
             line.layout()
 
-        self.height = style_length(
-            self.node, "height",
-            sum([line.height for line in self.children]))
+        self.height = sum([line.height for line in self.children])
 
     def recurse(self, node):
         if isinstance(node, Text):
@@ -457,93 +378,6 @@ class DocumentLayout:
 
     def __repr__(self):
         return "DocumentLayout()"
-
-class CSSParser:
-    def __init__(self, s):
-        self.s = s
-        self.i = 0
-
-    def whitespace(self):
-        while self.i < len(self.s) and self.s[self.i].isspace():
-            self.i += 1
-
-    def literal(self, literal):
-        assert self.i < len(self.s) and self.s[self.i] == literal
-        self.i += 1
-
-    def word(self):
-        start = self.i
-        while self.i < len(self.s):
-            cur = self.s[self.i]
-            if cur.isalnum() or cur in "/#-.%()\"'":
-                self.i += 1
-            else:
-                break
-        assert self.i > start
-        return self.s[start:self.i]
-
-    def pair(self):
-        prop = self.word()
-        self.whitespace()
-        self.literal(":")
-        self.whitespace()
-        val = self.word()
-        return prop.lower(), val
-
-    def ignore_until(self, chars):
-        while self.i < len(self.s):
-            if self.s[self.i] in chars:
-                return self.s[self.i]
-            else:
-                self.i += 1
-
-    def body(self):
-        pairs = {}
-        while self.i < len(self.s) and self.s[self.i] != "}":
-            try:
-                prop, val = self.pair()
-                pairs[prop.lower()] = val
-                self.whitespace()
-                self.literal(";")
-                self.whitespace()
-            except AssertionError:
-                why = self.ignore_until([";", "}"])
-                if why == ";":
-                    self.literal(";")
-                    self.whitespace()
-                else:
-                    break
-        return pairs
-
-    def selector(self):
-        out = TagSelector(self.word().lower())
-        self.whitespace()
-        while self.i < len(self.s) and self.s[self.i] != "{":
-            tag = self.word()
-            descendant = TagSelector(tag.lower())
-            out = DescendantSelector(out, descendant)
-            self.whitespace()
-        return out
-
-    def parse(self):
-        rules = []
-        while self.i < len(self.s):
-            try:
-                self.whitespace()
-                selector = self.selector()
-                self.literal("{")
-                self.whitespace()
-                body = self.body()
-                self.literal("}")
-                rules.append((selector, body))
-            except AssertionError:
-                why = self.ignore_until(["}"])
-                if why == "}":
-                    self.literal("}")
-                    self.whitespace()
-                else:
-                    break
-        return rules
 
 INPUT_WIDTH_PX = 200
 
@@ -650,10 +484,8 @@ class InputLayout:
         size = float(self.node.style["font-size"][:-2])
         self.font = get_font(size, weight, style)
 
-        self.width = style_length(
-            self.node, "width", INPUT_WIDTH_PX)
-        self.height = style_length(
-            self.node, "height", linespace(self.font))
+        self.width = INPUT_WIDTH_PX
+        self.height = linespace(self.font)
 
         if self.previous:
             space = self.previous.font.measureText(" ")
@@ -693,13 +525,6 @@ class InputLayout:
         return "InputLayout(x={}, y={}, width={}, height={})".format(
             self.x, self.y, self.width, self.height)
 
-def style_length(node, style_name, default_value):
-    style_val = node.style.get(style_name)
-    if style_val:
-        return int(style_val[:-2])
-    else:
-        return default_value
-
 def paint_visual_effects(node, cmds, rect):
     opacity = float(node.style.get("opacity", "1.0"))
 
@@ -721,30 +546,6 @@ def paint_visual_effects(node, cmds, rect):
             ],
             should_save=needs_blend_isolation),
     ]
-
-def style(node, rules, url):
-    node.style = {}
-    for property, default_value in INHERITED_PROPERTIES.items():
-        if node.parent:
-            node.style[property] = node.parent.style[property]
-        else:
-            node.style[property] = default_value
-    
-    for selector, body in rules:
-        if not selector.matches(node): continue
-        for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
-
-    if isinstance(node, Element) and "style" in node.attributes:
-        pairs = CSSParser(node.attributes["style"]).body()
-        for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
-    
-    for child in node.children:
-        style(child, rules, url)
 
 SCROLL_STEP = 100
 CHROME_PX = 100

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -625,8 +625,7 @@ class Tab:
         self.render()
 
     def render(self):
-        style(self.nodes, sorted(self.rules, key=cascade_priority),
-            self.url)
+        style(self.nodes, sorted(self.rules, key=cascade_priority))
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []


### PR DESCRIPTION
The PR elaborates the summary, adds an outline, and heavily modifies the exercises. In the exercises:

- I clarified the "transforms", "filters", and "overflow: scroll" exercises.
- I removed the "width/height" exercise since it duplicates an exercise from a prior chapter
- I removed the "z-index" exercises, which was quite sad, because without implementing `position` there's no way for `z-index` to have an effect. I considered adding that to the exercise (or making it depend on the transforms exercise—but I'm not sure that's enough) and that seemed too complex but I want to get a second opinion on that.
- I added an exercise on "interest regions". I'm not sure what's the best way to write this exercise, so would appreciate your take
- I added an exercise on hit testing, which also corrects a subtle bug in our rounded corners implementation, which is nice.