### PR TITLE
Improve async rendering section of chapter 12

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -174,7 +174,7 @@ Asynchronous rendering
 ======================
 
 In order to separate rendering from other tasks and make it into a proper
-pipeline, let make it asynchronous. Instead of updating rendering right away,
+pipeline, let's make it asynchronous. Instead of updating rendering right away,
 the browser should set *dirty bits* indicating that a particular part of the
 pipeline needs updating. Then when the pipeline is run, it will run the parts
 indicated by the dirty bits. We'll also need some way of
@@ -193,6 +193,10 @@ function completes, the timer thread is automatically ended.
 execute at about the time desired---even if the current thread is busy at that
 time---but, as we'll see, leads to some complications if you really want the
 function to be called on the same thread as the one calling `set_timeout`.
+But in any case, it wouldn't make any sense to run the task on the "current"
+thread, because the only time the current thread is free to run such a task
+is when the program has quit. Unlike JavaScript programming on a website,
+Python has no built-in event loop.
 
 [python-thread]: https://docs.python.org/3/library/threading.html
 
@@ -338,7 +342,7 @@ class Browser:
         self.needs_draw = False
 ```
 
-In each case where raster or draw was previously called synchronously, set the
+In each case where raster or draw was previously synchronous, set the
 dirty bits instead. Here's the change to `handle_click`:
 
 ``` {.python expected=False}

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -195,8 +195,8 @@ time---but, as we'll see, leads to some complications if you really want the
 function to be called on the same thread as the one calling `set_timeout`.
 But in any case, it wouldn't make any sense to run the task on the "current"
 thread, because the only time the current thread is free to run such a task
-is when the program has quit. Unlike JavaScript programming on a website,
-Python has no built-in event loop.
+is when the program has already quit! Unlike JavaScript programming on a
+website, Python has no built-in event loop.
 
 [python-thread]: https://docs.python.org/3/library/threading.html
 
@@ -209,9 +209,9 @@ def set_timeout(func, sec):
 Next, add three dirty bits to `Tab`:
 
 * `needs_pipeline_update`, indicating that
-the pipeline needs to be re-run
+the pipeline needs to be re-run.
 * `display_scheduled`, indicating that `set_timeout` was already called (this
-avoids double-running `set_timeout` unnecessarily)
+avoids double-running `set_timeout` unnecessarily).
 * `run_pipeline_now`, indicating that the event loop should
 run the pipeline.
 

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -374,14 +374,11 @@ call when that time expires. It will start a new thread and call that
 function *on that thread*[^thread-timer] at the desired time. When the
 function completes, the timer thread is automatically ended.
 
-[^thread-timer]: This is convenient because it enables the timer to
-execute at about the time desired---even if the current thread is busy at that
-time---but, as we'll see, leads to some complications if you really want the
-function to be called on the same thread as the one calling `set_timeout`.
-But in any case, it wouldn't make any sense to run the task on the "current"
-thread, because the only time the current thread is free to run such a task
-is when the program has already quit! Unlike JavaScript programming on a
-website, Python has no built-in event loop.
+[^thread-timer]: This is convenient because it enables the timer callback
+function to execute at about the time desired---even if the current thread is
+busy at that time. Nevertheless, we need the *task the callback wishes to
+trigger* to run on the current thread, not the timer thread. We'll use a task
+queue for that.
 
 [python-thread]: https://docs.python.org/3/library/threading.html
 


### PR DESCRIPTION
This PR does the following:

* Improves description of the what and why of the code
* Breaks up the code more with explanatory text
* Fixes a bug where `run_rendering_pipeline` was called on the timer thread, and replaces it with a call on the event loop.