### PR TITLE
Chapter 12 wordsmithing and polishing pass

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -1232,12 +1232,16 @@ class Tab:
         self.render()
         # ...
         self.browser.commit(
-            self.url, self.scroll,
+            self, self.url, self.scroll,
             document_height,
             self.display_list)
 ```
 
-In `Browser`:
+In `Browser`, commit will copy across the url, scroll offset and display list,
+and call `set_needs_raster_and_draw` as needed. Since each `Tab` has its own
+thread that is always running, the `tab` parameter is
+compared with the active tab to avoid committing display lists for invisible
+tabs.
 
 ``` {.python}
 class Browser:
@@ -1245,8 +1249,12 @@ class Browser:
         self.url = None
         self.scroll = 0
 
-    def commit(self, url, scroll, tab_height, display_list):
+    def commit(self, tab, url, scroll, tab_height, display_list):
         self.lock.acquire(blocking=True)
+        self.display_scheduled = False
+        if tab != self.tabs[self.active_tab]:
+            self.lock.release()
+            return
         if url != self.url or scroll != self.scroll:
             self.set_needs_raster_and_draw()
         self.url = url
@@ -1274,13 +1282,32 @@ Why the browser thread and not the main thread? The reason
 is simple: there is no point to rendering display lists
 faster than they can be drawn to the screen.
 
-Implement this by adding a `needs_animation_frame` dirty bit on `Browser`.
+Implement this by adding a `needs_animation_frame` dirty bit on `Browser`. Tabs
+call a special version of this method that uses a lock and disallows setting
+the bit for a non-active tab.^[The `Browser` use-cases that set this dirty bit
+also need a lock, but all of the calling functions already hold the lock. If
+they tried to call the version that locks then a [deadlock] would occur.]
+
+Setting the bit only for active tabs prevents others from setting a
+dirty bit they don't need (because there is nothing to display for a non-active
+tab), and elegantly prevents any `requestAnimationFrame`
+callbacks from running. Try making a second tab while the counter demo is
+running, then go back to the demo tab. Notice that it stopped counting up
+while the other tab was visible, and resumes when it is made visible again!
+
+[deadlock]: https://en.wikipedia.org/wiki/Deadlock
 
 ``` {.python}
 class Browser:
     def __init__(self):
         # ...
         self.needs_animation_frame = False
+
+    def set_tab_needs_animation_frame(self, tab):
+        self.lock.acquire(blocking=True)
+        if tab == self.tabs[self.active_tab]:
+            self.needs_animation_frame = True
+        self.lock.release()
 
     def set_needs_animation_frame(self):
         self.needs_animation_frame = True
@@ -1297,9 +1324,7 @@ if __name__ == "__main__":
     while True:
         # ...
         browser.raster_and_draw()
-        if browser.needs_animation_frame:
-            browser.schedule_animation_frame()
-        browser.needs_animation_frame = False
+        browser.schedule_animation_frame()
 ```
 
 And `schedule_animation_frame` on `Browser` works just like the version
@@ -1314,30 +1339,30 @@ class Browser:
     def schedule_animation_frame(self):
         def callback():
             self.lock.acquire(blocking=True)
-            self.display_scheduled = False
             active_tab = self.tabs[self.active_tab]
-            self.lock.release()
             active_tab.task_runner.schedule_task(
                 Task(active_tab.run_animation_frame))
+            self.lock.release()
         self.lock.acquire(blocking=True)
-        if not self.display_scheduled:
+        if not self.display_scheduled and self.needs_animation_frame:
             threading.Timer(REFRESH_RATE_SEC, callback).start()
             self.display_scheduled = True
+            self.needs_animation_frame = False
         self.lock.release()
 ```
 
-To make use of this sytem, call `set_needs_animation_frame` from
-`set_needs_render` and `request_animation_frame_callback`:
+To make use of this sytem, call `set_tab_needs_animation_frame` from
+`set_needs_render`, and also from `request_animation_frame_callback`:
 
 ``` {.python}
 class Tab:
     def set_needs_render(self):
         self.needs_render = True
