### PR TITLE
Remove rotation translation support

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -338,13 +338,11 @@ def try_numeric_animation(node, name,
         old_value = float(old_style[name])
         new_value = float(new_style[name])
 
-    change_per_frame = (new_value - old_value) / num_frames
-
     if not node in tab.animations:
         tab.animations[node] = {}
     tab.animations[node][name] = NumericAnimation(
-        node, name, is_px, old_value,
-        num_frames, change_per_frame, tab)
+        node, name, is_px, old_value, new_value,
+        num_frames, tab)
 ```
 
 [^more-units]: In a real browsers, there are a [lot more][units] units to
@@ -362,13 +360,13 @@ returns `False` if the animation has ended.
 class NumericAnimation:
     def __init__(
         self, node, property_name, is_px,
-        old_value, num_frames, change_per_frame, tab):
+        old_value, new_value, num_frames, tab):
         self.node = node
         self.property_name = property_name
         self.is_px = is_px
         self.old_value = old_value
         self.num_frames = num_frames
-        self.change_per_frame = change_per_frame
+        self.change_per_frame = (new_value - old_value) / num_frames
         self.tab = tab
         self.frame_count = 0
         self.animate()
@@ -740,13 +738,11 @@ when allocating a surface for animated content, we'll have to check the
 remainder of the display list for potential overlaps.
 
 We're now ready to start digging into the compositing algorithm and how to
-implement it, except for one thing: there is no way in our current browser
-for content to overlap! The example in this section used `position:relative`,
-`top` and `left`, CSS properties our browser doesn't have. So to investigate
-overlap, we *could* just add those properties. But overlap can also be
-caused by CSS transform, and in fact transforms are a very common form of
-visual effect animation on websites. So let's implement that and then come
-back to implementing compositing.
+implement it, except for one thing: there is no way in our current browser for
+content to overlap! The example in this section used the `transform` CSS
+property, which is not yet present in our browser. Not only that, but
+transforms are a common visual effect animation on websites. So let's implement
+that and then come back to implementing compositing.
 
 ::: {.further}
 TODO: describe the problem of layer explosion. Explain how this can actually
@@ -759,66 +755,37 @@ Transform animations
 The `transform` CSS property lets you apply linear transform visual
 effects to an element.[^not-always-visual] In general, you can apply
 [any linear transform][transform-def] in 3D space, but I'll just cover really
-basic  2D rotations and translations. Here's an example of rotation:
+basic 2D translations. Here's HTML for the overlap example mentioned in the
+last section:
 
 [^not-always-visual]: Technically it's not always just a visual effect. In
 real browsers, transformed element positions contribute to scrolling overflow.
 
 [transform-def]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
 
-    <div style="width:200px;height:200px;background:lightblue;
-                transform:rotate(10deg)">
-        Rotated ten<br>degrees clockwise
-    </div>
+    <div style="width:200px;height:200px;
+                background-color:lightblue"></div>
+    <div style="width:200px;height:200px;
+                background-color:lightgreen;
+                transform:translate(100px, -100px"></div>
 
-That renders like this:
-
-<div style="width:200px;height:200px;background:lightblue;transform:rotate(10deg)">
-Rotated ten<br>degrees clockwise
-</div>
-
-The origin of the rotation is the middle-point of the layout box of the element.
-
-And here's an example of translation:
-
-    <div style="width:200px;height:200px;background:lightblue;
-                transform:translate(150px, 0px)">
-        Translated 150px horizontally
-    </div>
-
-That renders like this:
-
-<div style="width:200px;height:200px;background:lightblue;transform:translate(150px, 0px)">
-Translated 150px horizontally
-</div>
-
-Adding in support for rendering `rotate` and `translate` is not too hard: first
+Adding in support for this kind of transform is not too hard: first
 just parse it:[^space-separated]
 
 [^space-separated]: The CSS transform syntax allows multiple transforms in a
 space-separated sequence; the end result is the composition of the transform.
-I won't implement that.
+I won't implement that, just like I didn't implement many other parts of the
+standardized transform syntax.
 
 ``` {.python}
-def parse_rotation_transform(transform_str):
-    left_paren = transform_str.find('(')
-    right_paren = transform_str.find('deg)')
-    return float(transform_str[left_paren + 1:right_paren])
-
-def parse_translate_transform(transform_str):
+def parse_transform(transform_str):
+    if transform_str.find('translate') < 0:
+        return None
     left_paren = transform_str.find('(')
     right_paren = transform_str.find(')')
     (x_px, y_px) = \
         transform_str[left_paren + 1:right_paren].split(",")
     return (float(x_px[:-2]), float(y_px[:-2]))
