### PR TITLE
Fix incorrect wording and add a warning footnote about GC

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -162,17 +162,17 @@ class Browser:
 ```
 
 The `CreateRGBSurfaceFrom` method then wraps the data in an SDL surface
-(this SDL surface does not copy the bytes!):
+(this SDL surface does not copy the bytes):
 [^use-after-free]
 
-[^use-after-free]: Note that since Skia and SDL are C++ libraries, they are
-generally unware of Python's garbage collection system. So the link between the
-output of `tobytes` and `sdl_window` is not guaranteed to be kept consistent
-when `skia_bytes` is garbage collected. Instead, the SDL surface will be
-pointing at a bogus piece of memory, which will lead to memory corruption or a
-crash. The code here is correct because all of these are local variables that
-are garbage-collected together, but if not you need to be careful to keep
-all of them alive at the same time.
+[^use-after-free]: Note that since Skia and SDL are C++ libraries, they are not
+always consistent with Python's garbage collection system. So the link between
+the output of `tobytes` and `sdl_window` is not guaranteed to be kept
+consistent when `skia_bytes` is garbage collected. Instead, the SDL surface
+will be pointing at a bogus piece of memory, which will lead to memory
+corruption or a crash. The code here is correct because all of these are local
+variables that are garbage-collected together, but if not you need to be
+careful to keep all of them alive at the same time.
 
 ``` {.python}
 class Browser:

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -161,7 +161,18 @@ class Browser:
             self.ALPHA_MASK = 0xff000000
 ```
 
-The `CreateRGBSurfaceFrom` method then copies the data:
+The `CreateRGBSurfaceFrom` method then wraps the data in an SDL surface
+(this SDL surface does not copy the bytes!):
+[^use-after-free]
+
+[^use-after-free]: Note that since Skia and SDL are C++ libraries, they are
+generally unware of Python's garbage collection system. So the link between the
+output of `tobytes` and `sdl_window` is not guaranteed to be kept consistent
+when `skia_bytes` is garbage collected. Instead, the SDL surface will be
+pointing at a bogus piece of memory, which will lead to memory corruption or a
+crash. The code here is correct because all of these are local variables that
+are garbage-collected together, but if not you need to be careful to keep
+all of them alive at the same time.
 
 ``` {.python}
 class Browser:
@@ -175,7 +186,8 @@ class Browser:
             self.BLUE_MASK, self.ALPHA_MASK)
 ```
 
-Finally, we draw all this pixel data on the window itself:
+Finally, we draw all this pixel data on the window itself by blitting (copying)
+it from `sdl_surface` to `sdl_window`'s surface:
 
 ``` {.python}
 class Browser:


### PR DESCRIPTION
Previously, the text claimed that SDL_CreateRGBSurfaceFrom copied the bytes.
Instead, it wraps the bytes and [does not copy them](https://wiki.libsdl.org/SDL_CreateRGBSurfaceFrom).

This PR fixes that and adds a warning footnote about the possibility of bugs involving
mixed Python & C++.

[This discussion](https://github.com/browserengineering/book/discussions/328) brought the bug to my attention.