-        self.browser.set_needs_animation_frame()
+        self.browser.set_tab_needs_animation_frame(self)
 
     def request_animation_frame_callback(self):
         self.needs_raf_callbacks = True
-        self.browser.set_needs_animation_frame()
+        self.browser.set_tab_needs_animation_frame(self)
 ```
 
 And also in `Browser`:
@@ -1460,9 +1485,9 @@ class Browser:
             self.lock.acquire(blocking=True)
             scroll = self.scroll
             active_tab = self.tabs[self.active_tab]
-            self.lock.release()
             active_tab.task_runner.schedule_task(
                 Task(active_tab.run_animation_frame, scroll))
+            self.lock.release()
         # ...
 ```
 
@@ -1500,7 +1525,7 @@ class Tab:
     def run_animation_frame(self, scroll):
         # ...
         self.browser.commit(
-            self.url,
+            self, self.url,
             clamped_scroll if self.scroll_changed_in_tab \
                 else None, 
             document_height, self.display_list)

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -842,74 +842,88 @@ web page is very large or complex.
 
 What if we ran raster and draw *in parallel* with the main thread, by using CPU
 parallelism? After all, they take as input only the display list and not the
-DOM. That sounds fun to try, but before adding such complexity, let's
-instrument the browser and measure how much time is really being spent in
-raster and draw.^[Pro tip: always measure before optimizing. You'll often
-be surprised at where the bottlenecks are.]
+DOM.
 
-Add a simple class measuring time spent:
+That sounds fun to try, but before adding such complexity, let's
+instrument the browser and measure how much time is really being spent
+in raster and draw.^[Pro tip: always measure before optimizing. You'll
+often be surprised at where the bottlenecks are.] We'll want to
+average across multiple raster-and-draw cycles:
 
 ``` {.python}
-class Timer:
-    def __init__(self):
-        self.time = None
+class MeasureTime:
+    def __init__(self, name):
+        self.name = name
+        self.start_time = None
+        self.total_s = 0
+        self.count = 0
 
-    def start(self):
-        self.time = time.time()
-
-    def stop(self):
-        result = time.time() - self.time
-        self.time = None
-        return result
+    def text(self):
+        avg = self.total_s / self.count
+        return "Time in {} on average: {:>.0f}ms".format(self.name, avg * 1000)
 ```
 
-Count the total time spent in the two categories. We'll also need a
-`handle_quit` hook in `Tab`, called from `Browser`, to print out the `Tab`
-rendering time.
+We'll measure the time for something like raster and draw by just
+calling `start` and `stop` methods on one of these `MeasureTime`
+objects:
+
+``` {.python}
+class MeasureTime:
+    def start(self):
+        self.start_time = time.time()
+
+    def stop(self):
+        self.total_s += time.time() - self.start_time
+        self.count += 1
+        self.start_time = None
+```
+
+Let's measure the total time for both render:
 
 ``` {.python}
 class Tab:
         # ...
-        self.time_in_render = 0.0
-        self.num_renders = 0
+        self.measure_render = MeasureTime("render")
 
     def render(self):
         if not self.needs_render:
             return
-        timer = Timer()
-        timer.start()
+        self.measure_render.start()
         # ...
-        self.time_in_render += timer.stop()
-        self.num_renders += 1
-
-    def handle_quit(self):
-        print("Time in render on average: {:>.0f}ms".format(
-            self.time_in_render / \
-                self.num_renders * 1000))
+        self.measure_render.stop()
 ```
