### PR TITLE
Simplify NumericAnimation and running animations

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -871,6 +871,7 @@ class Tab:
         if self.needs_style:
             # ...
             self.needs_layout = True
+            self.needs_style = False
         
         for node in tree_to_list(self.nodes, []):
             # ...
@@ -878,13 +879,12 @@ class Tab:
         if self.needs_layout:
             # ...
             self.needs_paint = True
+            self.needs_layout = False
     
         if self.needs_paint:
             # ...
+            self.needs_paint = False
 
-        self.needs_style = False
-        self.needs_layout = False
-        self.needs_paint = False
         self.measure_render.stop()
 ```
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -691,7 +691,7 @@ is given without units,[^more-units] so `NumericAnimation` looks at
 the old value to determine the unit to use, and then stores the old
 and new values parsed.
 
-[^more-units]: In a real browsers, there are a [lot more][units] units
+[^more-units]: In real browsers, there are a [lot more][units] units
 to contend with. And other constraints, too---like the fact that
 opacity should be a value between 0 and 1.
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -706,13 +706,19 @@ class NumericAnimation:
 ```
 
 If the animation is animating, we'll need to compute the new value of
-the property. Let's return that from the `animate`
-method:[^animation-curve]
+the property.[^animation-curve] Let's return that from the `animate`
+method:[^precompute]
 
 [^animation-curve]: Note that this class implements a linear animation
 interpretation (or *easing function*). By default, real browsers use a
 non-linear easing function, which looks better, so the demos from this
 chapter will not look quite the same in your browser.
+
+[^precompute]: Here I've chosen to compute `change_per_frame` in the
+constructor. Of course, this is a very simple calculation and it
+frankly doesn't matter much where exactly we do it, but if the
+animation were more complex, we could precompute some information in
+the constructor for use later.
 
 ``` {.python}
 class NumericAnimation:
@@ -730,11 +736,6 @@ class NumericAnimation:
         else:
             return "{}".format(current_value)
 ```
-
-Here I've chosen to compute `change_per_frame` in the constructor. Of
-course, this is a very simple calculation and it frankly doesn't matter
-much where exactly we do it, but if the animation were more complex,
-we could precompute some information in the constructor for use later.
 
 We're going to want to create these animation objects every time a
 style value changes. We can do that in `style` by diffing the old and

--- a/book/animations.md
+++ b/book/animations.md
@@ -648,7 +648,7 @@ Now add a frame count and an `animate` method that increments it:
 class NumericAnimation:
     def __init__(self, old_value, new_value, num_frames):
         # ...
-        self.frame_count = 0
+        self.frame_count = 1
 
     def animate(self):
         self.frame_count += 1
@@ -2069,10 +2069,9 @@ class TranslateAnimation:
         (new_x, new_y) = parse_transform(old_translation)
         self.num_frames = num_frames
 
-        self.frame_count = 0
+        self.frame_count = 1
         self.change_per_frame_x = (new_x - self.old_x) / num_frames
         self.change_per_frame_y = (new_y - self.old_y) / num_frames
-        self.animate()
 
     def animate(self):
         self.frame_count += 1
@@ -2367,7 +2366,7 @@ class ScrollAnimation:
         self.num_frames = 30
         self.change_per_frame = \
             (new_scroll - old_scroll) / self.num_frames
-        self.frame_count = 0
+        self.frame_count = 1
 
     def animate(self):
         self.frame_count += 1

--- a/book/animations.md
+++ b/book/animations.md
@@ -836,7 +836,7 @@ show the old value.
 
 So, let's run the animations! Basically, every frame, we're going to
 want to find all the active animations on the page and call `animate`
-on them. Since these animations are basically a variation of
+on them. Since these animations are a variation of
 JavaScript animations using `requestAnimationFrame`, let's run
 animations right after handling those callbacks:
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -859,14 +859,16 @@ Most of this code is straightforward: iterate over all nodes; loop
 through the animations; animate them; and, if the animation is still
 active, update the relevant property value.
 
-However, there's a bit of a catch. Right now, `render()` exits early
-if `self.needs_render` isn't set. But setting that re-runs `style`,
-which would notice that the animation changed a property value and
-start a *new* animation!
+But if you try it, it won't work. That's because right now, `render()`
+exits early if `needs_render` isn't set. That "dirty bit" is
+supposed to be set if there's rendering work to do, and when an
+animation is active, there is.
 
-They resolution here is that during an animation, we don't want to run
-`style`, but we do want to run `layout` and `paint`, the other two
-parts of `render`:[^even-more]
+It's not as simple as just setting `needs_render` any time an
+animation is active, however. Setting `needs_render` means re-runs
+`style`, which would notice that the animation changed a property
+value and start a *new* animation! During an animation, we want to run
+`layout` and `paint`, but we *don't* want to run `style`:[^even-more]
 
 [^even-more]: While a real browser definitely has an analog of the
 `needs_layout` and `needs_paint` flags, our fix for restarting

