### PR TITLE
Generate animation frames from the browser thread, not the main thread

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -201,7 +201,7 @@ to avoid double-running `set_timeout` unnecessarily) to `Tab`, which means
  
 Also, rename `render` to `run_rendering_pipeline`, and add a new
 `run_animation_frame` method that runs the pipeline and calls the other
-rendering pipeline stages on `Browser` via a new `raster_and_draw_if_needed`
+rendering pipeline stages on `Browser` via a new `raster_and_draw`
 method(which we'll implement shortly).
 
 ``` {.python expected=False}

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -202,7 +202,7 @@ to avoid double-running `set_timeout` unnecessarily) to `Tab`, which means
 Also, rename `render` to `run_rendering_pipeline`, and add a new
 `run_animation_frame` method that runs the pipeline and calls the other
 rendering pipeline stages on `Browser` via a new `raster_and_draw`
-method(which we'll implement shortly).
+method (which we'll implement shortly).
 
 ``` {.python expected=False}
 class Tab:

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -958,10 +958,8 @@ while True:
     if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
         # ...
     browser.raster_and_draw()
-        if browser.needs_animation_frame:
-            active_tab.schedule_animation_frame()
+    browser.schedule_animation_frame()
 ```
-
 
 [^fast-commit]: `commit` is the one time when both threads are both "stopped"
 simultaneously---in the sense that neither is running a different task at the

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -190,7 +190,7 @@ a function to call when that time expires.
 [python-thread]: https://docs.python.org/3/library/threading.html
 
 ``` {.python}
-def set_timeout(func, sec):     
+def set_timeout(func, sec):
     t = threading.Timer(sec, func)
     t.start()
 ```
@@ -201,8 +201,8 @@ to avoid double-running `set_timeout` unnecessarily) to `Tab`, which means
  
 Also, rename `render` to `run_rendering_pipeline`, and add a new
 `run_animation_frame` method that runs the pipeline and calls the other
-rendering pipeline stages on `Browser` via a new `raster_and_draw` method
-(which we'll implement shortly).
+rendering pipeline stages on `Browser` via a new `raster_and_draw_if_needed`
+method(which we'll implement shortly).
 
 ``` {.python expected=False}
 class Tab:
@@ -516,9 +516,8 @@ Count the total time spent in the two categories. We'll also need a
 `handle_quit` hook in `Tab`, called from `Browser`, to print out the `Tab`
 rendering time.
 
-``` {.python replace=browser/commit_func}
+``` {.python}
 class Tab:
-    def __init__(self, browser):
         # ...
         self.time_in_style_layout_and_paint = 0.0
         self.num_pipeline_updates = 0
@@ -825,10 +824,9 @@ the focus painting behavior needs to become a new `DrawLine` canvas command.
 [^one-per-tab]: That means there will be one main thread per `Tab`, and even
 tabs that are not currently shown will be able to run tasks in the background.
 
-
-``` {.python replace=browser/commit_func,%20body))/}
+``` {.python expected=False}
 class Tab:
-    def __init__(self, browser):
+        # ...
         self.main_thread_runner = MainThreadRunner(self)
         self.main_thread_runner.start()
 
@@ -838,9 +836,6 @@ class Tab:
             # ...
             self.main_thread_runner.schedule_task(
                 Task(self.js.run, req_url, body))
-
-    def set_needs_animation_frame(self):
-        self.main_thread_runner.schedule_animation_frame()
 
     def run_rendering_pipeline(self):
         # ...
@@ -884,13 +879,18 @@ Likewise, `Tab` can't have direct acccess to the `Browser`. But the only
 method it needs to call on `Browser` is `raster_and_draw`. We'll rename that
 to a `commit` method on `TabWrapper`, and pass this method to `Tab`'s
 constructor. When `commit` is called, all state of the `Tab` that's relevant
-to the `Browser` is sent across.
+to the `Browser` is sent across. Likewise add a `set_needs_animation_frame`
+method and also pass it.
 
 ``` {.python expected=False}
 class Tab:
-    def __init__(self, commit_func):
+    def __init__(self, commit_func, set_needs_animation_frame_func):
         # ...
         self.commit_func = commit_func
+        self.set_needs_animation_frame_func = set_needs_animation_frame_func
+
+    def set_needs_animation_frame(self):
+        self.set_needs_animation_frame_func()
 
     def run_animation_frame(self):
         self.run_rendering_pipeline()
@@ -905,7 +905,7 @@ class Tab:
 ``` {.python}
 class TabWrapper:
     def __init__(self, browser):
-        self.tab = Tab(self.commit)
+        self.tab = Tab(self.commit, self.set_needs_animation_frame)
         self.browser = browser
         self.url = None
         self.scroll = 0
@@ -921,11 +921,47 @@ class TabWrapper:
         self.browser.active_tab_display_list = display_list.copy()
         self.browser.set_needs_tab_raster()
         self.browser.compositor_lock.release()
+
+    def set_needs_animation_frame(self):
+        self.browser.compositor_lock.acquire(blocking=True)
+        self.browser.set_needs_animation_frame()
+        self.browser.compositor_lock.release()
+    
 ```
 
 Note that `commit` will acquire a lock on the browser thread before doing
 any of its work, because all of the inputs and outputs to it are cross-thread
 data structures.[^fast-commit]
+
+Let's now finish plubing the animation frame dirty bit to `Browser`. We'll store
+the bit, and check for it each time through the browser's event loop. This will
+be the trigger for actually scheduling an animation frame back on the main
+thread. This completes the loop: now the main thread will request that the
+browser thread schedule a task back on the main thread 16ms in the future).
+
+This setup is important because it needs to be the browser thread that
+determines the frame rate of the main thread, not the other way around. The
+reason is simple: there is no point to running the front half of the rendering
+pipeline faster than it can be drawn to the screen on the browser thread.
+
+``` {.python}
+class Browser:
+    def __init__(self):
+        # ...
+        self.needs_animation_frame = False
+
+    def set_needs_animation_frame(self):
+        self.needs_animation_frame = True
+# ...
+
+while True:
+    if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
+        # ...
+    browser.raster_and_draw()
+        if browser.needs_animation_frame:
+            active_tab.schedule_animation_frame()
+```
+
 
 [^fast-commit]: `commit` is the one time when both threads are both "stopped"
 simultaneously---in the sense that neither is running a different task at the
@@ -1121,25 +1157,25 @@ class MainThreadRunner:
         self.lock.release()
 
     def run(self):
-        # ...
-        self.lock.acquire(blocking=True)
-        needs_animation_frame = self.needs_animation_frame
-        self.needs_animation_frame = False
-        pending_scroll = self.pending_scroll
-        self.pending_scroll = None
-        self.lock.release()
-        if pending_scroll:
-            self.tab.apply_scroll(pending_scroll)
-        if needs_animation_frame:
-            self.tab.run_animation_frame()
-        # ...
-        self.lock.acquire(blocking=True)
-        if not self.tasks.has_tasks() and \
-            not self.needs_animation_frame and \
-            not self.pending_scroll and \
-            not self.needs_quit:
-            self.condition.wait()
-        self.lock.release()
+        while True:
+            self.lock.acquire(blocking=True)
+            needs_animation_frame = self.needs_animation_frame
+            self.needs_animation_frame = False
+            pending_scroll = self.pending_scroll
+            self.pending_scroll = None
+            self.lock.release()
+            if pending_scroll:
+                self.tab.apply_scroll(pending_scroll)
+            if needs_animation_frame:
+                self.tab.run_animation_frame()
+            # ...
+            self.lock.acquire(blocking=True)
+            if not self.tasks.has_tasks() and \
+                not self.needs_animation_frame and \
+                not self.pending_scroll and \
+                not self.needs_quit:
+                self.condition.wait()
+            self.lock.release()
 ```
 
 in `Tab`:

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -10,6 +10,7 @@ This file contains tests for Chapter 12 (Scheduling and Threading).
     >>> import lab12
     >>> import time
     >>> import threading
+    >>> lab12.USE_BROWSER_THREAD = False
 
 Testing basic loading and dirty bits
 ====================================
@@ -36,6 +37,7 @@ Before load, there is no tab height or display list.
 Once the Tab has loaded, the browser should need raster and draw.
 
     >>> browser.load(test_url)
+    >>> browser.render()
     >>> browser.needs_chrome_raster
     True
     >>> browser.needs_tab_raster

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -730,6 +730,11 @@ class Browser:
         self.needs_draw = False
         self.compositor_lock.release()
 
+    def schedule_animation_frame(self):
+        if self.needs_animation_frame:
+            self.needs_animation_frame = False
+            active_tab.schedule_animation_frame()
+
     def handle_down(self):
         self.compositor_lock.acquire(blocking=True)
         if not self.active_tab_height:
@@ -931,5 +936,4 @@ if __name__ == "__main__":
                 active_runner.display_scheduled = False
                 browser.render()
         browser.raster_and_draw()
-        if browser.needs_animation_frame:
-            active_tab.schedule_animation_frame()
+        browser.schedule_animation_frame()

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -701,7 +701,7 @@ class Browser:
     def set_needs_draw(self):
         self.needs_draw = True
 
-    def raster_and_draw_if_needed(self):
+    def raster_and_draw(self):
         self.compositor_lock.acquire(blocking=True)
         timer = None
         draw_timer = None
@@ -930,6 +930,6 @@ if __name__ == "__main__":
             if active_runner.display_scheduled:
                 active_runner.display_scheduled = False
                 browser.render()
-        browser.raster_and_draw_if_needed()
+        browser.raster_and_draw()
         if browser.needs_animation_frame:
             active_tab.schedule_animation_frame()

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -209,7 +209,7 @@ def clamp_scroll(scroll, tab_height):
     return max(0, min(scroll, tab_height - (HEIGHT - CHROME_PX)))
 
 class Tab:
-    def __init__(self, commit_func):
+    def __init__(self, commit_func, set_needs_animation_frame_func):
         self.history = []
         self.focus = None
         self.url = None
@@ -218,6 +218,7 @@ class Tab:
         self.needs_raf_callbacks = False
         self.needs_pipeline_update = False
         self.commit_func = commit_func
+        self.set_needs_animation_frame_func = set_needs_animation_frame_func
         if USE_BROWSER_THREAD:
             self.main_thread_runner = MainThreadRunner(self)
         else:
@@ -316,7 +317,7 @@ class Tab:
         self.set_needs_animation_frame()
 
     def set_needs_animation_frame(self):
-        self.main_thread_runner.schedule_animation_frame()
+        self.set_needs_animation_frame_func()
 
     def request_animation_frame_callback(self):
         self.needs_raf_callbacks = True
@@ -579,7 +580,7 @@ class MainThreadRunner:
 
 class TabWrapper:
     def __init__(self, browser):
-        self.tab = Tab(self.commit)
+        self.tab = Tab(self.commit, self.set_needs_animation_frame)
         self.browser = browser
         self.url = None
         self.scroll = 0
@@ -599,6 +600,14 @@ class TabWrapper:
         self.browser.active_tab_height = tab_height
         self.browser.active_tab_display_list = display_list.copy()
         self.browser.set_needs_tab_raster()
+        self.browser.compositor_lock.release()
+
+    def schedule_animation_frame(self):
+        self.tab.main_thread_runner.schedule_animation_frame()
+
+    def set_needs_animation_frame(self):
+        self.browser.compositor_lock.acquire(blocking=True)
+        self.browser.set_needs_animation_frame()
         self.browser.compositor_lock.release()
 
     def schedule_click(self, x, y):
@@ -665,6 +674,7 @@ class Browser:
             self.BLUE_MASK = 0x00ff0000
             self.ALPHA_MASK = 0xff000000
 
+        self.needs_animation_frame = False
         self.needs_tab_raster = False
         self.needs_chrome_raster = True
         self.needs_draw = True
@@ -677,6 +687,9 @@ class Browser:
         tab = self.tabs[self.active_tab].tab
         tab.run_animation_frame()
 
+    def set_needs_animation_frame(self):
+        self.needs_animation_frame = True
+
     def set_needs_tab_raster(self):
         self.needs_tab_raster = True
         self.needs_draw = True
@@ -688,7 +701,7 @@ class Browser:
     def set_needs_draw(self):
         self.needs_draw = True
 
-    def raster_and_draw(self):
+    def raster_and_draw_if_needed(self):
         self.compositor_lock.acquire(blocking=True)
         timer = None
         draw_timer = None
@@ -911,10 +924,12 @@ if __name__ == "__main__":
                     browser.handle_down()
             elif event.type == sdl2.SDL_TEXTINPUT:
                 browser.handle_key(event.text.text.decode('utf8'))
+        active_tab = browser.tabs[browser.active_tab]
         if not USE_BROWSER_THREAD:
-            active_runner = \
-                browser.tabs[browser.active_tab].tab.main_thread_runner
+            active_runner = active_tab.tab.main_thread_runner
             if active_runner.display_scheduled:
                 active_runner.display_scheduled = False
                 browser.render()
-        browser.raster_and_draw()
+        browser.raster_and_draw_if_needed()
+        if browser.needs_animation_frame:
+            active_tab.schedule_animation_frame()


### PR DESCRIPTION
This is because draw happens on the browser thread, so:
* A main thread running rendering faster than that is useless
* Animations will look choppy/broken because frames will be missed