+
+And raster-and-draw:
+
 
 ``` {.python}
 class Browser:
     def __init__(self):
-        self.time_in_raster_and_draw = 0
-        self.num_raster_and_draws = 0
+        self.measure_raster_and_draw = MeasureTime("raster-and-draw")
 
     def raster_and_draw(self):
-
         if not self.needs_raster_and_draw:
             return
         self.lock.acquire(blocking=True)
-        raster_and_draw_timer = Timer()
-        raster_and_draw_timer.start()
+        self.measure_raster_and_draw.start()
         # ...
-        self.time_in_raster_and_draw += raster_and_draw_timer.stop()
-        self.num_raster_and_draws += 1
-
-    def handle_quit(self):
-        print("Time in raster-and-draw on average: {:>.0f}ms".format(
-            self.time_in_raster_and_draw / \
-                self.num_raster_and_draws * 1000))
+        self.measure_raster_and_draw.stop()
 ```
+
+We can print out the timing measures when we quit:
+
+``` {.python}
+class Tab:
+    def handle_quit(self):
+        print(self.tab.measure_render.text())
+
+class Browser:
+    def handle_quit(self):
+        print(self.measure_raster_and_draw.text())
+```
+
+Naturally we'll need to call the `Tab`'s `handle_quit` method before
+quitting, so it has a chance to print its timing data.
 
 Now fire up the server and navigate to `/count`.^[The full URL will probably be
 `http://localhost:8000/count`] When it's done counting, click the close button

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -228,7 +228,7 @@ class JSContext:
         threading.Timer(time / 1000.0, run_callback).start()
 ```
 
-Now only the main thread will call `evaljs`, which is better. But now
+Now only the primary thread will call `evaljs`,. But now
 we have two threads accessing the `task_runner`: the main thread, to
 run tasks, and the timer thread, to add them. This is a [race
 condition](https://en.wikipedia.org/wiki/Race_condition) that can

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -85,7 +85,9 @@ class Tab:
 
 First-in-first-out is a simplistic way to choose which task to run
 next, and real browsers have sophisticated *schedulers* which consider
-things like XXX.
+[many different factors][chrome-scheduling].
+
+[chrome-scheduling]: https://blog.chromium.org/2015/04/scheduling-tasks-intelligently-for_30.html
 
 To run those tasks, we need to call the `run` method on our
 `TaskRunner`, which we can do in the main event loop:
@@ -322,7 +324,10 @@ function XMLHttpRequest() {
 ```
 
 When a script calls the `open` method on an `XMLHttpRequest` object,
-we'll now allow the `is_async` flag to be true:
+we'll now allow the `is_async` flag to be true:[^async-default]
+
+[^async-default]: In browsers, the default for `is_async` is `true`,
+    which the code below does not implement just for expedience.
 
 ``` {.javascript file=runtime}
 XMLHttpRequest.prototype.open = function(method, url, is_async) {
@@ -367,10 +372,9 @@ class JSContext:
         def run_load():
             headers, body = request(
                 full_url, self.tab.url, payload=body)
-            if is_async:
-                self.tab.task_runner.schedule_task(task)
-            else:
-                return body
+            task = Task(self.dispatch_xhr_onload, body, handle)
+            self.tab.task_runner.schedule_task(task)
+            return body
 ```
 
 Finally, depending on the `is_async` flag the browser will either call

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -716,7 +716,7 @@ The cadence of rendering
 
 So what should this cadence be? Well, clearly it shouldn't go faster
 than the display hardware can refresh. On most computers, this is 60 times
-per second, or 16ms per frame (`60 * 16.66ms ~= 1s`).
+per second, or 16ms per frame (`60*16.66ms ~= 1s`).
 
 Ideally, the cadence shouldn't be slower than that either, so that animations
 are as smooth as possibile. This was discussed briefly in Chapter 2 as well,
