### PR TITLE
Add parent pointers, thereby removing the need for paint chunks

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -2356,10 +2356,11 @@ the absolute bounds of a paint chunk:
 
 ``` {.python}
 def absolute_bounds(display_item):
-    ancestor_effects = ancestor_effects_list(display_item)
     retval = display_item.composited_bounds()
-    for ancestor_item in reversed(ancestor_effects):
-        retval = ancestor_item.map(retval)
+    effect = display_item.parent
+    while effect:
+        retval = effect.map(retval)
+        effect = effect.parent
     return retval
 ```
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -1266,7 +1266,7 @@ We can find all of the paint commands in the display tree using
 class Browser:
     def composite(self):
         paint_commands = [cmd
-            for cmd in tree_to_list(self.active_tab_display_list)
+            for cmd in tree_to_list(self.active_tab_display_list, [])
             if cmd.is_paint_command()
         ]
 ```

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1706,7 +1706,7 @@ class Browser:
         self.composited_layers = []
         add_parent_pointers(self.active_tab_display_list)
         paint_commands = [cmd
-            for cmd in tree_to_list(self.active_tab_display_list)
+            for cmd in tree_to_list(self.active_tab_display_list, [])
             if cmd.is_paint_command()
         ]
         for display_item in paint_commands:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1064,11 +1064,11 @@ def composited_ancestor_index(ancestor_effects):
     return -1
 
 def absolute_bounds(display_item):
-    ancestor_effects = ancestor_effects_list(display_item)
     retval = display_item.composited_bounds()
-    for ancestor_item in reversed(ancestor_effects):
-        if type(ancestor_item) is Transform:
-            retval = ancestor_item.map(retval)
+    effect = display_item.parent
+    while effect:
+        retval = effect.map(retval)
+        effect = effect.parent
     return retval
 
 class CompositedLayer:


### PR DESCRIPTION
This is a minimal PR that adds parent pointers to display trees and thereby eliminates the need for paint chunks. It also eliminates the need for the `display_list_to_paint_chunks` method; it is replaced with `tree_to_list`.

I tried to do a deeper refactor and avoid ever creating lists of ancestor effects (that is, replacing all such cases with `while` loops that walk up the parent pointers). However, I got trapped in a rabbit hole and so right now I just call an `ancestor_effects_list` helper method in a few places. The ultimate goal is to not use it anywhere, but it's probably best to do that later, after other refactors happen first.