### PR TITLE
Use only one task queue in MainThreadRunner

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -720,7 +720,7 @@ be the only class allowed to call methods on `Tab` or `JSContext`.
 begin the thread. This will excute the `run` method on that thread; `run` will
 execute forever (or until the program quits, which is indicated by the
 `needs_quit` dirty bit) and is where we'll put the main thread event loop.
-There will also be a task queue browser-generated tasks and scripts, and a
+There will also be a task queue for browser-generated tasks and scripts, and a
 rendering pipeline dirty bit.
 
 ``` {.python}

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -657,7 +657,7 @@ class JSContext:
             if url_origin(full_url) != url_origin(self.tab.url):
                 raise Exception(
                     "Cross-origin XHR request not allowed")
-            self.tab.main_thread_runner.schedule_script_task(
+            self.tab.main_thread_runner.schedule_task(
                 Task(self.xhr_onload, out, handle_local))
             return out
 
@@ -788,7 +788,7 @@ class Tab:
             async_req["thread"].join()
             req_url = async_req["url"]
             if async_req["type"] == "script":
-                self.main_thread_runner.schedule_script_task(
+                self.main_thread_runner.schedule_task(
                     Task(self.js.run, req_url,
                         script_results[req_url]['body']))
             else:
@@ -968,10 +968,7 @@ class SingleThreadedTaskRunner:
     def schedule_animation_frame(self):
         self.tab.run_animation_frame()
 
-    def schedule_script_task(self, script):
-        script()
-
-    def schedule_browser_task(self, callback):
+    def schedule_task(self, callback):
         callback()
 
     def schedule_scroll(self, scroll):
@@ -996,8 +993,7 @@ class MainThreadRunner:
         self.tab = tab
         self.needs_animation_frame = False
         self.main_thread = threading.Thread(target=self.run, args=())
-        self.script_tasks = TaskQueue()
-        self.browser_tasks = TaskQueue()
+        self.tasks = TaskQueue()
         self.needs_quit = False
         self.pending_scroll = None
 
@@ -1007,15 +1003,9 @@ class MainThreadRunner:
         self.condition.notify_all()
         self.lock.release()
 
-    def schedule_script_task(self, script):
+    def schedule_task(self, callback):
         self.lock.acquire(blocking=True)
-        self.script_tasks.add_task(script)
-        self.condition.notify_all()
-        self.lock.release()
-
-    def schedule_browser_task(self, callback):
-        self.lock.acquire(blocking=True)
-        self.browser_tasks.add_task(callback)
+        self.tasks.add_task(callback)
         self.condition.notify_all()
         self.lock.release()
 
@@ -1033,8 +1023,7 @@ class MainThreadRunner:
 
     def clear_pending_tasks(self):
         self.needs_animation_frame = False
-        self.script_tasks.clear()
-        self.browser_tasks.clear()
+        self.tasks.clear()
         self.pending_scroll = None
 
     def start(self):
@@ -1056,28 +1045,19 @@ class MainThreadRunner:
             if needs_animation_frame:
                 self.tab.run_animation_frame()
 
-            browser_method = None
+            task = None
             self.lock.acquire(blocking=True)
-            if self.browser_tasks.has_tasks():
-                browser_method = self.browser_tasks.get_next_task()
+            if self.tasks.has_tasks():
+                task = self.tasks.get_next_task()
             self.lock.release()
-            if browser_method:
-                browser_method()
-
-            script = None
-            self.lock.acquire(blocking=True)
-            if self.script_tasks.has_tasks():
-                script = self.script_tasks.get_next_task()
-            self.lock.release()
-            if script:
-                script()
+            if task:
+                task()
 
             self.lock.acquire(blocking=True)
-            if not self.script_tasks.has_tasks() and \
-                not self.browser_tasks.has_tasks() and not \
-                self.needs_animation_frame and not \
-                self.pending_scroll and not \
-                self.needs_quit:
+            if not self.tasks.has_tasks() and \
+                not self.needs_animation_frame and \
+                not self.pending_scroll and \
+                not self.needs_quit:
                 self.condition.wait()
             self.lock.release()
 
@@ -1089,7 +1069,7 @@ class TabWrapper:
         self.scroll = 0
 
     def schedule_load(self, url, body=None):
-        self.tab.main_thread_runner.schedule_browser_task(
+        self.tab.main_thread_runner.schedule_task(
             Task(self.tab.load, url, body))
         self.browser.set_needs_chrome_raster()
 
@@ -1106,15 +1086,15 @@ class TabWrapper:
         self.browser.compositor_lock.release()
 
     def schedule_click(self, x, y):
-        self.tab.main_thread_runner.schedule_browser_task(
+        self.tab.main_thread_runner.schedule_task(
             Task(self.tab.click, x, y))
 
     def schedule_keypress(self, char):
-        self.tab.main_thread_runner.schedule_browser_task(
+        self.tab.main_thread_runner.schedule_task(
             Task(self.tab.keypress, char))
 
     def schedule_go_back(self):
-        self.tab.main_thread_runner.schedule_browser_task(
+        self.tab.main_thread_runner.schedule_task(
             Task(self.tab.go_back))
 
     def schedule_scroll(self, scroll):

--- a/src/test12.py
+++ b/src/test12.py
@@ -22,10 +22,7 @@ class MockMainThreadRunner:
 	def schedule_animation_frame(self):
 		self.tab.run_animation_frame()
 
-	def schedule_script_task(self, script):
-		script()
-
-	def schedule_browser_task(self, callback):
+	def schedule_task(self, callback):
 		callback()
 
 	def schedule_scroll(self, scroll):
@@ -47,10 +44,7 @@ class MockNoOpMainThreadRunner:
 	def schedule_animation_frame(self):
 		pass
 
-	def schedule_script_task(self, script):
-		pass
-
-	def schedule_browser_task(self, callback):
+	def schedule_task(self, callback):
 		pass
 
 	def schedule_scroll(self, scroll):


### PR DESCRIPTION
There didn't turn out to be any reason to have two task queues in the chapter.