@@ -870,72 +870,45 @@ rendering time.
 ``` {.python}
 class Tab:
         # ...
-        self.time_in_style_layout_and_paint = 0.0
+        self.time_in_render = 0.0
         self.num_renders = 0
 
     def render(self):
-        # ...
+        if not self.needs_render:
+            return
         timer = Timer()
         timer.start()
-        style(self.nodes, sorted(self.rules,
-            key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
-        self.document.layout()
-        self.display_list = []
-        self.document.paint(self.display_list)
         # ...
-        self.time_in_style_layout_and_paint += timer.stop()
+        self.time_in_render += timer.stop()
         self.num_renders += 1
 
     def handle_quit(self):
-        print("""Time in style, layout and paint: {:>.6f}s
-    ({:>.6f}ms per render on average;
-    {} total renders)""".format(
-            self.time_in_style_layout_and_paint,
-            self.time_in_style_layout_and_paint / \
-                self.num_renders * 1000,
-            self.num_renders))
-        # ...
+        print("Time in render on average: {:>.0f}ms".format(
+            self.time_in_render / \
+                self.num_renders * 1000))
 ```
 
 ``` {.python}
 class Browser:
     def __init__(self):
-        self.time_in_raster = 0
-        self.time_in_draw = 0
+        self.time_in_raster_and_draw = 0
         self.num_raster_and_draws = 0
 
     def raster_and_draw(self):
+
         if not self.needs_raster_and_draw:
             return
+        self.lock.acquire(blocking=True)
+        raster_and_draw_timer = Timer()
+        raster_and_draw_timer.start()
+        # ...
+        self.time_in_raster_and_draw += raster_and_draw_timer.stop()
         self.num_raster_and_draws += 1
 
-        raster_timer = Timer()
-        raster_timer.start()
-        self.raster_chrome()
-        self.raster_tab()
-        self.time_in_raster += raster_timer.stop()
-
-        draw_timer = Timer()
-        draw_timer.start()
-        self.draw()
-        self.time_in_draw += draw_timer.stop()
-        self.needs_raster_and_draw = False
-
     def handle_quit(self):
-        print("""Time in raster: {:>.6f}s
-    ({:>.6f}ms per raster run on average;
-    {} total rasters)""".format(
-            self.time_in_raster,
-            self.time_in_raster / \
-                self.num_raster_and_draws * 1000,
-            self.num_raster_and_draws))
-        print("""Time in draw: {:>.6f}s
-    ({:>.6f}ms per draw run on average;
-    {} total draw updates)""".format(
-            self.time_in_draw,
-            self.time_in_draw / self.num_raster_and_draws * 1000,
-            self.num_raster_and_draws))
+        print("Time in raster-and-draw on average: {:>.0f}ms".format(
+            self.time_in_raster_and_draw / \
+                self.num_raster_and_draws * 1000))
 ```
 
 Now fire up the server and navigate to `/count`.^[The full URL will probably be
@@ -943,47 +916,42 @@ Now fire up the server and navigate to `/count`.^[The full URL will probably be
 on the window. The browser will print out the total time spent in each
 category. When I ran it on my computer, it said:
 
-Time in raster: 1.379575s
-    (13.659154ms per raster run on average;
-    101 total rasters)
-Time in draw: 2.961407s
-    (29.320861ms per draw run on average;
-    101 total draw updates)
-Time in style, layout and paint: 2.192260s
-    (21.922598ms per render on average;
-    100 total renders)
+    Time in raster-and-draw on average: 66ms
+    Time in render on average: 20ms
 
-Over a total of 100 frames of animation, the browser spent about 50ms
-rastering per frame,[^raster-draw] and 30ms drawing. That's a lot, and certainly
-greater than our 16ms time budget.
-
-On the other hand, the browser spent about 20ms per animation frame in the other
-phases, which is also a lot. We'll see how to optimize that in
-a future chapter.
-
-Based on these timings, the first thing to try is optimizing
-draw. I profiled it in more depth, and found that each of the
-surface-drawing-into-surface steps (of which there are three) take a
-significant amount of time.[^profile-draw] (I told you that
-[optimizing surfaces](visual-effects.md#optimizing-surface-use) was important!) 
-
-But even if those surfaces were optimized (not such an easy feat), raster is
-still very expensive. So we should see a win by running raster and draw on a
-parallel thread.
-
-[^profile-draw]: I encourage you to do this profiling, to see for yourself.
-
-[^raster-draw]: When I first wrote this section of the chapter, I was surprised
-at how high the raster and draw time was, so I went back and added the separate
-draw timer that you see in the code above. Profiling your code often yields
-interesting insights!
+Over a total of 100 frames of animation, the browser spent abou 20ms in `render`
+and aboutt 66ms in `raster_and_draw` per animation frame. Therefore, moving
+`raster_and_draw` to a second thread has the potential to reduce total
+rendering time from 88ms to 66ms by running the two operations in parallel. In
+addition, there would only be a 20ms delay to any other main-thread task that
+wants to run after rendering. That's more than enough of a win to justify
+the second thread.
 
 ::: {.further}
-The best way to optimize `draw` is to perform raster and draw on the GPU (and
-modern browsers do this), so that the draws can happen in parallel in GPU
-hardware. Skia also supports this, so you could try it. But raster and draw
-sometimes really do take a lot of time on complex pages, even
-with the GPU. So rendering pipeline parallelism is a performance win regardless.
+
+If you profile just raster and draw, you'll find that there is lots of time
+spent doing both. Within draw, each drawing-into-surface step takes a
+significant amount of time. I told you that
+[optimizing surfaces](visual-effects.md#optimizing-surface-use) was important!
+In any case, I encourage you to do this profiling, to see for yourself.
+
+The best way to optimize `draw` is to perform raster and draw on the
+GPU---modern browsers do this---so that the draws can happen in parallel in GPU
+hardware. Skia supports GPU raster, so you could try it. But raster and draw
+sometimes really do take a lot of time on complex pages, even with the GPU. So
+rendering pipeline parallelism is a performance win regardless, and if it's
+done in a separate process, there are also security advantages.
+
+Further, even with the second thread, the browser thread is somewhat
+unresponsive to clicks and scrolls---it's not good to wait around 66ms
+before *starting* to handle a click event! For this reason, modern browsers run
+raster and draw on [*yet more* threads or processes][renderingng-architecture].
+ This change finally the browser thread extremely responsive
+to input.[^thread-exercise]
+
+[^thread-exercise]: I've left this task to an exercise.
+
+[renderingng-architecture]: https://developer.chrome.com/blog/renderingng-architecture/#process-and-thread-structure
 :::
 
 Slow scripts
@@ -1251,10 +1219,10 @@ class Browser:
 
     def commit(self, tab, url, scroll, tab_height, display_list):
         self.lock.acquire(blocking=True)
-        self.display_scheduled = False
         if tab != self.tabs[self.active_tab]:
             self.lock.release()
             return
+        self.display_scheduled = False
         if url != self.url or scroll != self.scroll:
             self.set_needs_raster_and_draw()
         self.url = url
@@ -1968,3 +1936,11 @@ present.
    rendering cadence. This problem can be lessened by *prioritizing* rendering
    tasks: placing them in a separate queue that can take priority over
    other tasks. Implement this.
+
+* *Raster-and-draw thread*: the browser thread is currently not very responsive
+   to input events, because raster and draw are
+   [slow](#parallel-rendering). Fix this by adding a raster-and-draw thread
+   controlled by the browser thread, so that the browser thread is no longer
+   blocked on this work. Be careful to take into account that SDL is not
+   thread-safe, so all of the steps that directly use SDL still need to happen
+   on the browser thread.

--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -920,7 +920,7 @@ category. When I ran it on my computer, it said:
     Time in render on average: 20ms
 
 Over a total of 100 frames of animation, the browser spent abou 20ms in `render`
-and aboutt 66ms in `raster_and_draw` per animation frame. Therefore, moving
+and about 66ms in `raster_and_draw` per animation frame. Therefore, moving
 `raster_and_draw` to a second thread has the potential to reduce total
 rendering time from 88ms to 66ms by running the two operations in parallel. In
 addition, there would only be a 20ms delay to any other main-thread task that

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -100,7 +100,7 @@ Testing TabWrapper
     >>> browser.scroll == 0
     True
 
-    >>> browser.commit("test-url", 1, 24, [3])
+    >>> browser.commit(browser.tabs[0], "test-url", 1, 24, [3])
     >>> browser.url
     'test-url'
     >>> browser.scroll

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -31,17 +31,24 @@ from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import DocumentLayout, DrawLine, parse_color
 
-class Timer:
-    def __init__(self):
-        self.time = None
+class MeasureTime:
+    def __init__(self, name):
+        self.name = name
+        self.start_time = None
+        self.total_s = 0
+        self.count = 0
 
     def start(self):
-        self.time = time.time()
+        self.start_time = time.time()
 
     def stop(self):
-        result = time.time() - self.time
-        self.time = None
-        return result
+        self.total_s += time.time() - self.start_time
+        self.count += 1
+        self.start_time = None
+
+    def text(self):
+        avg = self.total_s / self.count
+        return "Time in {} on average: {:>.0f}ms".format(self.name, avg * 1000)
 
 FONTS = {}
 
@@ -304,8 +311,7 @@ class Tab:
             self.task_runner = SingleThreadedTaskRunner(self)
         self.task_runner.start()
 
-        self.time_in_render = 0.0
-        self.num_renders = 0
+        self.measure_render = MeasureTime("render")
 
         with open("browser8.css") as f:
             self.default_style_sheet = CSSParser(f.read()).parse()
@@ -423,8 +429,7 @@ class Tab:
     def render(self):
         if not self.needs_render:
             return
-        timer = Timer()
-        timer.start()
+        self.measure_render.start()
         style(self.nodes, sorted(self.rules,
             key=cascade_priority))
         self.document = DocumentLayout(self.nodes)
@@ -440,8 +445,7 @@ class Tab:
             y = obj.y
             self.display_list.append(
                 DrawLine(x, y, x, y + obj.height))
-        self.time_in_render += timer.stop()
-        self.num_renders += 1
+        self.measure_render.stop()
         self.needs_render = False
 
     def click(self, x, y):
@@ -505,11 +509,6 @@ class Tab:
             self.history.pop()
             back = self.history.pop()
             self.load(back)
-
-    def handle_quit(self):
-        print("Time in render on average: {:>.0f}ms".format(
-            self.time_in_render / \
-                self.num_renders * 1000))
 
 
 WIDTH, HEIGHT = 800, 600
@@ -578,7 +577,7 @@ class TaskRunner:
             needs_quit = self.needs_quit
             self.lock.release()
             if needs_quit:
-                self.tab.handle_quit()
+                self.handle_quit()
                 return
 
             task = None
@@ -588,6 +587,9 @@ class TaskRunner:
             self.lock.release()
             if task:
                 task.run()
+
+    def handle_quit(self):
+        print(self.tab.measure_render.text())
 
 REFRESH_RATE_SEC = 0.016 # 16ms
 
@@ -613,8 +615,7 @@ class Browser:
         self.url = None
         self.scroll = 0
 
-        self.time_in_raster_and_draw = 0
-        self.num_raster_and_draws = 0
+        self.measure_raster_and_draw = MeasureTime("raster-and-draw")
 
         if sdl2.SDL_BYTEORDER == sdl2.SDL_BIG_ENDIAN:
             self.RED_MASK = 0xff000000
@@ -671,15 +672,13 @@ class Browser:
         if not self.needs_raster_and_draw:
             return
         self.lock.acquire(blocking=True)
-        raster_and_draw_timer = Timer()
-        raster_and_draw_timer.start()
+        self.measure_raster_and_draw.start()
 
         self.raster_chrome()
         self.raster_tab()
         self.draw()
 
-        self.time_in_raster_and_draw += raster_and_draw_timer.stop()
-        self.num_raster_and_draws += 1
+        self.measure_raster_and_draw.stop()
         self.needs_raster_and_draw = False
         self.lock.release()
 
@@ -860,10 +859,7 @@ class Browser:
         sdl2.SDL_UpdateWindowSurface(self.sdl_window)
 
     def handle_quit(self):
-        print("Time in raster-and-draw on average: {:>.0f}ms".format(
-            self.time_in_raster_and_draw / \
-                self.num_raster_and_draws * 1000))
-
+        print(self.measure_raster_and_draw.text())
         self.tabs[self.active_tab].task_runner.set_needs_quit()
         sdl2.SDL_DestroyWindow(self.sdl_window)
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -529,6 +529,7 @@ class SingleThreadedTaskRunner:
     def __init__(self, tab):
         self.tab = tab
         self.needs_quit = False
+        self.lock = threading.Lock()
 
     def schedule_task(self, callback):
         callback.run()
@@ -900,8 +901,8 @@ if __name__ == "__main__":
         if not USE_BROWSER_THREAD:
             if active_tab.task_runner.needs_quit:
                 break
-            if active_tab.display_scheduled:
-                active_tab.display_scheduled = False
+            if browser.display_scheduled:
+                browser.display_scheduled = False
                 browser.render()
         browser.raster_and_draw()
         browser.schedule_animation_frame()

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -261,10 +261,8 @@ class JSContext:
             headers, body = request(
                 full_url, self.tab.url, payload=body)
             task = Task(self.dispatch_xhr_onload, body, handle)
-            if is_async:
-                self.tab.task_runner.schedule_task(task)
-            else:
-                return body
+            self.tab.task_runner.schedule_task(task)
+            return body
 
         if not is_async:
             return run_load(is_async)

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -527,7 +527,7 @@ class Task:
         self.args = args
         self.__name__ = "task"
 
-    def __call__(self):
+    def run(self):
         self.task_code(*self.args)
         self.task_code = None
         self.args = None
@@ -538,7 +538,7 @@ class SingleThreadedTaskRunner:
         self.needs_quit = False
 
     def schedule_task(self, callback):
-        callback()
+        callback.run()
 
     def clear_pending_tasks(self):
         pass
@@ -593,7 +593,7 @@ class TaskRunner:
                 task = self.tasks.pop(0)
             self.lock.release()
             if task:
-                task()
+                task.run()
 
 REFRESH_RATE_SEC = 0.016 # 16ms
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -260,9 +260,11 @@ class JSContext:
         def run_load():
             headers, body = request(
                 full_url, self.tab.url, payload=body)
-            self.tab.task_runner.schedule_task(
-                Task(self.dispatch_xhr_onload, body, handle))
-            return body
+            task = Task(self.dispatch_xhr_onload, body, handle)
+            if is_async:
+                self.tab.task_runner.schedule_task(task)
+            else:
+                return body
 
         if not is_async:
             return run_load(is_async)


### PR DESCRIPTION
This PR contains a pass over roughly the first half of Chapter 12. It does minor reorganizations, wordsmithing, and polish, plus a couple of major changes:

- [x] Merge the Tasks and Task Queues sections. With the various changes throughout the chapter over the last month, there's much less need for an organizational section at the top, and we can use it to introduce the `Task` and `TaskRunner` instead.
- [x] Replace `Task.__call__` with `Task.run`. The use of the `__call__` convention goes back to initial experiments with the Tkinter task queue.
- [x] Rephrased the discussion of multiple threads and locks to be positive ("we have to do XXX") instead of negative ("we're done! but we have a bug")
- [x] Renamed `xhr_onload` to `dispatch_xhr_onload` to parallel `dispatch_event`