--- a/book/animations.md
+++ b/book/animations.md
@@ -647,20 +647,15 @@ animated:[^delete-complicated]
     tabs where just looping over all the already-completed animations
     can take a while.
 
-<!--
-This is not actually present in the code; it's hacked in with a
-hasattr() in style() instead. Ugly!
--->
-
-``` {.python expected=False}
-class Element:
-    def __init__(self, tag, attributes, parent):
+``` {.python}
+class Text:
+    def __init__(self, text, parent):
         # ...
         self.style = {}
         self.animations = {}
 
-class Text:
-    def __init__(self, text, parent):
+class Element:
+    def __init__(self, tag, attributes, parent):
         # ...
         self.style = {}
         self.animations = {}

--- a/book/animations.md
+++ b/book/animations.md
@@ -831,7 +831,7 @@ def style(node, rules):
 
 Now, any time a property listed in `transition` changes its value,
 we'll create an animation and get ready to run it. Note that the
-animation will start running next frame; until then, we want it to
+animation will start running in the next frame; until then, we want it to
 show the old value.
 
 So, let's run the animations! Basically, every frame, we're going to

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -179,5 +179,5 @@ if __name__ == "__main__":
                     elif ".js" in value:
                         failure += test_entry(chapter, metadata, key, "javascript", key)
     else:
-        failure = compare_files(args.book, args.code, None, args.file)
+        failure = compare_files(args.book, args.code, "python", args.file)
     sys.exit(failure)

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -74,8 +74,12 @@ def tangle(file):
     return list(get_blocks(out.stdout.decode("utf8").split("\n")))
 
 def find_block(block, text):
-    differ = difflib.Differ(charjunk=lambda c: c == " ", linejunk=lambda s: "..." in s)
-    d = differ.compare(block.splitlines(keepends=True), text.splitlines(keepends=True))
+    differ = difflib.Differ(charjunk=lambda c: c == " ", linejunk=str.isspace)
+    block_lines = [
+        i for i in block.splitlines(keepends=True)
+        if "..." not in i and not i.isspace()
+    ]
+    d = differ.compare(block_lines, text.splitlines(keepends=True))
     same = []
     last_type = None
     for n, l in enumerate(d):
@@ -93,10 +97,7 @@ def find_block(block, text):
         elif type == " ":
             same.append((False, l))
         elif type == "-":
-            if "..." in l:
-                type = " "
-            else:
-                same.append((True, l))
+            same.append((True, l))
         else:
             raise ValueError("Invalid diff type `" + type + "`")
         last_type = type

--- a/src/lab13-tests.md
+++ b/src/lab13-tests.md
@@ -44,17 +44,17 @@ The div in this example has `width` and `height` set to `30px` and `40px`
 respectively.
 
     >>> lab13.style_length(div, "width", 13)
-    30
+    30.0
     >>> lab13.style_length(div, "height", 14)
-    40
+    40.0
 
 The actual width and height from layout should match:
 
 	>>> div_obj = tab.document.children[0].children[0].children[0]
 	>>> div_obj.width
-	30
+	30.0
 	>>> div_obj.height
-	40
+	40.0
 
 Testing CSS transtions
 ======================
@@ -80,5 +80,5 @@ Testing CSS transtions
 There is a transition defined for opacity, for a duration of 2 seconds. This is
 about 125 animation frames, so `get_transition` should return 125.
 
-	>>> lab13.get_transition("opacity", div.style)
-	125.0
+	>>> lab13.parse_transition(div.style.get("transition"))
+	{'opacity': 125.0}

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -906,28 +906,6 @@ def diff_styles(old_style, new_style):
 
     return transitions
 
-class TranslateAnimation:
-    def __init__(self, old_value, new_value, num_frames):
-        (self.old_x, self.old_y) = parse_transform(old_translation)
-        (new_x, new_y) = parse_transform(old_translation)
-        self.num_frames = num_frames
-
-        self.frame_count = 0
-        self.change_per_frame_x = (new_x - self.old_x) / num_frames
-        self.change_per_frame_y = (new_y - self.old_y) / num_frames
-        self.animate()
-
-    def animate(self):
-        self.frame_count += 1
-        return self.frame_count < self.num_frames
-
-    def value(self):
-        return "translate({}px,{}px)".format(
-                self.old_x +
-                self.change_per_frame_x * self.frame_count,
-                self.old_y +
-                self.change_per_frame_y * self.frame_count)
-
 class NumericAnimation:
     def __init__(self, old_value, new_value, num_frames):
         self.is_px = old_value.endswith("px")
