### PR TITLE
Invert the order of rendering sections

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1275,7 +1275,7 @@ do that inside `commit`.
 On the `Browser` side, the new `commit` method needs to read out all
 of the data it was sent and call `set_needs_raster_and_draw` as
 needed. Because this call will come from another thread, we'll need to
-take a lock:
+acquire a lock:
 
 ``` {.python}
 class Browser:

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -29,7 +29,7 @@ the TaskRunner and run all the tests on the same thread as the Browser.
 
 Before load, there is no tab height or display list.
 
-	>>> browser.active_tab_height == None
+	>>> browser.active_tab_height == 0
 	True
     >>> browser.active_tab_display_list == None
     True


### PR DESCRIPTION
This PR changes around the order of the rendering sections. It now introduces the steady rendering cadence _first_, then introduces the dirty bits, and sets up `needs_animation_frame` once we start talking about `requestAnimationFrame`.

The other big change is to set up `schedule_animation_frame` on the `Browser` from the beginning, which means we need to change less in the two-threads section. That makes that section a little easier.