### PR TITLE
Consolidate the three Browser dirty bits

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -571,7 +571,7 @@ The `needs_raster_and_draw` dirty bit is not just for making the browser a
 bit more efficient. Later in the chapter, we'll move raster and draw to another
 thread. If that bit was not there, then that thread would cause very erratic
 behavior when animating. Once you've read the whole chapter and implemented
-that thread, try removing this dirty bit and see for yourself.
+that thread, try removing this dirty bit and see for yourself!
 :::
 
 Scripts and rendering

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -566,6 +566,14 @@ class Browser:
         self.set_needs_raster_and_draw()
 ```
 
+::: {.further}
+The `needs_raster_and_draw` dirty bit is not just for making the browser a
+bit more efficient. Later in the chapter, we'll move raster and draw to another
+thread. If that bit was not there, then that thread would cause very erratic
+behavior when animating. Once you've read the whole chapter and implemented
+that thread, try removing this dirty bit and see for yourself.
+:::
+
 Scripts and rendering
 =====================
 

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -38,11 +38,7 @@ Once the Tab has loaded, the browser should need raster and draw.
 
     >>> browser.load(test_url)
     >>> browser.render()
-    >>> browser.needs_chrome_raster
-    True
-    >>> browser.needs_tab_raster
-    True
-    >>> browser.needs_draw
+    >>> browser.needs_raster_and_draw
     True
 
 The Tab has already committed:
@@ -66,11 +62,7 @@ After performing raster and draw, the display list should be present.
     drawString(text=Text, x=13.0, y=36.10546875, color=ff000000)
     drawString(text=), x=13.0, y=58.44921875, color=ff000000)
 
-    >>> browser.needs_chrome_raster
-    False
-    >>> browser.needs_tab_raster
-    False
-    >>> browser.needs_draw
+    >>> browser.needs_raster_and_draw
     False
 
 The initial sroll offset is 0.
@@ -81,11 +73,7 @@ The initial sroll offset is 0.
 Scrolling down causes a draw but nothing else.
 
     >>> browser.handle_down()
-    >>> browser.needs_chrome_raster
-    False
-    >>> browser.needs_tab_raster
-    False
-    >>> browser.needs_draw
+    >>> browser.needs_raster_and_draw
     True
 
     Focusing the address bar and typing into it causes chrome raster and draw,
@@ -95,11 +83,7 @@ Scrolling down causes a draw but nothing else.
     >>> browser.focus
     'address bar'
     >>> browser.handle_key('c')
-    >>> browser.needs_chrome_raster
-    True
-    >>> browser.needs_tab_raster
-    False
-    >>> browser.needs_draw
+    >>> browser.needs_raster_and_draw
     True
 
 Testing TabWrapper

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -697,7 +697,7 @@ class Browser:
         if not self.active_tab_height:
             return
         active_tab = self.tabs[self.active_tab]
-        self.needs_raster_and_draw()
+        self.set_needs_raster_and_draw()
         scroll = clamp_scroll(
             active_tab.scroll + SCROLL_STEP,
             self.active_tab_height)
@@ -717,7 +717,7 @@ class Browser:
             elif 50 <= e.x < WIDTH - 10 and 40 <= e.y < 90:
                 self.focus = "address bar"
                 self.address_bar = ""
-            self.set_needs_chrome_raster()
+            self.set_needs_raster_and_draw()
         else:
             self.focus = "content"
             self.tabs[self.active_tab].schedule_click(
@@ -729,7 +729,7 @@ class Browser:
         if not (0x20 <= ord(char) < 0x7f): return
         if self.focus == "address bar":
             self.address_bar += char
-            self.set_needs_chrome_raster()
+            self.set_needs_raster_and_draw()
         elif self.focus == "content":
             self.tabs[self.active_tab].schedule_keypress(char)
         self.lock.release()
@@ -740,7 +740,7 @@ class Browser:
             self.tabs[self.active_tab].schedule_load(self.address_bar)
             self.tabs[self.active_tab].url = self.address_bar
             self.focus = None
-            self.set_needs_chrome_raster()
+            self.set_needs_raster_and_draw()
         self.lock.release()
 
     def load(self, url):


### PR DESCRIPTION
This PR removes needs_chrome_raster, needs_tab_raster and needs_draw, and replaces them with a single dirty bit needs_raster_and_draw. Aims accomplished:

* Simplifies the code substantially (and found one bug in lab12.py as a result -- raster timing was wrong)
* Provides room for an exercise on this topic

I found that needs_raster_and_draw is necessary and can't be removed. The reason is that the browser thread event loop is unfortunately continuously polling and can't be made event-driven (because SDL doesn't seem to support it). So without this loop, the browser thread would have erratic behavior when trying to run animations, because it'd waste a lot of time doing useless rasters and delay responding to the main thread.