### PR TITLE
Don't re-raster unless necessary

### DIFF
--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1487,9 +1487,6 @@ class TaskRunner:
     def handle_quit(self):
         print(self.tab.measure_render.text())
 
-    def handle_quit(self):
-        print(self.tab.measure_render.text())
-
 REFRESH_RATE_SEC = 0.016 # 16ms
 
 class PaintChunk:
@@ -1658,6 +1655,9 @@ class Browser:
             WIDTH, HEIGHT, sdl2.SDL_WINDOW_SHOWN | sdl2.SDL_WINDOW_OPENGL)
         self.gl_context = sdl2.SDL_GL_CreateContext(self.sdl_window)
         self.skia_context = skia.GrDirectContext.MakeGL()
+
+        print("OpenGL initialied: vendor={}, renderer={}".format(
+            GL.glGetString(GL.GL_VENDOR), GL.glGetString(GL.GL_RENDERER)))
 
         self.root_surface = skia.Surface.MakeFromBackendRenderTarget(
             self.skia_context,
@@ -1937,6 +1937,7 @@ class Browser:
     def handle_quit(self):
         print(self.measure_composite_raster_and_draw.text())
         self.tabs[self.active_tab].task_runner.set_needs_quit()
+        sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
 if __name__ == "__main__":


### PR DESCRIPTION
With all the changes below, animations are extremely fast and about 0ms per frame.

This PR:

* Avoids tab or chrome raster unless the chrome needs it or re-compositing is needed
* "Re-compositing" is a proxy for "anything was painted by the main thread except for animation updates"

To make this useful, this PR also:
* Separates raster and draw into different dirty bits

And fixes some bugs/enhances things:
* Clear display lists and composited layers when switching tabs or changing documents
* Print GL renderer and vendor
* Delete GL context on quit