### PR TITLE
Strip ports from the top_level_url

### DIFF
--- a/book/security.md
+++ b/book/security.md
@@ -868,7 +868,15 @@ class JSContext:
 The `request` function can now check the `top_level_url` argument
 before sending `SameSite` cookies. Remember that `SameSite` cookies
 are only sent for `GET` requests or if the new URL and the top-level
-URL have the same host name:
+URL have the same host name:[^schemeful]
+
+[^schemeful]: At I write this, some browsers also check that the new
+    URL and the top-level URL have the same scheme and some browsers
+    ignore subdomains, so that `www.foo.com` and `login.foo.com` are
+    considered the "same site". If cookies were invented today, they'd
+    probably be specific to URL origins, much like CSP policies, but
+    alas historical contingencies and backwards compatibility force
+    rules that are more complex but easier to deploy.
 
 ``` {.python}
 def request(url, top_level_url, payload=None):

--- a/book/security.md
+++ b/book/security.md
@@ -877,6 +877,8 @@ def request(url, top_level_url, payload=None):
         allow_cookie = True
         if top_level_url and params.get("samesite", "none") == "lax":
             _, _, top_level_host, _ = top_level_url.split("/", 3)
+            if ":" in top_level_host:
+                top_level_host, _ = top_level_host.split(":", 1)
             allow_cookie = (host == top_level_host or method == "GET")
         if allow_cookie:
             body += "Cookie: {}\r\n".format(cookie)

--- a/src/lab10-tests.md
+++ b/src/lab10-tests.md
@@ -169,6 +169,16 @@ case the cookie is *not* sent:
     >>> tab.load(url3, body="who=me")
     >>> test.socket.last_request(url3)
     b'POST /add HTTP/1.0\r\nHost: test.test\r\nContent-Length: 6\r\n\r\nwho=me'
+    
+The same-site check should ignore ports, so if the hosts are the same
+but the ports differ, the cookie should be sent:
+
+    >>> tab.load(url)
+    >>> url5 = "http://test.test:8000/test"
+    >>> test.socket.respond(url5, b"HTTP/1.0 200 OK\r\n\r\nHi!", method="POST")
+    >>> tab.load(url5, body="who=me")
+    >>> test.socket.last_request(url5)
+    b'POST /test HTTP/1.0\r\nHost: test.test\r\nCookie: bar=baz\r\nContent-Length: 6\r\n\r\nwho=me'
 
 Testing Content-Security-Policy
 ===============================

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -69,6 +69,8 @@ def request(url, top_level_url, payload=None):
         allow_cookie = True
         if top_level_url and params.get("samesite", "none") == "lax":
             _, _, top_level_host, _ = top_level_url.split("/", 3)
+            if ":" in top_level_host:
+                top_level_host, _ = top_level_host.split(":", 1)
             allow_cookie = (host == top_level_host or method == "GET")
         if allow_cookie:
             body += "Cookie: {}\r\n".format(cookie)


### PR DESCRIPTION
This PR fixes #409 by stripping ports from the top level URL in the SameSite check inside the `request` function. This implements the way SameSite works in Safari and Firefox, but the future looks likely to be a "schemeful" SameSite check already shipped by Chrome and behind a flag in Firefox. I added a footnote about it but don't think we should implement it.