### PR TITLE
Initially make all visual effects composited

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1270,7 +1270,7 @@ don't have recursive children in `children`.
 We can find all of the paint commands in the display tree using
 `tree_to_list`:
 
-``` {.python replace=cmd.is_paint_command()/not%20cmd.needs_compositing()}
+``` {.python expected=False}
 class Browser:
     def composite(self):
         paint_commands = [cmd
@@ -1876,7 +1876,7 @@ class Browser:
         # ...
         paint_commands = [cmd
             for cmd in tree_to_list(self.active_tab_display_list, [])
-            if not cmd.needs_compositing()
+            if not cmd.needs_compositing() and cmd.parent.needs_compositing()
         ]
         # ...
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -1320,7 +1320,7 @@ animations would end up applying to the wrong paint commands.) For
 now, let's focus on the simplest possible way to do that, which is to
 put every paint command into its own layer:
 
-``` {.python}
+``` {.python expected=False}
 class Browser:
     def __init__(self):
         # ...
@@ -1331,8 +1331,8 @@ class Browser:
         # ...
         for display_item in paint_commands:
             layer = CompositedLayer(skia_context)
-            layer.add_display_item(display_item)
-            composited_layers.append(layer)
+            layer.add_paint_chunk(display_item)
+            self.composited_layers.append(layer)
 ```
 
 Once there is a list of `CompositedLayer`s, rastering the `CompositedLayer`s
@@ -1543,9 +1543,9 @@ order. Later items in the display list have to draw later.
 class Browser:
     def composite(self):
         for display_item in paint_commands:
-            for layer in reversed(composited_layers):
+            for layer in reversed(self.composited_layers):
                 if layer.can_merge(display_item):
-                    layer.add_display_item(display_item)
+                    layer.add_paint_chunk(display_item)
                     break
             else:
                 # ...

--- a/book/animations.md
+++ b/book/animations.md
@@ -1330,9 +1330,24 @@ class Browser:
         self.composited_layers = []
         # ...
         for display_item in paint_commands:
-            layer = CompositedLayer(skia_context)
+            layer = CompositedLayer(self.skia_context)
             layer.add_paint_chunk(display_item)
             self.composited_layers.append(layer)
+```
+
+Here, a `CompositedLayer` just stores a list of display items (and a
+surface that they'll be drawn to) and `add_paint_chunk` adds a paint
+command to the list:
+
+``` {.python replace=self.display_items.append/%20%20%20%20self.display_items.append}
+class CompositedLayer:
+    def __init__(self, skia_context):
+        self.skia_context = skia_context
+        self.surface = None
+        self.display_items = []
+
+    def add_paint_chunk(self, display_item):
+        self.display_items.append(display_item)
 ```
 
 Once there is a list of `CompositedLayer`s, rastering the `CompositedLayer`s
@@ -1740,10 +1755,10 @@ class CompositedLayer:
 
         if composited_index < len(ancestor_effects) - 1:
             self.display_items.append(
-                (ancestor_effects[composited_index + 1],
-                 self.ancestor_effects))
+                ancestor_effects[composited_index + 1],
+            )
         else:
-            self.display_items.append((display_item, ancestor_effects))
+            self.display_items.append(display_item)
 ```
 
 * `composited_bounds`: returns the union of the composited bounds of all
@@ -1755,7 +1770,7 @@ class CompositedLayer:
     # ...
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             retval.join(item.composited_bounds())
         return retval
 ```
@@ -1784,7 +1799,7 @@ class CompositedLayer:
         canvas.clear(skia.ColorTRANSPARENT)
         canvas.save()
         canvas.translate(-bounds.left(), -bounds.top())
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             item.execute(canvas)
         canvas.restore()
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -1270,7 +1270,7 @@ don't have recursive children in `children`.
 We can find all of the paint commands in the display tree using
 `tree_to_list`:
 
-``` {.python}
+``` {.python replace=cmd.is_paint_command()/not%20cmd.needs_compositing()}
 class Browser:
     def composite(self):
         paint_commands = [cmd

--- a/book/animations.md
+++ b/book/animations.md
@@ -1316,29 +1316,11 @@ visual effects.
 
 Two paint commands can be put into the same composited layer if they
 have the exact same set of animating ancestor effects. (Otherwise the
-animations would end up applying to the wrong paint commands.)
+animations would end up applying to the wrong paint commands.) For
+now, let's focus on the simplest possible way to do that, which is to
+put every paint command into its own layer:
 
