### PR TITLE
Fix the animation frame cadence

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1311,7 +1311,6 @@ class Browser:
             self.active_tab_height = data.height
             if data.display_list:
                 self.active_tab_display_list = data.display_list
-            self.needs_animation_frame = False
             self.animation_timer = None
             self.set_needs_raster_and_draw()
         self.lock.release()
@@ -1512,6 +1511,7 @@ class Browser:
             self.lock.acquire(blocking=True)
             scroll = self.scroll
             active_tab = self.tabs[self.active_tab]
+            self.needs_animation_frame = False
             task = Task(active_tab.run_animation_frame, scroll)
             active_tab.task_runner.schedule_task(task)
             self.lock.release()

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -522,7 +522,6 @@ class Browser:
             self.active_tab_height = data.height
             if data.display_list:
                 self.active_tab_display_list = data.display_list
-            self.needs_animation_frame = False
             self.animation_timer = None
             self.set_needs_raster_and_draw()
         self.lock.release()
@@ -553,6 +552,7 @@ class Browser:
             self.lock.acquire(blocking=True)
             scroll = self.scroll
             active_tab = self.tabs[self.active_tab]
+            self.needs_animation_frame = False
             self.lock.release()
             task = Task(active_tab.run_animation_frame, scroll)
             active_tab.task_runner.schedule_task(task)


### PR DESCRIPTION
needs_animation_frame is not enough to avoid scheduling tons of extra rendering tasks. For example, once it's true the browser thread will go wild adding more timers. This is what display_scheduled avoided before it was removed last week.

I've re-added display_scheduled via the back door in a way that doesn't look like a dirty bit: put an animation_timer object on Browser that is cleared in commit.

Before this PR, the task list quickly got enormous and it looked like typing into the url bar to load a new page was broken. Now it's very responsive.

This PR also applies some more editorial fixes I found in re-reading today.