### PR TITLE
Improvements to the browser thread section

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -1126,11 +1126,7 @@ class TaskRunner:
 ```
 
 In `run`, implement a simple event loop scheduling strategy that runs one
-task per loop.[^not-ideal]
-
-[^not-ideal]: This is not quite the "ideal" loop described at the beginning
-of the chapter, but I hope it's clear that it would be easy to change strategies
-to prioritize rendering.
+task per loop.
 
 ``` {.python}
 class TaskRunner:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -683,10 +683,6 @@ class Browser:
         self.lock.release()
 
     def schedule_animation_frame(self):
-        if not self.needs_animation_frame:
-            return
-        self.needs_animation_frame = False
-
         def callback():
             self.lock.acquire(blocking=True)
             self.display_scheduled = False
@@ -713,13 +709,12 @@ class Browser:
         self.scroll = scroll
         self.set_needs_raster_and_draw()
         self.lock.release()
-        self.schedule_animation_frame()
 
     def set_active_tab(self, index):
         self.active_tab = index
         self.scroll = 0
         self.url = None
-        self.schedule_animation_frame()
+        self.set_needs_animation_frame()
 
     def handle_click(self, e):
         self.lock.acquire(blocking=True)
@@ -923,4 +918,6 @@ if __name__ == "__main__":
                 active_tab.display_scheduled = False
                 browser.render()
         browser.raster_and_draw()
-        browser.schedule_animation_frame()
+        if browser.needs_animation_frame:
+            browser.schedule_animation_frame()
+        browser.needs_animation_frame = False

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -656,9 +656,7 @@ class Browser:
         self.lock.release()
 
     def set_needs_animation_frame(self):
-        self.lock.acquire(blocking=True)
         self.needs_animation_frame = True
-        self.lock.release()
 
     def set_needs_raster_and_draw(self):
         self.needs_raster_and_draw = True

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -662,6 +662,7 @@ class Browser:
 
     def set_needs_raster_and_draw(self):
         self.needs_raster_and_draw = True
+        self.set_needs_animation_frame()
 
     def raster_and_draw(self):
         if not self.needs_raster_and_draw:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -754,7 +754,6 @@ class Browser:
         active_tab = self.tabs[self.active_tab]
         active_tab.task_runner.schedule_task(
             Task(active_tab.load, url, body))
-        self.set_needs_raster_and_draw()
 
     def handle_enter(self):
         self.lock.acquire(blocking=True)


### PR DESCRIPTION
* Lay out the plan in advance
* Do things in smaller chunks
* Remove some code no longer needed
* Avoid having to rename run_once by calling it run throughout
* Omit irrelevant-to-this-section code like needs_quit

Also:
* Add a new exercise on scheduling optimizations