### PR TITLE
Locking improvements earlier in chapter 12

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -192,6 +192,9 @@ tab is not the active tab. This flexibilty is quite powerful, and we can use it
 without having to dive into the guts of a `Tab` or how it loads web pages---all
 we'd have to do is implement a new `TaskRunner` heuristic.
 
+Example: setTimeout
+===================
+
 Now for the fun part I promised. Let's implement the
 [`setTimeout`][settimeout] JavaScript API, which provides a way to run
 JavaScript a given number of milliseconds from now. In terms of the JavaScript
@@ -210,21 +213,19 @@ for that module:
 import threading
 ```
 
-Implement a `set_timeout` helper function that runs a callback at a specified
-time in the future. You can do that by creating a new
-[Python thread][python-thread] via the `threading.Timer` class, which takes
-two parameters: a time delta in seconds from now, and a function to call when
-that time expires.
+The `threading` module has a class  called `Timer`. This class lets you run a
+callback at a specified time in the future, on a new
+[Python thread][python-thread]. It taes two parameters: a time delta in seconds
+from now, and a function to call when that time expires. The following code will
+run `func` 10 seconds in the future on a new thread:
 
 [python-thread]: https://docs.python.org/3/library/threading.html
 
 ``` {.python}
-def set_timeout(func, sec):     
-    t = threading.Timer(sec, func)
-    t.start()
+threading.Timer(10, func).start()
 ```
 
-Now we're ready to implement `setTimeout`. In the JavaScript runtime, add
+Now implement `setTimeout` on top of this class. In the JavaScript runtime, add
 a new internal handle for each call to `setTimeout`, and store the mapping
 between handles and callback functions in a global object called
 `SET_TIMEOUT_REQUESTS`. When the timeout occurs, Python will call
@@ -247,23 +248,21 @@ function __runSetTimeout(handle) {
 ```
 
 On the Python side, add a binding for `setTimeout` and an implementation that
-calls `set_timeout`. However, we have to be careful here, since in the code
-below, `run_callback` will run *on a different Python thread than the current
-one*. So we can't just call `evaljs` directly, or we'll end up with JavaScript
-running on two Python threads at the same time, which is not ok.[^js-thread]
+starts a `threading.Timer`. However, we have to be careful here, since in the
+code below, `run_callback` will run *on a different Python thread than the
+current one*. So we can't just call `evaljs` directly, or we'll end up with
+JavaScript running on two Python threads at the same time, which is not
+ok.[^js-thread]
 
-Not all is lost though! This problem can be solved elegantly with the
-`TaskRunner`: instead of running the script right away, schedule a task to
-do it later, when the other thread is free.[^locking] Here's the code:
-
-[^locking]: This code has a bug: it accesses data structures shared
-between two threads without a thread lock. We'll see soon how to fix it.
+This is easy to fix by using the `TaskRunner` you already implemented: instead
+of running the script right away, schedule a task to do it later, when the
+other thread is free. Here's the code:
 
 [^js-thread]: JavaScript is not a multi-threaded programming language.
-It's possible on the web to create [js-workers] of various kinds, but they
+It's possible on the web to create [workers] of various kinds, but they
 all run independently and communicate only via special message-passing APIs.
 
