### PR TITLE
Switch to GPU-backed surfaces in Chapter 13

### DIFF
--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1639,7 +1639,9 @@ class Browser:
                 skia.kRGBA_8888_ColorType, skia.ColorSpace.MakeSRGB())
         assert self.root_surface is not None
 
-        self.chrome_surface = skia.Surface(WIDTH, CHROME_PX)
+        self.chrome_surface =  skia.Surface.MakeRenderTarget(
+                self.skia_context, skia.Budgeted.kNo,
+                skia.ImageInfo.MakeN32Premul(WIDTH, CHROME_PX))
 
         self.tabs = []
         self.active_tab = None


### PR DESCRIPTION
This improves the speed of raster and draw substantially (80ms -> 30ms)

(It's still not as fast as it could be; now we need to stop reallocating the surfaces on every composite.)