### PR TITLE
Skip style recalc for animations

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -749,10 +749,11 @@ form.
 
 The main difficulty with implementing compositing turns out to be dealing
 with its *side-effects for overlapping content*. To understand the concept,
-consider this simple example of a blue square overlapped by an green one.
+consider this simple example of a green square overlapped by an blue one,
+except that the blue one is *earlier* in the DOM painting order.
 
-<div style="width:200px;height:200px;background-color:lightblue"></div>
-<div style="width:200px;height:200px;background-color:lightgreen;transform:translate(100px, -100px)"></div>
+<div style="width:200px;height:200px;background-color:lightblue;transform:translate(50px,50px)"></div>
+<div style="width:200px;height:200px;background-color:lightgreen"></div>
 
 Suppose we want to animate opacity on the blue square, and so allocate a
 `skia.Surface` and GPU texture for it. But we don't want to animate the green

--- a/src/example13-opacity-transition.js
+++ b/src/example13-opacity-transition.js
@@ -17,5 +17,5 @@ function go() {
 		div.style = "opacity:0.1";
 	else
 		div.style = "opacity:1.0";
-	setTimeout(go, 2000);
+	setTimeout(go, 16*120);
 }

--- a/src/example13-transform-transition.html
+++ b/src/example13-transform-transition.html
@@ -1,4 +1,4 @@
 <link rel="stylesheet" href="example13-transform-transition.css">
-<div style="background-color:lightblue"></div>
-<div style="background-color:lightgreen;transform:translate(100px,-100px)"></div>
+<div style="background-color:lightblue;transform:translate(50px,50px)"></div>
+<div style="background-color:lightgreen"></div>
 <script src="example13-transform-transition.js"></script>

--- a/src/example13-transform-transition.js
+++ b/src/example13-transform-transition.js
@@ -10,13 +10,13 @@ function frame() {
 }
 requestAnimationFrame(frame);
 
-var go_down = false;
-var div = document.querySelectorAll("div")[1];
+var go_up = false;
+var div = document.querySelectorAll("div")[0];
 function go() {
-	go_down = !go_down;
-	if (go_down)
-		div.style = "background-color:lightgreen;transform:translate(0px,0px)";
+	go_up = !go_up;
+	if (go_up)
+		div.style = "background-color:lightblue;transform:translate(0px,0px)";
 	else
-		div.style = "background-color:lightgreen;transform:translate(100px,-100px)";
-	setTimeout(go, 2000);
+		div.style = "background-color:lightblue;transform:translate(50px,50px)";
+	setTimeout(go, 16*120);
 }

--- a/src/example13-width-transition.js
+++ b/src/example13-width-transition.js
@@ -17,6 +17,6 @@ function go() {
 		div.style = "background-color:lightblue;width:100px";
 	else
 		div.style = "background-color:lightblue;width:400px";
-	setTimeout(go, 2100);
+	setTimeout(go, 16*120);
 }
 


### PR DESCRIPTION
This avoids re-creating main-thread animations on every frame.

The true implementation in a browser will be more complex, tracking animation updates separately from regular ones. I'll add a go-further about it later.