@@ -939,9 +917,8 @@ class NumericAnimation:
             self.new_value = float(new_value)
         self.num_frames = num_frames
 
-        self.frame_count = 0
+        self.frame_count = 1
         self.change_per_frame = (new_value - old_value) / num_frames
-        self.animate()
 
     def animate(self):
         self.frame_count += 1
@@ -955,6 +932,27 @@ class NumericAnimation:
         else:
             return "{}".format(updated_value)
 
+class TranslateAnimation:
+    def __init__(self, old_value, new_value, num_frames):
+        (self.old_x, self.old_y) = parse_transform(old_translation)
+        (new_x, new_y) = parse_transform(old_translation)
+        self.num_frames = num_frames
+
+        self.frame_count = 1
+        self.change_per_frame_x = (new_x - self.old_x) / num_frames
+        self.change_per_frame_y = (new_y - self.old_y) / num_frames
+
+    def animate(self):
+        self.frame_count += 1
+        return self.frame_count < self.num_frames
+
+    def value(self):
+        return "translate({}px,{}px)".format(
+                self.old_x +
+                self.change_per_frame_x * self.frame_count,
+                self.old_y +
+                self.change_per_frame_y * self.frame_count)
+
 class ScrollAnimation:
     def __init__(self, old_scroll, new_scroll):
         self.old_scroll = old_scroll
@@ -962,8 +960,7 @@ class ScrollAnimation:
         self.num_frames = 30
         self.change_per_frame = \
             (new_scroll - old_scroll) / self.num_frames
-        self.frame_count = 0
-        self.animate()
+        self.frame_count = 1
 
     def animate(self):
         self.frame_count += 1

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1323,6 +1323,7 @@ class Tab:
             if 'scroll-behavior' in body.style:
                 self.scroll_behavior = body.style['scroll-behavior']
             self.needs_layout = True
+            self.needs_style = False
 
         for node in tree_to_list(self.nodes, []):
             for (property_name, animation) in node.animations.items():
@@ -1346,6 +1347,7 @@ class Tab:
             self.document = DocumentLayout(self.nodes)
             self.document.layout()
             self.needs_paint = True
+            self.needs_layout = False
         
         if self.needs_paint:
             self.display_list = []
@@ -1359,9 +1361,7 @@ class Tab:
                 y = obj.y
                 self.display_list.append(
                     DrawLine(x, y, x, y + obj.height))
-        self.needs_style = False
-        self.needs_layout = False
-        self.needs_paint = False
+                self.needs_paint = False
 
         self.measure_render.stop()
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1330,15 +1330,9 @@ class Tab:
                     self.scroll = scroll
         self.js.interp.evaljs("__runRAFHandlers()")
 
-        to_delete = []
-        for node in self.animations:
-            for (property_name, animation) in \
-                self.animations[node].items():
-                if not animation.animate():
-                    to_delete.append((node, property_name))
-
-        for (node, property_name) in to_delete:
-            del self.animations[node][property_name]
+        for node, animations in self.animations.items():
+            for (property_name, animation) in animations.items():
+                animation.animate()
 
         if self.scroll_animation:
             if not self.scroll_animation.animate():

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -16,8 +16,37 @@ import threading
 import time
 import urllib.parse
 from lab4 import print_tree
-from lab4 import Element
-from lab4 import Text
+
+class Text:
+    def __init__(self, text, parent):
+        self.text = text
+        self.children = []
+        self.parent = parent
+
+        self.style = {}
+        self.animations = {}
+
+    def __repr__(self):
+        return repr(self.text)
+
+class Element:
+    def __init__(self, tag, attributes, parent):
+        self.tag = tag
+        self.attributes = attributes
+        self.children = []
+        self.parent = parent
+
+        self.style = {}
+        self.animations = {}
+
+    def __repr__(self):
+        attrs = [" " + k + "=\"" + v + "\"" for k, v  in self.attributes.items()]
+        return "<" + self.tag + "".join(attrs) + ">"
+
+import sys
+sys.modules['lab4'].Text = Text
+sys.modules['lab4'].Element = Element
+
 from lab4 import HTMLParser
 from lab6 import cascade_priority
 from lab6 import layout_mode
@@ -31,12 +60,6 @@ from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import draw_line, draw_text, get_font, linespace, \
     parse_blend_mode, parse_color, request, CHROME_PX, SCROLL_STEP
 import OpenGL.GL as GL
-
-def add_field(node, name, mk):
-    if not hasattr(node, name):
-        setattr(node, name, mk(node))
-    for child in node.children:
-        add_field(child, name, mk)
 
 class MeasureTime:
     def __init__(self, name):