-
-def parse_transform(transform_str):
-    if transform_str.find('translate') >= 0:
-        return (parse_translate_transform(transform_str), None)
-    elif transform_str.find('rotate') >= 0:
-        return (None, parse_rotation_transform(transform_str))
-    else:
-        return (None, None)
 ```
 
 And add some code to `paint_visual_effects`:
@@ -826,29 +793,25 @@ And add some code to `paint_visual_effects`:
 ``` {.python}
 def paint_visual_effects(node, cmds, rect):
     # ...
-    (translation, rotation) = parse_transform(
-        node.style.get("transform", ""))
+    translation = parse_transform(node.style.get("transform", ""))
     # ...
     save_layer = \
     # ...
 
-    transform = Transform(
-        translation, rotation, rect, node, [save_layer])
+    transform = Transform(translation, rect, node, [save_layer])
     # ...
     return [transform]
 ```
 TODO:verify that translation does indeed come after blending.
 
 The `Transform` display list command is pretty straightforward as well: it calls
-either the `rotate` or `translate` Skia canvas method, which are conveniently
-built-in.
+the `translate` Skia canvas method, which s conveniently built-in.
 
 ``` {.python expected=False}
 class Transform(DisplayItem):
     def __init__(self, translation, rotation_degrees,
         rect, node, cmds):
         self.translation = translation
-        self.rotation_degrees = rotation_degrees
         self.self_rect = rect
         self.cmds = cmds
 
@@ -857,17 +820,6 @@ class Transform(DisplayItem):
             (x, y) = self.translation
             canvas.save()
             canvas.translate(x, y)
-            for cmd in self.cmds:
-                cmd.execute(canvas)
-            canvas.restore()
-        elif self.rotation_degrees != None:
-            (center_x, center_y) = center_point(self.self_rect)
-            rotation_x = self.center_x
-            rotation_y = self.center_y
-            canvas.save()
-            canvas.rotate(
-                degrees=self.rotation_degrees,
-                px=rotation_x, py=rotation_y)
             for cmd in self.cmds:
                 cmd.execute(canvas)
             canvas.restore()
@@ -885,19 +837,44 @@ def try_transform_animation(node, old_style, new_style, tab):
     if num_frames == None:
         return None;
 
-    (old_translation, old_rotation) = parse_transform(old_style["transform"])
-    (new_translation, new_rotation) = parse_transform(new_style["transform"])
+    old_translation = parse_transform(old_style["transform"])
+    new_translation = parse_transform(new_style["transform"])
 
-    if old_rotation == None or new_rotation == None:
+    if old_translation == None or new_translation == None:
         return None
-
-    change_per_frame = (new_rotation - old_rotation) / num_frames
 
     if not node in tab.animations:
         tab.animations[node] = {}
