### PR TITLE
Get rid of composited ancestor index

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1691,8 +1691,7 @@ class CompositedLayer:
 
         canvas.save()
         canvas.translate(draw_offset_x, draw_offset_y)
-        self.draw_internal(
-            canvas, op, 0, self.ancestor_effects)
+        self.draw_internal(canvas, op, 0, self.ancestor_effects)
         canvas.restore()
 ```
 

--- a/src/example13-transform-transition.js
+++ b/src/example13-transform-transition.js
@@ -1,4 +1,3 @@
-
 var count = 0
 function frame() {
 	if (count == 1) {

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1175,8 +1175,7 @@ class CompositedLayer:
 
         canvas.save()
         canvas.translate(draw_offset_x, draw_offset_y)
-        self.draw_internal(
-            canvas, op, 0, self.ancestor_effects)
+        self.draw_internal(canvas, op, 0, self.ancestor_effects)
         canvas.restore()
 
     def __repr__(self):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1076,60 +1076,50 @@ class CompositedLayer:
     def __init__(self, skia_context):
         self.skia_context = skia_context
         self.surface = None
-        self.paint_chunks = []
+        self.display_items = []
         self.ancestor_effects = []
 
     def can_merge(self, display_item, ancestor_effects):
-        if len(self.paint_chunks) == 0:
+        if len(self.display_items) == 0:
             return True
         if len(self.ancestor_effects) != len(ancestor_effects):
             return False
         if len(self.ancestor_effects) == 0:
             return True
-        return self.ancestor_effects[-1] == ancestor_effects[-1]
+        return self.ancestor_effects[-1] == ancestor_effects[
+            composited_ancestor_index(ancestor_effects)]
 
     def add_paint_chunk(self, display_item, ancestor_effects):
         assert self.can_merge(display_item, ancestor_effects)
         composited_index = composited_ancestor_index(ancestor_effects)
-        if len(self.paint_chunks) == 0 and composited_index >= 0:
+        if len(self.display_items) == 0 and composited_index >= 0:
             self.ancestor_effects = ancestor_effects[0:composited_index + 1]
 
         if composited_index < len(ancestor_effects) - 1:
-            self.paint_chunks.append(
+            self.display_items.append(
                 (ancestor_effects[composited_index + 1],
                  self.ancestor_effects))
         else:
-            self.paint_chunks.append((display_item, ancestor_effects))
+            self.display_items.append((display_item, ancestor_effects))
 
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.paint_chunks:
+        for (item, ancestor_effects) in self.display_items:
             retval.join(item.composited_bounds())
         return retval
 
     def absolute_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.paint_chunks:
+        for (item, ancestor_effects) in self.display_items:
             retval.join(absolute_bounds(item, ancestor_effects))
         return retval
 
     def composited_items(self):
         items = []
-        (item, ancestor_effects) = self.paint_chunks[0]
-        for item in ancestor_effects:
+        for item in self.ancestor_effects:
             if item.needs_compositing():
                 items.append(item)
         return items
-
-    def draw_internal(self, canvas, op, start, end, ancestor_effects):
-        if start == end:
-            op()
-        else:
-            ancestor_item = ancestor_effects[start]
-            def recurse_op():
-                self.draw_internal(canvas, op, start + 1, end,
-                    ancestor_effects)
-            ancestor_item.draw(canvas, recurse_op)
 
     def raster(self):
         bounds = self.composited_bounds()
@@ -1152,12 +1142,8 @@ class CompositedLayer:
         canvas.clear(skia.ColorTRANSPARENT)
         canvas.save()
         canvas.translate(-bounds.left(), -bounds.top())
-        for (item, ancestor_effects) in self.paint_chunks:
-            def op():
-                item.execute(canvas)
-            self.draw_internal(
-                canvas, op, len(self.ancestor_effects),
-                len(ancestor_effects), ancestor_effects)
+        for (item, ancestor_effects) in self.display_items:
+            item.execute(canvas)
         canvas.restore()
 
         if SHOW_COMPOSITED_LAYER_BORDERS:
@@ -1165,6 +1151,16 @@ class CompositedLayer:
                 canvas, 0, 0, irect.width() - 1,
                 irect.height() - 1,
                 border_color="red")
+
+    def draw_internal(self, canvas, op, index, ancestor_effects):
+        if index == len(self.ancestor_effects):
+            op()
+        else:
+            ancestor_item = ancestor_effects[index]
+            def recurse_op():
+                self.draw_internal(canvas, op, index + 1,
+                    ancestor_effects)
+            ancestor_item.draw(canvas, recurse_op)
 
     def draw(self, canvas, draw_offset):
         if not self.surface: return
@@ -1177,16 +1173,10 @@ class CompositedLayer:
 
         (draw_offset_x, draw_offset_y) = draw_offset
 
-        (item, ancestor_effects) = self.paint_chunks[0]
-
         canvas.save()
         canvas.translate(draw_offset_x, draw_offset_y)
-        if len(self.ancestor_effects) > 0:
-            self.draw_internal(
-                canvas, op, 0, len(self.ancestor_effects),
-                ancestor_effects)
-        else:
-            op()
+        self.draw_internal(
+            canvas, op, 0, self.ancestor_effects)
         canvas.restore()
 
     def __repr__(self):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1077,30 +1077,29 @@ class CompositedLayer:
         self.skia_context = skia_context
         self.surface = None
         self.paint_chunks = []
-        self.composited_ancestor_index = -1
+        self.ancestor_effects = []
 
     def can_merge(self, display_item, ancestor_effects):
         if len(self.paint_chunks) == 0:
             return True
-        (item, self_ancestor_effects) = self.paint_chunks[0]
-        other_composited_ancestor_index = \
-            composited_ancestor_index(ancestor_effects)
-        if self.composited_ancestor_index != \
-            other_composited_ancestor_index:
+        if len(self.ancestor_effects) != len(ancestor_effects):
             return False
-        if self.composited_ancestor_index == -1:
+        if len(self.ancestor_effects) == 0:
             return True
-        return self_ancestor_effects[
-            self.composited_ancestor_index] == \
-            ancestor_effects[
-            other_composited_ancestor_index]
+        return self.ancestor_effects[-1] == ancestor_effects[-1]
 
     def add_paint_chunk(self, display_item, ancestor_effects):
         assert self.can_merge(display_item, ancestor_effects)
-        if len(self.paint_chunks) == 0:
-            self.composited_ancestor_index = \
-            composited_ancestor_index(ancestor_effects)
-        self.paint_chunks.append((display_item, ancestor_effects))
+        composited_index = composited_ancestor_index(ancestor_effects)
+        if len(self.paint_chunks) == 0 and composited_index >= 0:
+            self.ancestor_effects = ancestor_effects[0:composited_index + 1]
+
+        if composited_index < len(ancestor_effects) - 1:
+            self.paint_chunks.append(
+                (ancestor_effects[composited_index + 1],
+                 self.ancestor_effects))
+        else:
+            self.paint_chunks.append((display_item, ancestor_effects))
 
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()
@@ -1157,7 +1156,7 @@ class CompositedLayer:
             def op():
                 item.execute(canvas)
             self.draw_internal(
-                canvas, op, self.composited_ancestor_index + 1,
+                canvas, op, len(self.ancestor_effects),
                 len(ancestor_effects), ancestor_effects)
         canvas.restore()
 
@@ -1182,9 +1181,9 @@ class CompositedLayer:
 
         canvas.save()
         canvas.translate(draw_offset_x, draw_offset_y)
-        if self.composited_ancestor_index >= 0:
+        if len(self.ancestor_effects) > 0:
             self.draw_internal(
-                canvas, op, 0, self.composited_ancestor_index + 1,
+                canvas, op, 0, len(self.ancestor_effects),
                 ancestor_effects)
         else:
             op()


### PR DESCRIPTION
Do so by storing off the display item of the highest non-composited ancestor instead of the leaf paint chunk.

This allows us to significantly simplify raster and draw on `CompositedLayer`.