-To satisfy this constraint, we *could* just put each paint command in its own
-composited layer. But of course, for examples more complex than just one
-`DrawText` that would result in a huge number of surfaces, and most likely
-exhaust the computer's GPU memory. So the goal of the *compositing algorithm*
-is to come up with a way to pack paint chunks into only a small number of
-composited layers.^[There are many possible compositing algorithms, with their
-own tradeoffs of memory, time and code complexity. I'll present a simplified
-version of the one used by Chromium.]
-
-Below is the algorithm we'll use; as you can see it's not very complicated. It
-loops over the list of paint chunks; for each paint chunk it tries to add it to
-an existing `CompositedLayer` by walking *backwards* through the
-`CompositedLayer` list.[^why-backwards] If one is found, the paint chunk is
-added to it; if not, a new `CompositedLayer` is added with that paint chunk to
-start. The `can_merge` method on a `CompositedLayer` checks compatibility of
-the paint chunk's animating ancestor effects with the ones already on it.
-
-[^why-backwards]: Backwards, because we can't draw things in the wrong
-order. Later items in the display list have to draw later.
-
-``` {.python expected=False}
+``` {.python}
 class Browser:
     def __init__(self):
         # ...
@@ -1348,20 +1330,10 @@ class Browser:
         self.composited_layers = []
         # ...
         for display_item in paint_commands:
