### PR TITLE
Fix outliner for Chapter 13

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -2024,7 +2024,9 @@ Outline
 The complete set of functions, classes, and methods in our browser 
 should now look something like this:
 
-TODO
+::: {.cmd .python .outline html=True}
+    python3 infra/outlines.py --html src/lab13.py
+:::
 
 Exercises
 =========

--- a/book/animations.md
+++ b/book/animations.md
@@ -607,7 +607,7 @@ one constant and one debugging method, actually). Install the library:
 and then import it:
 
 ``` {.python}
-from OpenGL import GL
+import OpenGL.GL as GL
 ```
 
 Then we'll need to configure `sdl_window` and start/stop a

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -30,7 +30,7 @@ from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import draw_line, draw_text, get_font, linespace, \
     parse_blend_mode, parse_color, request, CHROME_PX, SCROLL_STEP
-from OpenGL import GL
+import OpenGL.GL as GL
 
 class MeasureTime:
     def __init__(self, name):


### PR DESCRIPTION
This PR changes the lab 13 code to use an `import ... as ...` instead of a `from ... import ...` since that is how the outliner distinguishes local and package imports.