### PR TITLE
Typo fixes, editorial, and one more go-further

### DIFF
--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -66,10 +66,10 @@ A descendant selector stores its ancestor and descendant as TagSelectors,
 with a priority that sums them.
 
     >>> lab6.CSSParser("div span { foo: bar }").parse()
-    [(DescendantSelector(ancestor=TagSelector(tag=div, priority=1), descendant=TagSelector(tag=span, priority=1), priority=2, {'foo': 'bar'})]
+    [(DescendantSelector(ancestor=TagSelector(tag=div, priority=1), descendant=TagSelector(tag=span, priority=1), priority=2), {'foo': 'bar'})]
 
     >>> lab6.CSSParser("div span h1 { foo: bar }").parse()
-    [(DescendantSelector(ancestor=DescendantSelector(ancestor=TagSelector(tag=div, priority=1), descendant=TagSelector(tag=span, priority=1), priority=2, descendant=TagSelector(tag=h1, priority=1), priority=3, {'foo': 'bar'})]
+    [(DescendantSelector(ancestor=DescendantSelector(ancestor=TagSelector(tag=div, priority=1), descendant=TagSelector(tag=span, priority=1), priority=2), descendant=TagSelector(tag=h1, priority=1), priority=3), {'foo': 'bar'})]
 
 Multiple rules can be present.
 


### PR DESCRIPTION
* The go-further is about the bounds of composited layers and how they are decided upon.
* Moved text for debugging opengl to a better place.
* Made clear that execute can be slow with multiple surfaces.
* Fixes lab6 tests to account for a previous PR