### PR TITLE
Chapter 12 final pass

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1221,7 +1221,7 @@ Communication in the other direction is a little subtler.
 
 Originally, threads were a mechanism for improving *responsiveness*
 via pre-emptive multitasking, not *throughput* (frames per second).
-Nowadays, even phones have several cores plus a highly parallel GPU,
+Nowadays, though, even phones have several cores plus a highly parallel GPU,
 and threads are much more powerful. It's therefore useful to
 distinguish between conceptual events; event queues and dependencies
 between them; and their implementation on a computer architecture.
@@ -1519,11 +1519,14 @@ so, and only store the browser thread's scroll offset if
 
 [^scroll-complicated]: Two-threaded scroll has a lot of edge cases,
 including some I didn't anticipate when writing this chapter. For
-example, it's pretty clear that a load should force scroll to 0, but
+example, it's pretty clear that a load should force scroll to 0
+(unless the browser implements [scroll restoration][scroll-restoration]!), but
 what about a scroll clamp followed by a browser scroll that brings it
 back to within the clamped region? By splitting the browser into two
 threads, we've brought in all of the challenges of concurrency and
 distributed state.
+
+[scroll-restoration]: https://developer.mozilla.org/en-US/docs/Web/API/History/scrollRestoration
 
 ``` {.python}
 class Tab:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -446,7 +446,8 @@ class TaskRunner:
             needs_quit = self.needs_quit
             self.lock.release()
             if needs_quit:
-                return self.handle_quit()
+                self.handle_quit()
+                return
 
             task = None
             self.lock.acquire(blocking=True)

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -157,8 +157,7 @@ class JSContext:
         if not isasync:
             return run_load()
         else:
-            load_thread = threading.Thread(target=run_load)
-            load_thread.start()
+            threading.Thread(target=run_load).start()
 
     def now(self):
         return int(time.time() * 1000)
@@ -447,8 +446,7 @@ class TaskRunner:
             needs_quit = self.needs_quit
             self.lock.release()
             if needs_quit:
-                self.handle_quit()
-                return
+                return self.handle_quit()
 
             task = None
             self.lock.acquire(blocking=True)
@@ -561,8 +559,7 @@ class Browser:
 
     def handle_down(self):
         self.lock.acquire(blocking=True)
-        if not self.active_tab_height:
-            return
+        if not self.active_tab_height: return
         active_tab = self.tabs[self.active_tab]
         scroll = clamp_scroll(
             self.scroll + SCROLL_STEP,


### PR DESCRIPTION
This final pass does a lot of small wording changes, and moves around a bunch of go-furthers so they are 1:1 with sections. It also:

- Adds a go-further on refresh rates
- Merges two go-furthers on allocating event loops to cores
- Adds a section, "Committing display lists", to split the mega-section into two