-    tab.animations[node]["trransform"] = RotationAnimation(
-        node, old_rotation, num_frames, change_per_frame, tab)
+    tab.animations[node]["transform"] = TranslateAnimation(
+        node, old_translation, new_translation, num_frames, tab)
+```
 
+And `TranslateAnimation`:
+
+
+``` {.python}
+class TranslateAnimation:
+    def __init__(
+        self, node, old_translation, new_translation, num_frames, tab):
+        self.node = node
+        (self.old_x, self.old_y) = old_translation
+        (new_x, new_y) = new_translation
+        self.change_per_frame_x = (new_x - self.old_x) / num_frames
+        self.change_per_frame_y = (new_y - self.old_y) / num_frames
+        self.num_frames = num_frames
+        self.tab = tab
+        self.frame_count = 0
+        self.animate()
+
+    def animate(self):
+        self.frame_count += 1
+        if self.frame_count >= self.num_frames: return False
+        self.node.style["transform"] = \
+            "translate({}px,{}px)".format(
+                self.old_x + self.change_per_frame_x * self.frame_count,
+                self.old_y + self.change_per_frame_y * self.frame_count)
+        self.tab.set_needs_render()
+        return True
 ```
 
 Implementing compositing

--- a/book/animations.md
+++ b/book/animations.md
@@ -715,9 +715,7 @@ with its *side-effects for overlapping content*. To understand the concept,
 consider this simple example of a blue square overlapped by an green one.
 
 <div style="width:200px;height:200px;background-color:lightblue"></div>
-<div style="width:200px;height:200px;
-            background-color:lightgreen;position:relative;
-            top:-100px;left:100px;"></div>
+<div style="width:200px;height:200px;background-color:lightgreen;transform:translate(100px, -100px"></div>
 
 Suppose we want to animate opacity on the blue square, and so allocate a
 `skia.Surface` and GPU texture for it. But we don't want to animate the green
@@ -740,9 +738,9 @@ remainder of the display list for potential overlaps.
 We're now ready to start digging into the compositing algorithm and how to
 implement it, except for one thing: there is no way in our current browser for
 content to overlap! The example in this section used the `transform` CSS
-property, which is not yet present in our browser. Not only that, but
-transforms are a common visual effect animation on websites. So let's implement
-that and then come back to implementing compositing.
+property, which is not yet present in our browser. Because of that, and also
+because transforms are a common visual effect animation on websites, let's
+implement that and then come back to implementing compositing.
 
 ::: {.further}
 TODO: describe the problem of layer explosion. Explain how this can actually

--- a/book/animations.md
+++ b/book/animations.md
@@ -850,7 +850,7 @@ def try_transform_animation(node, old_style, new_style, tab):
 And `TranslateAnimation`:
 
 
-``` {.python}
+``` {.python expected=False}
 class TranslateAnimation:
     def __init__(
         self, node, old_translation, new_translation, num_frames, tab):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1004,13 +1004,11 @@ def try_numeric_animation(node, name,
         old_value = float(old_style[name])
         new_value = float(new_style[name])
 
-    change_per_frame = (new_value - old_value) / num_frames
-
     if not node in tab.animations:
         tab.animations[node] = {}
     tab.animations[node][name] = NumericAnimation(
-        node, name, is_px, old_value,
-        num_frames, change_per_frame, tab)
+        node, name, is_px, old_value, new_value,
+        num_frames, tab)
 
 def style(node, rules, tab):
     old_style = None
@@ -1063,13 +1061,13 @@ class RotationAnimation:
 class NumericAnimation:
     def __init__(
         self, node, property_name, is_px,
-        old_value, num_frames, change_per_frame, tab):
+        old_value, new_value, num_frames, tab):
         self.node = node
         self.property_name = property_name
         self.is_px = is_px
         self.old_value = old_value
         self.num_frames = num_frames
-        self.change_per_frame = change_per_frame
+        self.change_per_frame = (new_value - old_value) / num_frames
         self.tab = tab
         self.frame_count = 0
         self.animate()

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -118,12 +118,10 @@ class DisplayItem:
                 noop=(" <no-op>" if self.is_noop() else ""))
 
 class Transform(DisplayItem):
-    def __init__(self, translation, rotation_degrees,
+    def __init__(self, translation,
         rect, node, cmds):
         self.translation = translation
-        self.rotation_degrees = rotation_degrees
-        assert translation == None or rotation_degrees == None
-        should_transform = translation != None or rotation_degrees != None
+        should_transform = translation != None
         self.self_rect = rect
         my_bounds = self.compute_bounds(rect, cmds, should_transform)
 
@@ -134,18 +132,11 @@ class Transform(DisplayItem):
     def draw(self, canvas, op):
         if self.is_noop():
             op()
-        elif self.translation:
+        else:
+            assert self.translation
             (x, y) = self.translation
             canvas.save()
             canvas.translate(x, y)
-            op()
-            canvas.restore()
-        else:
-            (center_x, center_y) = center_point(self.self_rect)
-            canvas.save()
-            canvas.rotate(
-                degrees=self.rotation_degrees,
-                px=center_x, py=center_y)
             op()
             canvas.restore()
 
@@ -159,10 +150,6 @@ class Transform(DisplayItem):
         if self.translation:
             (x, y) = self.translation
             matrix.setTranslate(x, y)
-        else:
-            (center_x, center_y) = center_point(self.self_rect)
-            matrix.setRotate(
-                self.rotation_degrees, center_x, center_y)
         return matrix.mapRect(rect)
 
     def compute_bounds(self, rect, cmds, should_transform):
@@ -173,17 +160,14 @@ class Transform(DisplayItem):
     def copy(self, other):
         assert other.item_type == self.item_type
         self.translation = other.translation
-        self.rotation_degrees = other.rotation_degrees
-        should_transform = self.translation != None or self.rotation_degrees != None
+        should_transform = self.translation != None
         self.rect = self.compute_bounds(self.rect, self.get_cmds(), should_transform)
 
     def __repr__(self):
         if self.is_noop():
             return "Transform(<no-op>)"
-        elif self.translation:
-            return "Transform(translate({}, {}))".format(self.translation)
         else:
-            return "Transform(rotate({}))".format(self.rotation_degrees)
+            return "Transform(translate({}, {}))".format(self.translation)
 
 class DrawRRect(DisplayItem):
     def __init__(self, rect, radius, color):
@@ -320,25 +304,14 @@ class SaveLayer(DisplayItem):
         else:
             return "SaveLayer(alpha={})".format(self.sk_paint.getAlphaf())
 
-def parse_rotation_transform(transform_str):
-    left_paren = transform_str.find('(')
-    right_paren = transform_str.find('deg)')
-    return float(transform_str[left_paren + 1:right_paren])
-
-def parse_translate_transform(transform_str):
+def parse_transform(transform_str):
+    if transform_str.find('translate') < 0:
+        return None
     left_paren = transform_str.find('(')
     right_paren = transform_str.find(')')
     (x_px, y_px) = \
         transform_str[left_paren + 1:right_paren].split(",")
     return (float(x_px[:-2]), float(y_px[:-2]))
-
-def parse_transform(transform_str):
-    if transform_str.find('translate') >= 0:
-        return (parse_translate_transform(transform_str), None)
-    elif transform_str.find('rotate') >= 0:
-        return (None, parse_rotation_transform(transform_str))
-    else:
-        return (None, None)
 
 USE_COMPOSITING = True
 
@@ -787,8 +760,7 @@ def style_length(node, style_name, default_value):
 def paint_visual_effects(node, cmds, rect):
     opacity = float(node.style.get("opacity", "1.0"))
     blend_mode = parse_blend_mode(node.style.get("mix-blend-mode"))
-    (translation, rotation) = parse_transform(
-        node.style.get("transform", ""))
+    translation = parse_transform(node.style.get("transform", ""))
 
     border_radius = float(node.style.get("border-radius", "0px")[:-2])
     if node.style.get("overflow", "visible") == "clip":
@@ -806,8 +778,7 @@ def paint_visual_effects(node, cmds, rect):
                 should_clip=needs_clip),
         ], should_save=needs_blend_isolation)
 
-    transform = Transform(
-        translation, rotation, rect, node, [save_layer])
+    transform = Transform(translation, rect, node, [save_layer])
 
     if transform.needs_compositing() or save_layer.needs_compositing:
         node.transform = transform
@@ -978,18 +949,16 @@ def try_transform_animation(node, old_style, new_style, tab):
     if num_frames == None:
         return None;
 
-    (old_translation, old_rotation) = parse_transform(old_style["transform"])
-    (new_translation, new_rotation) = parse_transform(new_style["transform"])
+    old_translation = parse_transform(old_style["transform"])
+    new_translation = parse_transform(new_style["transform"])
 
-    if old_rotation == None or new_rotation == None:
+    if old_translation == None or new_translation == None:
         return None
-
-    change_per_frame = (new_rotation - old_rotation) / num_frames
 
     if not node in tab.animations:
         tab.animations[node] = {}
-    tab.animations[node]["trransform"] = RotationAnimation(
-        node, old_rotation, num_frames, change_per_frame, tab)
+    tab.animations[node]["transform"] = TranslateAnimation(
+        node, old_translation, new_translation, num_frames, tab)
 
 def try_numeric_animation(node, name,
     old_style, new_style, tab, is_px):
@@ -1038,13 +1007,15 @@ def style(node, rules, tab):
     for child in node.children:
         style(child, rules, tab)
 
-class RotationAnimation:
+class TranslateAnimation:
     def __init__(
-        self, node, old_rotation, num_frames, change_per_frame, tab):
+        self, node, old_translation, new_translation, num_frames, tab):
         self.node = node
-        self.old_rotation = old_rotation
+        (self.old_x, self.old_y) = old_translation
+        (new_x, new_y) = new_translation
+        self.change_per_frame_x = (new_x - self.old_x) / num_frames
+        self.change_per_frame_y = (new_y - self.old_y) / num_frames
         self.num_frames = num_frames
-        self.change_per_frame = change_per_frame
         self.tab = tab
         self.frame_count = 0
         self.animate()
@@ -1053,8 +1024,9 @@ class RotationAnimation:
         self.frame_count += 1
         if self.frame_count >= self.num_frames: return False
         self.node.style["transform"] = \
-            "rotate({}deg)".format(
-                self.old_rotation + self.change_per_frame * self.frame_count)
+            "translate({}px,{}px)".format(
+                self.old_x + self.change_per_frame_x * self.frame_count,
+                self.old_y + self.change_per_frame_y * self.frame_count)
         self.tab.set_needs_animation(self.node, "transform", True)
         return True
 


### PR DESCRIPTION
It's unnecessary to support them to get across the point of overlap and animated transforms, and removing 
support is a great simplification of the code.

This PR also:
* Adds text for translation transform animations to the text
