### PR TITLE
Update next link in Chapter 10

### DIFF
--- a/book/security.md
+++ b/book/security.md
@@ -2,7 +2,7 @@
 title: Keeping Data Private
 chapter: 10
 prev: scripts
-next: reflow
+next: visual-effects
 ...
 
 Our browser has grown up and now runs (small) web applications. With


### PR DESCRIPTION
The original next link pointed to `reflow`, but it's not published yet. Putting `visual-effects`, which is Chapter 11 and has `security` as prev.

Fixes #400