### PR TITLE
Pass over threads section of Chapter 12

### DIFF
--- a/book/scheduling-and-threading.md
+++ b/book/scheduling-and-threading.md
@@ -962,8 +962,8 @@ extremely responsive to input, at the cost of even more complexity.
 
 [renderingng-architecture]: https://developer.chrome.com/blog/renderingng-architecture/#process-and-thread-structure
 
-The browser thread
-==================
+Two threads
+===========
 
 Running rendering in parallel with raster and draw would allow us to
 produce a new frame every 66ms, instead of every 88ms. But more

--- a/src/eventloop12.js
+++ b/src/eventloop12.js
@@ -1,23 +1,14 @@
 var count = 0;
-var start_time = Date.now();
-var cur_frame_time = start_time;
-
-artificial_delay_ms = 200;
 
 function callback() {
     if (count == 0)
         requestXHR();
 
-    var since_last_frame = Date.now() - cur_frame_time;
-    while (since_last_frame < artificial_delay_ms) {
-        var since_last_frame = Date.now() - cur_frame_time;
-    }
-    var total_elapsed = Date.now() - start_time;
+    for (var i = 0; i < 1e9; i++);
     var output = document.querySelectorAll("div")[1];
     output.innerHTML = "count: " + (count++);
     if (count < 100)
         requestAnimationFrame(callback);
-    cur_frame_time = Date.now()
 }
 requestAnimationFrame(callback);
 

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -100,7 +100,8 @@ Testing TabWrapper
     >>> browser.scroll == 0
     True
 
-    >>> browser.commit(browser.tabs[0], "test-url", 1, 24, [3])
+    >>> commit_data = lab12.CommitForRaster("test-url", 1, 24, [3])
+    >>> browser.commit(browser.tabs[0], commit_data)
     >>> browser.url
     'test-url'
     >>> browser.scroll

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -401,11 +401,11 @@ class Tab:
 
     def set_needs_render(self):
         self.needs_render = True
-        self.browser.set_tab_needs_animation_frame(self)
+        self.browser.set_needs_animation_frame(self)
 
     def request_animation_frame_callback(self):
         self.needs_raf_callbacks = True
-        self.browser.set_tab_needs_animation_frame(self)
+        self.browser.set_needs_animation_frame(self)
 
     def run_animation_frame(self, scroll):
         self.scroll = scroll
@@ -658,18 +658,15 @@ class Browser:
         self.set_needs_raster_and_draw()
         self.lock.release()
 
-    def set_tab_needs_animation_frame(self, tab):
+    def set_needs_animation_frame(self, tab):
         self.lock.acquire(blocking=True)
         if tab == self.tabs[self.active_tab]:
             self.needs_animation_frame = True
         self.lock.release()
 
-    def set_needs_animation_frame(self):
-        self.needs_animation_frame = True
-
     def set_needs_raster_and_draw(self):
         self.needs_raster_and_draw = True
-        self.set_needs_animation_frame()
+        self.needs_animation_frame = True
 
     def raster_and_draw(self):
         if not self.needs_raster_and_draw:
@@ -717,7 +714,7 @@ class Browser:
         self.active_tab = index
         self.scroll = 0
         self.url = None
-        self.set_needs_animation_frame()
+        self.needs_animation_frame = True
 
     def handle_click(self, e):
         self.lock.acquire(blocking=True)


### PR DESCRIPTION
This PR makes a couple of big changes to Chapter 12, from the profiling section through threading and threaded scrolling.

- Does all the profiling before introducing the idea of threaded rendering.
- Moves "slow scripts" section to be right before threaded scrolling, which it motivates.
- Makes `set_needs_animation_frame` the one that checks tab identity, and makes calls from `Browser` directly modify the variable.
- Replaces the many arguments to `commit` with a new `CommitForRaster` object, and add some text about ownership.