### PR TITLE
Add a page to thank contributors

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -91,6 +91,7 @@ Appendix
 3. [Glossary](glossary.md)
 4. [Bibliography](bibliography.md)
 5. [About the Authors](about.md)
-6. [List of courses taught from this book](classes.md)
+6. [Contributors](/thanks)
+7. [List of courses taught from this book](classes.md)
 
 :::

--- a/infra/api.py
+++ b/infra/api.py
@@ -122,29 +122,34 @@ def comment():
 @bottle.get("/thanks")
 @bottle.view("thanks.view")
 def thanks():
-    names = [name for name, email in DATA.contributors()]
+    author_names = {
+        "Pavel Panchekha",
+        "Chris Harrelson"
+    }
+
+    feedback_names = {name for name, email in DATA.contributors() if name}
 
     # The list below comes from running
     #
     #   git log --format='%aN' | sort -u`
     #
     # And deleting the authors' names.
-    extra_names = [
+    gh_names = {
         "Abram Himmer",
         "Anthony",
         "BO41",
         "Ian Briggs",
         "Shuhei Kagawa",
-    ]
-
-    all_names = {
-        name
-        for name in names + extra_names
-        if name
-        and name not in ["Pavel Panchekha", "Chris Harrelson"]
     }
 
-    return { "names": list(all_names) }
+    patreon_names = {
+        "[list goes here]"
+    }
+
+    return {
+        "patreon": list(patreon_names - author_names),
+        "contribute": list((feedback_names | gh_names) - author_names),
+    }
 
 def splitword(text):
     out = [[]]

--- a/infra/api.py
+++ b/infra/api.py
@@ -87,6 +87,14 @@ class Data:
     def status(self, i):
         return self.data[i]["status"]
 
+    def contributors(self):
+        return {
+            (entry['name'], entry.get('email'))
+            for entry in self.data
+            if 'name' in entry and 'status' in entry
+            if entry["status"] in ["saved", "archived"]
+        }
+
     def set_status(self, i, status):
         self.data[i]['status'] = status
         self.save()
@@ -110,6 +118,33 @@ def text_comment():
 def comment():
     data = json.load(bottle.request.body)
     DATA.chapter_comment(**data)
+    
+@bottle.get("/thanks")
+@bottle.view("thanks.view")
+def thanks():
+    names = [name for name, email in DATA.contributors()]
+
+    # The list below comes from running
+    #
+    #   git log --format='%aN' | sort -u`
+    #
+    # And deleting the authors' names.
+    extra_names = [
+        "Abram Himmer",
+        "Anthony",
+        "BO41",
+        "Ian Briggs",
+        "Shuhei Kagawa",
+    ]
+
+    all_names = {
+        name
+        for name in names + extra_names
+        if name
+        and name not in ["Pavel Panchekha", "Chris Harrelson"]
+    }
+
+    return { "names": list(all_names) }
 
 def splitword(text):
     out = [[]]

--- a/www/thanks.view
+++ b/www/thanks.view
@@ -27,13 +27,18 @@
 We want to thank our
 <a href="https://patreon.com/browserengineering">Patreon</a>
 <em>subscribers</em>, who support this book financially:
-[list here].
+{{", ".join(patreon[:-1])}}, and {{patreon[-1]}}.
 </p>
 
 <p>
 Moreover, we thank <em>contributors</em> who submitted typo fixes,
 questions, and comments through the book's built-in feedback tools:
-{{", ".join(names[:-1])}}, and {{names[-1]}}.
+{{", ".join(contribute[:-1])}}, and {{contribute[-1]}}.
+</p>
+
+<p>
+We are grateful to <em>students</em> of <a href="classes.html">classes
+using this book</a>, who often read drafts and gave valuable feedback.
 </p>
 
 <p>

--- a/www/thanks.view
+++ b/www/thanks.view
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US" xml:lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=yes" />
+  <link rel="stylesheet" href="/book.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn%7CLora&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn:400i%7CLora:400i&display=swap" />
+  <title>Contributors | Web Browser Engineering</title>
+</head>
+<body>
+
+<header>
+  <h1 class="title">Contributors</h1>
+  <a href="https://twitter.com/browserbook">Twitter</a> · <a href="/blog/">Blog</a> ·
+  <a href="https://patreon.com/browserengineering">Patreon</a> ·
+  <a href="https://github.com/browserengineering/book/discussions">Discussions</a>
+</header>
+
+<nav class="links">
+  Contributors to <a href="index.html" title="Table of Contents">Web Browser Engineering</a>.
+  <a rel="prev" title="Previous chapter" href="about.html">&lt;</a>
+  <a rel="next" title="Next chapter" href="classes.html">&gt;</a>
+</nav>
+
+<p>
+We want to thank our
+<a href="https://patreon.com/browserengineering">Patreon</a>
+<em>subscribers</em>, who support this book financially:
+[list here].
+</p>
+
+<p>
+Moreover, we thank <em>contributors</em> who submitted typo fixes,
+questions, and comments through the book's built-in feedback tools:
+{{", ".join(names[:-1])}}, and {{names[-1]}}.
+</p>
+
+<p>
+Finally, we thank all <em>readers</em> of Web Browser Engineering, for
+whom we wrote the book.
+</p>
+
+</body>
+


### PR DESCRIPTION
This PR adds a page at `/thanks` that thanks all contributors. Right now the code needs a hard-coded list of Patreon supporters (@chrishtr I'll need you to supply this), a hard-coded list of git contributors (we don't expect too many, so hopefully this isn't too annoying) and an auto-generated list of contributors through the built-in feedback tools.