### PR TITLE
Fix the animation frame cadence

### DIFF
--- a/src/lab12.py
+++ b/src/lab12.py
@@ -423,9 +423,9 @@ class TaskRunner:
         self.main_thread = threading.Thread(target=self.run)
         self.needs_quit = False
 
-    def schedule_task(self, callback):
+    def schedule_task(self, task):
         self.lock.acquire(blocking=True)
-        self.tasks.append(callback)
+        self.tasks.append(task)
         self.lock.release()
 
     def set_needs_quit(self):
@@ -499,6 +499,8 @@ class Browser:
             self.BLUE_MASK = 0x00ff0000
             self.ALPHA_MASK = 0xff000000
 
+        self.animation_timer = None
+
         self.needs_animation_frame = False
         self.needs_raster_and_draw = False
 
@@ -519,7 +521,7 @@ class Browser:
             self.active_tab_height = data.height
             if data.display_list:
                 self.active_tab_display_list = data.display_list
-            self.needs_animation_frame = False
+            self.animation_timer = None
             self.set_needs_raster_and_draw()
         self.lock.release()
 
@@ -549,13 +551,16 @@ class Browser:
             self.lock.acquire(blocking=True)
             scroll = self.scroll
             active_tab = self.tabs[self.active_tab]
+            self.needs_animation_frame = False
             self.lock.release()
             task = Task(active_tab.run_animation_frame, scroll)
             active_tab.task_runner.schedule_task(task)
         self.lock.acquire(blocking=True)
-        if self.needs_animation_frame:
+        if self.needs_animation_frame and not self.animation_timer:
             if USE_BROWSER_THREAD:
-                threading.Timer(REFRESH_RATE_SEC, callback).start()
+                self.animation_timer = \
+                    threading.Timer(REFRESH_RATE_SEC, callback)
+                self.animation_timer.start()
         self.lock.release()
 
     def handle_down(self):


### PR DESCRIPTION
needs_animation_frame is not enough to avoid scheduling tons of extra rendering tasks. For example, once it's true the browser thread will go wild adding more timers. This is what display_scheduled avoided before it was removed last week.

I've re-added display_scheduled via the back door in a way that doesn't look like a dirty bit: put an animation_timer object on Browser that is cleared in commit.

Before this PR, the task list quickly got enormous and it looked like typing into the url bar to load a new page was broken. Now it's very responsive.

This PR also applies some more editorial fixes I found in re-reading today.