### PR TITLE
Simplify how composited updates are applied

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1945,7 +1945,7 @@ class Browser:
 Now we need to update `draw_list` to take into account the latest value, which
 should be looked up in `composited_updates`. Define a method `clone_latest`
 that clones the update visual effect from `composited_updates` if there is one,
-and otherwise clones the original.
+and otherwise clones the original.[^ptrcompare]
 
 ``` {.python}
 class Browser:


### PR DESCRIPTION
* Store them in a dictionary keyed by node, so that we don't have an n^2 loop
* Don't mutate the ancestor effects in place, instead clone the updated one rather than the existing one
* Delete the copy methods on all DisplayItem subtypes