### PR TITLE
Simplify browser->main thread communication

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -1040,13 +1040,13 @@ to prioritize rendering.
 ``` {.python}
 class MainThreadEventLoop:
     def run(self):
-            task = None
-            self.lock.acquire(blocking=True)
-            if self.tasks.has_tasks():
-                task = self.tasks.get_next_task()
-            self.lock.release()
-            if task:
-                task()
+        task = None
+        self.lock.acquire(blocking=True)
+        if self.tasks.has_tasks():
+            task = self.tasks.get_next_task()
+        self.lock.release()
+        if task:
+            task()
 ```
 
 This works, but is quite inefficient in terms of CPU use. Even if there are no

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -1524,19 +1524,19 @@ class TabWrapper:
             scroll = self.scroll
             # ...
             self.tab.event_loop.schedule_task(
-                Task(self.tab.run_animation_frame, scroll))```
+                Task(self.tab.run_animation_frame, scroll))
+```
 
 In `Browser`:
 
 ``` {.python}
 class Browser:
     def handle_down(self):
+        scroll = clamp_scroll(
+            active_tab.scroll + SCROLL_STEP,
+            self.active_tab_height)
         # ...
-        active_tab.schedule_scroll(
-            clamp_scroll(
-                active_tab.scroll + SCROLL_STEP,
-                self.active_tab_height))
-        # ...
+        active_tab.schedule_scroll(scroll)
 ```
 
 That was pretty complicated, but we got it done. Fire up the counting demo and

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -478,18 +478,10 @@ class TaskQueue:
 class SingleThreadedEventLoop:
     def __init__(self, tab):
         self.tab = tab
-
-    def schedule_scroll(self, scroll):
-        self.tab.apply_scroll(scroll)
-
-    def schedule_animation_frame(self):
-        self.display_scheduled = True
+        self.needs_quit = False
 
     def schedule_task(self, callback):
         callback()
-
-    def schedule_scroll(self, scroll):
-        self.tab.scroll = scroll
 
     def clear_pending_tasks(self):
         pass
@@ -498,6 +490,7 @@ class SingleThreadedEventLoop:
         pass
 
     def set_needs_quit(self):
+        self.needs_quit = True
         pass
 
     def run(self):
@@ -670,7 +663,7 @@ class Browser:
     def render(self):
         assert not USE_BROWSER_THREAD
         tab = self.tabs[self.active_tab].tab
-        tab.run_animation_frame(self.tab_wrapper.scroll)
+        tab.run_animation_frame(self.tabs[self.active_tab].scroll)
 
     def set_needs_animation_frame(self):
         self.needs_animation_frame = True
@@ -915,9 +908,10 @@ if __name__ == "__main__":
                 browser.handle_key(event.text.text.decode('utf8'))
         active_tab = browser.tabs[browser.active_tab]
         if not USE_BROWSER_THREAD:
-            active_runner = active_tab.tab.event_loop
-            if active_runner.display_scheduled:
-                active_runner.display_scheduled = False
+            if active_tab.tab.event_loop.needs_quit:
+x                break
+            if active_tab.display_scheduled:
+                active_tab.display_scheduled = False
                 browser.render()
         browser.raster_and_draw()
         browser.schedule_animation_frame()

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -909,7 +909,7 @@ if __name__ == "__main__":
         active_tab = browser.tabs[browser.active_tab]
         if not USE_BROWSER_THREAD:
             if active_tab.tab.event_loop.needs_quit:
-x                break
+                break
             if active_tab.display_scheduled:
                 active_tab.display_scheduled = False
                 browser.render()

--- a/src/test12.py
+++ b/src/test12.py
@@ -19,14 +19,8 @@ class MockMainThreadEventLoop:
 	def __init__(self, tab):
 		self.tab = tab
 
-	def schedule_animation_frame(self):
-		self.tab.run_animation_frame()
-
 	def schedule_task(self, callback):
 		callback()
-
-	def schedule_scroll(self, scroll):
-		pass
 
 	def clear_pending_tasks(self):
 		pass
@@ -41,13 +35,7 @@ class MockNoOpMainThreadEventLoop:
 	def __init__(self, tab):
 		self.tab = tab
 
-	def schedule_animation_frame(self):
-		pass
-
 	def schedule_task(self, callback):
-		pass
-
-	def schedule_scroll(self, scroll):
 		pass
 
 	def start(self):


### PR DESCRIPTION
Instead of special scroll and animation frame bits, just use a task.

There turns out to already be an exercise about a scheduling strategy that prioritizes rendering.