-            for layer in reversed(composited_layers):
-                if layer.can_merge(display_item):
-                    layer.add_display_item(display_item)
-                    break
-            else:
-                layer = CompositedLayer(skia_context)
-                layer.add_display_item(display_item)
-                composited_layers.append(layer)
+            layer = CompositedLayer(skia_context)
+            layer.add_display_item(display_item)
+            composited_layers.append(layer)
 ```
-
-The `can_merge` and `add_display_item` methods use
-`ancestor_effects_list` to make sure we group paint commands
-correctly. If you're not familiar with Python's `for ... else` syntax,
-the `else` block executes only if the loop never executed `break`.
 
 Once there is a list of `CompositedLayer`s, rastering the `CompositedLayer`s
 will be look like this:
@@ -1542,6 +1514,66 @@ and clipping.
 
 :::
 
+Grouping Paint Commands
+=======================
+
+Right now, every paint command it put in its own layer. But layers are
+expensive: each of them allocates a surface, and each of those
+allocates and holds on to GPU memory. GPU memory is limited, and we
+want to use less of it when possible. To that end, we'd like to use
+fewer layers.
+
+Below is the algorithm we'll use;^[There are many possible compositing
+algorithms, with their own tradeoffs of memory, time and code
+complexity. I'll present a simplified version of the one used by
+Chromium.] as you can see it's not very complicated. It loops over the
+list of paint chunks; for each paint chunk it tries to add it to an
+existing `CompositedLayer` by walking *backwards* through the
+`CompositedLayer` list.[^why-backwards] If one is found, the paint
+chunk is added to it; if not, a new `CompositedLayer` is added with
+that paint chunk to start. The `can_merge` method on a
+`CompositedLayer` checks compatibility of the paint chunk's animating
+ancestor effects with the ones already on it.
+
+[^why-backwards]: Backwards, because we can't draw things in the wrong
+order. Later items in the display list have to draw later.
+
+
+``` {.python}
+class Browser:
+    def composite(self):
+        for display_item in paint_commands:
+            for layer in reversed(composited_layers):
+                if layer.can_merge(display_item):
+                    layer.add_display_item(display_item)
+                    break
+            else:
+                # ...
+```
+
+If you're not familiar with Python's `for ... else` syntax, the `else`
+block executes only if the loop never executed `break`.
+
+The `can_merge` method returns whether the given paint chunk is
+compatible with being drawn into the same `CompositedLayer` as the
+existing ones. This will be true if they have the same nearest
+composited ancestor (or both have none).
+ 
+``` {.python}
+class CompositedLayer:
+    def can_merge(self, display_item):
+        ancestor_effects = ancestor_effects_list(display_item)
+        if len(self.display_items) == 0:
+            return True
+        if len(self.ancestor_effects) != len(ancestor_effects):
+            return False
+        if len(self.ancestor_effects) == 0:
+            return True
+        return self.ancestor_effects[-1] == ancestor_effects[
+            composited_ancestor_index(ancestor_effects)]
+```
+
+
 Composited display items
 ========================
 
@@ -1692,24 +1724,6 @@ highest parent display item that is not composited.
 animation".
 
 The `CompositedLayer` class will have the following methods:
-
-* `can_merge`: returns whether the given paint chunk is compatible with being
-  drawn into the same `CompositedLayer` as the existing ones. This will be true
-  if they have the same nearest composited ancestor (or both have none).
- 
-``` {.python}
-class CompositedLayer:
-    def can_merge(self, display_item):
-        ancestor_effects = ancestor_effects_list(display_item)
-        if len(self.display_items) == 0:
-            return True
-        if len(self.ancestor_effects) != len(ancestor_effects):
-            return False
-        if len(self.ancestor_effects) == 0:
-            return True
-        return self.ancestor_effects[-1] == ancestor_effects[
-            composited_ancestor_index(ancestor_effects)]
-```
 
 * `add_paint_chunk`: adds a new paint chunk to the `CompositedLayer`. The first
   one being added will initialize its `composited_ancestor_index`.

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1712,7 +1712,7 @@ class Browser:
         add_parent_pointers(self.active_tab_display_list)
         paint_commands = [cmd
             for cmd in tree_to_list(self.active_tab_display_list, [])
-            if not cmd.needs_compositing()
+            if not cmd.needs_compositing() and cmd.parent.needs_compositing()
         ]
         for display_item in paint_commands:
             for layer in reversed(self.composited_layers):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1099,21 +1099,21 @@ class CompositedLayer:
 
         if composited_index < len(ancestor_effects) - 1:
             self.display_items.append(
-                (ancestor_effects[composited_index + 1],
-                 self.ancestor_effects))
+                ancestor_effects[composited_index + 1],
+            )
         else:
-            self.display_items.append((display_item, ancestor_effects))
+            self.display_items.append(display_item)
 
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             retval.join(item.composited_bounds())
         return retval
 
     def absolute_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.display_items:
-            retval.join(absolute_bounds(item, ancestor_effects))
+        for item in self.display_items:
+            retval.join(absolute_bounds(item))
         return retval
 
     def composited_items(self):
@@ -1144,7 +1144,7 @@ class CompositedLayer:
         canvas.clear(skia.ColorTRANSPARENT)
         canvas.save()
         canvas.translate(-bounds.left(), -bounds.top())
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             item.execute(canvas)
         canvas.restore()
 
@@ -1165,7 +1165,7 @@ class CompositedLayer:
         return ("layer: composited_bounds={} " +
             "absolute_bounds={} first_chunk={}").format(
             self.composited_bounds(), self.absolute_bounds(),
-            self.display_items[0] if len(self.display_items) > 0 else 'None')
+            self.display_items if len(self.display_items) > 0 else 'None')
 
 def raster(display_list, canvas):
     for cmd in display_list:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -112,7 +112,7 @@ class DisplayItem:
                 cmd.composited_bounds_internal(rect)
 
     def needs_compositing(self):
-        return False
+        return any([child.needs_compositing() for child in children])
 
     def clone(self, children):
         assert False
@@ -133,7 +133,8 @@ class Transform(DisplayItem):
             canvas.restore()
 
     def needs_compositing(self):
-        return USE_COMPOSITING and self.translation
+        return USE_COMPOSITING and self.translation or \
+            any([child.needs_compositing() for child in children])
 
     def map(self, rect):
         if not self.translation:
@@ -261,9 +262,6 @@ class ClipRRect(DisplayItem):
         if self.should_clip:
             canvas.restore()
 
-    def needs_compositing(self):
-        return False
-
     def clone(self, children):
         return ClipRRect(self.rect, self.radius, children, \
             self.should_clip)
@@ -289,7 +287,8 @@ class SaveLayer(DisplayItem):
             canvas.restore()
 
     def needs_compositing(self):
-        return USE_COMPOSITING and self.should_save
+        return USE_COMPOSITING and self.should_save or \
+            any([child.needs_compositing() for child in children])
 
     def clone(self, children):
         return SaveLayer(self.sk_paint, self.node, children, \

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1064,6 +1064,11 @@ def composited_ancestor_index(ancestor_effects):
         count -= 1
     return -1
 
+def composited_ancestor(node):
+    while node and not node.needs_compositing():
+        node = node.parent
+    return node
+
 def absolute_bounds(display_item):
     retval = display_item.composited_bounds()
     effect = display_item.parent
@@ -1708,7 +1713,7 @@ class Browser:
         add_parent_pointers(self.active_tab_display_list)
         paint_commands = [cmd
             for cmd in tree_to_list(self.active_tab_display_list, [])
-            if cmd.is_paint_command()
+            if not cmd.needs_compositing()
         ]
         for display_item in paint_commands:
             for layer in reversed(self.composited_layers):


### PR DESCRIPTION
This PR moves `needs_compositing` to a later section. It doesn't yet simplify `CompositedLayer` (except a little bit) but I think once this is merged it should be possible to do a massive simplification.