-[js-workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API
+[workers]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API
 
 ``` {.python}
 class JSContext:
@@ -278,10 +277,47 @@ class JSContext:
                 Task(self.interp.evaljs,
                     "__runSetTimeout({})".format(handle)))
 
-        set_timeout(run_callback, time / 1000.0)
+        threading.Timer(time / 1000.0, run_callback).start()
 ```
 
 That's it! Your browser now supports running asynchronous JavaScript tasks.
+
+Except there is a bug in this code: it doesn't account for the fact that
+the first thread and the timer thread run concurrently, and there is therefore
+no guarantee that one callback that writes to `schedule_task` will not be 
+interleaved with code on the other thread trying to read the task queue,
+leading to a [race condition](https://en.wikipedia.org/wiki/Race_condition)
+bug and nondeterministic results.
+
+This bug is easily fixed by use of a `threading.Lock` object. Before reading
+or writing to a data structure shared across threads, acquire the lock; after
+you're done, release it.^[The `blocking` parameter to `acquire` indicates
+whether the thread should block on acquiring the lock or not; in this chapter
+you'll always set it to true.] The code changes in `TaskRunner` are pretty
+easy---just be careful to not forget to release the lock, and hold it for the
+minimum time possible, so as to maximize thread parallelism.^[That's why the
+code releases the lock before calling `task`: after the task has been removed
+from the queue, it can't be accessed by another thread.]
+
+``` {.python expected=False}
+class TaskRunner:
+    def __init__(self):
+        # ...
+        self.lock = threading.Lock()
+
+    def schedule_task(self, callback):
+        self.lock.acquire(blocking=True)
+        self.tasks.add_task(callback)
+        self.lock.release()
+
+    def run_once(self):
+        self.lock.acquire(blocking=True)
+        task = None
+        if self.tasks.has_tasks():
+            task = self.tasks.get_next_task()
+        self.lock.release()
+        task()
+```
 
 ::: {.further}
 Event loops often map 1:1 to CPU threads within a single CPU process, but
@@ -366,29 +402,7 @@ indicated by the dirty bits. We'll also need some way of
 *scheduling* the rendering pipeline to be updated at a given time in the
 future.
 
-Let's start with how to schedule the update, via a new `set_timeout` function.
-This function will run a callback at a specified time in the future. You can do
-that by starting a new [Python thread][python-thread] via the `threading.Timer`
-class, which takes two parameters: a time delta from now, and a function to
-call when that time expires. It will start a new thread and call that
-function *on that thread*[^thread-timer] at the desired time. When the
-function completes, the timer thread is automatically ended.
-
-[^thread-timer]: This is convenient because it enables the timer callback
-function to execute at about the time desired---even if the current thread is
-busy at that time. Nevertheless, we need the *task the callback wishes to
-trigger* to run on the current thread, not the timer thread. We'll use a task
-queue for that.
-
-[python-thread]: https://docs.python.org/3/library/threading.html
-
-``` {.python}
-def set_timeout(func, sec):
-    t = threading.Timer(sec, func)
-    t.start()
-```
-
-Next, add three dirty bits to `Tab`:
+First, add three dirty bits to `Tab`:
 
 * `needs_pipeline_update`, indicating that
 the pipeline needs to be re-run.
@@ -397,12 +411,8 @@ avoids double-running `set_timeout` unnecessarily).
 * `run_pipeline_now`, indicating that the event loop should
 run the pipeline.
 
-Add methods to set the dirty bits and call `set_timeout` as
-needed.[^race-condition]
-
-[^race-condition]: This code has a race condition because it's setting variables
-on one thread from another without a thread lock. Let's ignore that for now and
-fix it later in the chapter.
+Add methods to set the dirty bits and use a `threading.Timer`  as
+needed to schedule future renders.
 
 ``` {.python expected=False}
 class Tab:
@@ -422,7 +432,7 @@ class Tab:
             self.run_pipeline_now = True
 
         if not self.display_scheduled:
-            set_timeout(callback, REFRESH_RATE_SEC)
+            threading.Timer(REFRESH_RATE_SEC, callback).start()
             self.display_scheduled = True
 ```
  
@@ -947,12 +957,12 @@ by default) will be the browser thread, and we'll make a new one for
 the main thread. Let's add more code to the `TaskRunner` class to make it
 into a complete event loop, and then rename it to `MainThreadEventLoop`.
 
-The two threads will communicate by reading and writing shared data structures,
-and use `threading.Lock` objects to prevent race conditions.
-`MainThreadEventLoop` will be the only class allowed to call methods on `Tab`
-or `JSContext`.
+The two threads will communicate by reading and writing shared data structures
+(and use `threading.Lock` objects to prevent race conditions, just like with
+`TaskRunner`). `MainThreadEventLoop` will be the only class allowed to call
+methods on `Tab` or `JSContext`.
 
-`MainThreadEventLoop` will add a lock and a thread object. Calling `start` will
+`MainThreadEventLoop` will add a thread object. Calling `start` will
 begin the thread. This will execute the `run` method on that thread; `run`
 (instead of `run_once`) will execute forever (or until the program quits, which
 is indicated by the `needs_quit` dirty bit) and is where we'll put the main

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -295,9 +295,9 @@ you're done, release it.^[The `blocking` parameter to `acquire` indicates
 whether the thread should block on acquiring the lock or not; in this chapter
 you'll always set it to true.] The code changes in `TaskRunner` are pretty
 easy---just be careful to not forget to release the lock, and hold it for the
-minimum time possible, so as to maximize thread parallelism.^[That's why the
+minimum time possible, so as to maximize thread parallelism. That's why the
 code releases the lock before calling `task`: after the task has been removed
-from the queue, it can't be accessed by another thread.]
+from the queue, it can't be accessed by another thread.
 
 ``` {.python expected=False}
 class TaskRunner:

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -290,14 +290,15 @@ leading to a [race condition](https://en.wikipedia.org/wiki/Race_condition)
 bug and nondeterministic results.
 
 This bug is easily fixed by use of a `threading.Lock` object. Before reading
-or writing to a data structure shared across threads, acquire the lock; after
-you're done, release it.^[The `blocking` parameter to `acquire` indicates
-whether the thread should block on acquiring the lock or not; in this chapter
-you'll always set it to true.] The code changes in `TaskRunner` are pretty
-easy---just be careful to not forget to release the lock, and hold it for the
-minimum time possible, so as to maximize thread parallelism. That's why the
-code releases the lock before calling `task`: after the task has been removed
-from the queue, it can't be accessed by another thread.
+from or writing to a data structure shared across threads, acquire the lock;
+after you're done, release it.^[The `blocking` parameter to `acquire` indicates
+whether the thread should wait for the lock to be available before continuing;
+in this chapter you'll always set it to true. When the thread is waiting, it's
+said to be *blocked*.] The code changes in `TaskRunner` are pretty easy---just
+be careful to not forget to release the lock, and hold it for the minimum time
+possible, so as to maximize thread parallelism. That's why the code releases
+the lock before calling `task`: after the task has been removed from the queue,
+it can't be accessed by another thread.
 
 ``` {.python expected=False}
 class TaskRunner:

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -221,7 +221,7 @@ run `func` 10 seconds in the future on a new thread:
 
 [python-thread]: https://docs.python.org/3/library/threading.html
 
-``` {.python}
+``` {.python expected=False}
 threading.Timer(10, func).start()
 ```
 

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -215,7 +215,7 @@ import threading
 
 The `threading` module has a class  called `Timer`. This class lets you run a
 callback at a specified time in the future, on a new
-[Python thread][python-thread]. It taes two parameters: a time delta in seconds
+[Python thread][python-thread]. It takes two parameters: a time delta in seconds
 from now, and a function to call when that time expires. The following code will
 run `func` 10 seconds in the future on a new thread:
 

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -6,7 +6,7 @@ next: skipped
 ...
 
 To be a capable application platform, the browser must run
-applications effieciently and stay responsive to user actions. To do
+applications efficiently and stay responsive to user actions. To do
 so, the browser must explicitly choose which of its many tasks to
 prioritize and delay unnecessary tasks until later. Such a task queue
 system also allows the browser to split tasks across multiple threads,
@@ -23,7 +23,7 @@ it starts spend more and more time querying remote servers, animating
 objects on the page, or prefetching information that the user may
 need. This requires a change in perspective: while users are slow and
 deliberative, leaving long gaps between actions for the browser to
-catch up, applications can be very demanding, with a neverending queue
+catch up, applications can be very demanding, with a never-ending queue
 of tasks for the browser to do.
 
 Modern browsers adapt to this reality by multitasking, prioritizing,
@@ -188,7 +188,7 @@ that we had no choice but to eval scripts right away just as they were loaded.
 But now it's pretty clear that we have a lot more control over when to run
 scripts. For example, it's easy to make a change to `TaskRunner` to only run
 one script per second, or to not run them at all during page load, or when a
-tab is not the active tab. This flexibilty is quite powerful, and we can use it
+tab is not the active tab. This flexibility is quite powerful, and we can use it
 without having to dive into the guts of a `Tab` or how it loads web pages---all
 we'd have to do is implement a new `TaskRunner` heuristic.
 
@@ -340,7 +340,7 @@ rendered. Most of the time spent doing work in a browser is in *rendering
 interactions* with the browser, such as loading, scrolling, clicking and typing.
 All of these interactions require rendering. If you want to make those
 interactions faster and smoother, the very first think you have to do is
-carefully optimize the rendering pieline.
+carefully optimize the rendering pipeline.
 
 The main event loop of a web page in a browser is called the *rendering event
 loop*. An idealized rendering event loop looks like this:
@@ -485,7 +485,7 @@ in the previous section:
 Let's take advantage of this new asynchronous technology by replacing all cases
 where the rendering pipeline is computed synchronously with
 `set_needs_pipeline_update`, for example `load`:^[There are more of them; you
-shoud fix them all.]
+should fix them all.]
 
 ``` {.python}
 class Tab:
@@ -780,7 +780,7 @@ class Tab:
 
     def handle_quit(self):
         print("""Time in style, layout and paint: {:>.6f}s
-    ({:>.6f}ms per pipelne run on average;
+    ({:>.6f}ms per pipeline run on average;
     {} total pipeline updates)""".format(
             self.tab.time_in_style_layout_and_paint,
             self.tab.time_in_style_layout_and_paint / \
@@ -845,7 +845,7 @@ category. When I ran it on my computer, it said:
         (28.699088ms per draw run on average;
         100 total draw updates)
     Time in style, layout and paint: 1.973732s
-        (19.737322ms per pipelne run on average;
+        (19.737322ms per pipeline run on average;
         100 total pipeline updates)
 
 Over a total of 100 frames of animation, the browser spent about 40ms
@@ -869,9 +869,9 @@ parallel thread.
 
 [^profile-draw]: I encourage you to do this profiling, to see for yourself.
 
-[^raster-draw]: When I first wrote this section of the chapter, I was surpised
+[^raster-draw]: When I first wrote this section of the chapter, I was surprised
 at how high the raster and draw time was, so I went back and added the separate
-draw timer that you see in the code above. Profiing your code often yields
+draw timer that you see in the code above. Profiling your code often yields
 interesting insights!
 
 ::: {.further}
@@ -1151,7 +1151,7 @@ safe for any methods on `Tab` to be directly called by `Browser`, because
 class that only exposes what's needed. `TabWrapper` will run on the browser
 thread.
 
-Likewise, `Tab` can't have direct acccess to the `Browser`. But the only
+Likewise, `Tab` can't have direct access to the `Browser`. But the only
 method it needs to call on `Browser` is `raster_and_draw`. We'll rename that
 to a `commit` method on `TabWrapper`, and pass this method to `Tab`'s
 constructor. When `commit` is called, all state of the `Tab` that's relevant
@@ -1209,7 +1209,7 @@ Note that `commit` will acquire a lock on the browser thread before doing
 any of its work, because all of the inputs and outputs to it are cross-thread
 data structures.[^fast-commit]
 
-Let's now finish plubing the animation frame dirty bit to `Browser`. We'll store
+Let's now finish plumbing the animation frame dirty bit to `Browser`. We'll store
 the bit, and check for it each time through the browser's event loop. This will
 be the trigger for actually scheduling an animation frame back on the main
 thread. This completes the loop: now the main thread will request that the
@@ -1349,7 +1349,7 @@ class Browser:
 ```
 
 ::: {.further}
-Python is unfortuately not fully thread-safe. For this reason, it has a
+Python is unfortunately not fully thread-safe. For this reason, it has a
 [global interpreter lock][gil], which means that you can't truly run two Python
 threads in parallel.[^why-gil]
 
@@ -1362,7 +1362,7 @@ half of the rendering pipeline.
 Another point: the global interpreter lock doesn't save us from race conditions
 for shared data structures. In particular, the Python interpreter on a thread
 may yield between bytecode operations at any time. So the locks we added are
-still useful, because race coditions such as reading and writing sequentially
+still useful, because race conditions such as reading and writing sequentially
 from the same Python variable and getting locally-inconsistent results
 (because the other thread modified it in the meantime) are still possible. And
 in fact, while debugging the code for this chapter, I encountered this kind of
@@ -1537,7 +1537,7 @@ events, and so can avoid this situation.[^real-browser-threaded-scroll]
 
 [^real-browser-threaded-scroll]: A real browser would also have an optimization
 to disable threaded scrolling only if there was such an event listener, and
-transition back to threaded as soon as it doens't see `preventDefault` called.
+transition back to threaded as soon as it doesn't see `preventDefault` called.
 This situation is so important that there is also a special kind of event
 listener [designed just for it][designed-for].
 
@@ -1647,14 +1647,14 @@ class Tab:
                         style_results[req_url]['body']).parse())
 ```
 
-Now our browser will parallleize loading sub-resources!
+Now our browser will parallelize loading sub-resources!
 
 Next up is `XHMLHttpRequest`. We introduced this API in chapter 10, and
 implemented it only as a synchronous API. But in fact, the synchronous
 version of that API is almost useless for real websites,^[It's also a huge
 performance footgun, for the same reason we've been adding async tasks
-in this chapter!] because the whole point of using thia API on a
-website is to keep it resposive to the user while network requests are going
+in this chapter!] because the whole point of using this API on a
+website is to keep it responsive to the user while network requests are going
 on.
 
 Let's fix that. We'll make the following changes. There are a bunch of them, but they
@@ -1732,7 +1732,7 @@ class JSContext:
 As you can see, the threading and task machinery we've built is quite
 general and multi-purpose!
 
-Now let's try out this new async API by augmenting our counter javscript like
+Now let's try out this new async API by augmenting our counter javascript like
 this:
 
 ``` {.javascript file=eventloop}
@@ -1839,7 +1839,7 @@ idea to try to optimistically move style and layout off the main thread for
 cases when JavaScript doesn't force it to be done otherwise? Maybe, but even
 setting aside this problem there are unfortunately other sources of forced
 style and layout. One example is our current implementation of `click`. The
-first linke of this method forces a layout:
+first line of this method forces a layout:
 
 ``` {.python}
 class Tab:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -167,7 +167,7 @@ class JSContext:
                 Task(self.interp.evaljs,
                     "__runSetTimeout({})".format(handle)))
 
-        set_timeout(run_callback, time / 1000.0)
+        threading.Timer(time / 1000.0, run_callback).start()
 
     def xhr_onload(self, out, handle):
         do_default = self.interp.evaljs(
@@ -206,10 +206,6 @@ SCROLL_STEP = 100
 CHROME_PX = 100
 
 USE_BROWSER_THREAD = True
-
-def set_timeout(func, sec):
-    t = threading.Timer(sec, func)
-    t.start()
 
 def raster(display_list, canvas):
     for cmd in display_list:
@@ -526,7 +522,7 @@ class MainThreadEventLoop:
         self.lock.acquire(blocking=True)
         if not self.display_scheduled:
             if USE_BROWSER_THREAD:
-                set_timeout(callback, REFRESH_RATE_SEC)
+                threading.Timer(REFRESH_RATE_SEC, callback).start()
             self.display_scheduled = True
         self.lock.release()
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -634,7 +634,7 @@ class TabWrapper:
 
     def handle_quit(self):
         print("""Time in style, layout and paint: {:>.6f}s
-    ({:>.6f}ms per pipelne run on average;
+    ({:>.6f}ms per pipeline run on average;
     {} total pipeline updates)""".format(
             self.tab.time_in_style_layout_and_paint,
             self.tab.time_in_style_layout_and_paint / \


### PR DESCRIPTION
This PR:

* Removes some redundant code left over from previous PRs
* Adds a named setTimeout section
* Moves locking into the setTimeout section, where it is a natural addition and simplifies future discussions
* Gets rid of set_timeout as it was probably not adding any value, and may have been actively confusing as it has the same name as setTimeout
* Fixes various spelling errors