### PR TITLE
Fix a race condition with display_scheduled

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -1061,8 +1061,8 @@ threads in parallel.[^why-gil]
 This means that the *throughput* (animation frames delivered per second) of our
 browser will not actually be greater with two threads. Even though the
 throughput is not higher, the *responsiveness* of the browser thread is still
-massively improved, since it isn't blocked on JavaScript or the front half of
-the rendering pipeline.
+massively improved, since it often isn't blocked on JavaScript or the front
+half of the rendering pipeline.
 
 Another point: the global interpreter lock doesn't save us from race conditions
 for shared data structures. In particular, the Python interpreter on a thread


### PR DESCRIPTION
There was a bug in which the display_scheduled variable on a Tab could be accessed from
multiple threads (via a threading.Timer thread). I fixed it and moved it to main_thread_runnner,
which is also simpler.

I also added text explaining that the threading locks really are useful, and why.