### PR TITLE
Remove an extra new line in the Conclusion list

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -82,7 +82,6 @@ Conclusion
 ==========
 
 1. [What Wasn't Covered](skipped.md)
-
 2. [A Changing Landscape](change.md)
 
 Appendix


### PR DESCRIPTION
It's not consistent with the next Appendix list, and the extra line is causing the list items to have `<p>` tags inside.

<img width="745" alt="Screenshot 2022-04-03 at 20 20 17" src="https://user-images.githubusercontent.com/498635/161442631-4dbe809b-624b-42a6-8b24-70b19be8537d.png">

The extra `<p>` tags don't seem to affect real browsers' rendering, but they pose extra challenges to my toy browser: margin collapsing of parent-child (`<li>` and `<p>`) and then siblings (`<li>` and `<li>`); and `<li>` not being `InlineLayout` 😃 

<img width="1000" alt="Screenshot 2022-04-03 at 20 19 04" src="https://user-images.githubusercontent.com/498635/161442974-368a8747-23f4-4b8a-86a2-db82c8e5ae73.png">