### PR TITLE
Fix compositing and transforms

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1735,7 +1735,7 @@ class Tab:
 * Save off each `Element` that updates its composited animation, in a new
 array called `composited_animation_updates`:
 
-``` {.python replace=if%20property_name/if%20USE_COMPOSITING%20and%20property_name}
+``` {.python expected=False}
 class Tab:
     def __init__(self, browser):
         # ...
@@ -1915,6 +1915,7 @@ class Browser:
         else:
             for (node, save_layer) in self.composited_updates:
                 for layer in self.composited_layers:
+                    if node != composited_item.node: continue
                     composited_items = layer.composited_items()
                     for composited_item in composited_items:
                         if type(composited_item) is SaveLayer:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1319,7 +1319,9 @@ class Tab:
                 value = animation.animate()
                 if value:
                     node.style[property_name] = value
-                    if USE_COMPOSITING and property_name == "opacity":
+                    if USE_COMPOSITING and \
+                        (property_name == "opacity" or \
+                         property_name == "transform"):
                         self.composited_animation_updates.append(node)
                         self.set_needs_paint()
                     else:
@@ -1757,6 +1759,7 @@ class Browser:
                 for layer in self.composited_layers:
                     composited_items = layer.composited_items()
                     for composited_item in composited_items:
+                        if node != composited_item.node: continue
                         if type(composited_item) is Transform:
                             composited_item.copy(transform)
                         elif type(composited_item) is SaveLayer:


### PR DESCRIPTION
* Transforms fell of the composited path in PR 470; fixed that
* Somehow PR 470 plus the above fix exhibited a pre-existing bug where the code forgot to skip composited updates with mismatching node ids. Fixed that.