@@ -832,8 +855,6 @@ class JSContext:
     def innerHTML_set(self, handle, s):
         doc = HTMLParser(
             "<html><body>" + s + "</body></html>").parse()
-        add_field(doc, "style", lambda x: {})
-        add_field(doc, "animations", lambda x: {})
         new_nodes = doc.children[0].children
         elt = self.handle_to_node[handle]
         elt.children = new_nodes
@@ -1229,8 +1250,6 @@ class Tab:
                self.allowed_origins = csp[1:]
 
         self.nodes = HTMLParser(body).parse()
-        add_field(self.nodes, "style", lambda x: {})
-        add_field(self.nodes, "animations", lambda x: {})
 
         self.js = JSContext(self)
         scripts = [node.attributes["src"] for node

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1310,7 +1310,20 @@ class Tab:
 
         self.browser.commit(self, commit_data)
 
-    def run_animations(self):
+    def render(self):
+        self.measure_render.start()
+
+        if self.needs_style:
+            style(self.nodes, sorted(self.rules, key=cascade_priority))
+
+            if self.nodes.children[0].tag == "body":
+                body = self.nodes.children[0]
+            else:
+                body = self.nodes.children[1]
+            if 'scroll-behavior' in body.style:
+                self.scroll_behavior = body.style['scroll-behavior']
+            self.needs_layout = True
+
         for node in tree_to_list(self.nodes, []):
             for (property_name, animation) in node.animations.items():
                 if animation.animate():
@@ -1328,21 +1341,6 @@ class Tab:
                 self.tab.browser.set_needs_animation_frame(self)
             else:
                 self.scroll_animation = None
-
-    def render(self):
-        self.measure_render.start()
-
-        if self.needs_style:
-            style(self.nodes, sorted(self.rules, key=cascade_priority))
-
-            if self.nodes.children[0].tag == "body":
-                body = self.nodes.children[0]
-            else:
-                body = self.nodes.children[1]
-            if 'scroll-behavior' in body.style:
-                self.scroll_behavior = body.style['scroll-behavior']
-
-        self.run_animations()
 
         if self.needs_layout:
             self.document = DocumentLayout(self.nodes)

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -43,6 +43,8 @@ class Element:
         attrs = [" " + k + "=\"" + v + "\"" for k, v  in self.attributes.items()]
         return "<" + self.tag + "".join(attrs) + ">"
 
+# Patch the `Text` and `Element` classes so that all other code that
+# uses them, like HTMLParser, all refer to the patched versions.
 import sys
 sys.modules['lab4'].Text = Text
 sys.modules['lab4'].Element = Element

--- a/src/test12.py
+++ b/src/test12.py
@@ -1,5 +1,4 @@
 from test11 import *
-import lab12
 import threading
 
 class MockTimer:


### PR DESCRIPTION
This PR is a big refactor of, basically, the "CSS transitions" section of Chapter 13.

First, I made a lot of changes to how animations are created:

- I've moved the animations from `Tab` to `Element`, so we don't need to pass the `tab` into `style` and clearer naming in some places.
- I've moved responsibility for calling `set_needs_layout` out of `NumericAnimation` and into `Tab`. This has a lot of benefits: `NumericAnimation` now has a reasonable number of arguments and we can move the logic about compositing out of `NumericAnimation` and into `Tab`.
- As a result of that, I've split the `animate` method into two parts. `animate` just steps the frame counter and decides if the animation is still running. `value` produces the new value. This makes the code shorter because it lets us move the node and property name out of `NumericAnimation`.
  - While I didn't do this, I think this could let us fix the edge case where we change one property while another is animating: instead of having the animation write to `node.style`, we can have the `layout` methods query both `node.style[property]` and `node.animations[property].value()`. (We'd write a helper method to do this, of course.) It might be worth doing—more code but fewer confusing edge cases could be a win.
- I've redone the logic for parsing `transition` values, determining what properties are transitioning, and creating animation objects for them. Instead of going property by property, I have a single `diff_styles` method that finds all properties that have changed. Then, because of the changes above, both `TranslateAnimation` and `NumericAnimation` take the same list of arguments, I can treat all animatable properties generically, which eliminates the need for `try_xxx_animation` functions. This saves a lot of repetitive code.

Then, I made a lot of changes to how animations are run:

- I moved running animations into a `run_animations` method; I'm not actually sure this is good but it lets me change the order in which things happen in the text.
- I now run animations *after* `style` instead of *before*. This avoids a kind of circular dependency that would come up earlier and reinforces the pipeline idea of style -> animate -> layout -> paint.
- I now introduce the `needs_layout` and `needs_paint` flags earlier because now it's pretty natural to do so.