### PR TITLE
Simplify `CompositedLayer`

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1331,13 +1331,13 @@ class Browser:
         # ...
         for display_item in paint_commands:
             layer = CompositedLayer(self.skia_context)
-            layer.add_paint_chunk(display_item)
+            layer.add(display_item)
             self.composited_layers.append(layer)
 ```
 
 Here, a `CompositedLayer` just stores a list of display items (and a
-surface that they'll be drawn to) and `add_paint_chunk` adds a paint
-command to the list:
+surface that they'll be drawn to) and `add` adds a paint command to
+the list:
 
 ``` {.python replace=self.display_items.append/%20%20%20%20self.display_items.append}
 class CompositedLayer:
@@ -1346,7 +1346,7 @@ class CompositedLayer:
         self.surface = None
         self.display_items = []
 
-    def add_paint_chunk(self, display_item):
+    def add(self, display_item):
         self.display_items.append(display_item)
 ```
 
@@ -1560,7 +1560,7 @@ class Browser:
         for display_item in paint_commands:
             for layer in reversed(self.composited_layers):
                 if layer.can_merge(display_item):
-                    layer.add_paint_chunk(display_item)
+                    layer.add(display_item)
                     break
             else:
                 # ...
@@ -1585,7 +1585,7 @@ class CompositedLayer:
         else:
             return True
 
-    def add_paint_chunk(self, display_item):
+    def add(self, display_item):
         assert self.can_merge(display_item)
         self.parent_effect = display_item.parent
         self.display_items.append(display_item)
@@ -2181,7 +2181,7 @@ that needs to be animated.
                     layer.absolute_bounds(),
                     absolute_bounds(display_item)):
                     layer = CompositedLayer(self.skia_context)
-                    layer.add_paint_chunk(display_item)
+                    layer.add(display_item)
                     self.composited_layers.append(layer)
                     break
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -1270,7 +1270,7 @@ don't have recursive children in `children`.
 We can find all of the paint commands in the display tree using
 `tree_to_list`:
 
-``` {.python replace=cmd.is_paint_command()/not%20cmd.needs_compositing()}
+``` {.python expected=False}
 class Browser:
     def composite(self):
         paint_commands = [cmd
@@ -1876,7 +1876,7 @@ class Browser:
         # ...
         paint_commands = [cmd
             for cmd in tree_to_list(self.active_tab_display_list, [])
-            if not cmd.needs_compositing()
+            if not cmd.needs_compositing() and cmd.parent.needs_compositing()
         ]
         # ...
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -1320,7 +1320,7 @@ animations would end up applying to the wrong paint commands.) For
 now, let's focus on the simplest possible way to do that, which is to
 put every paint command into its own layer:
 
-``` {.python}
+``` {.python expected=False}
 class Browser:
     def __init__(self):
         # ...
@@ -1331,8 +1331,8 @@ class Browser:
         # ...
         for display_item in paint_commands:
             layer = CompositedLayer(skia_context)
-            layer.add_display_item(display_item)
-            composited_layers.append(layer)
+            layer.add_paint_chunk(display_item)
+            self.composited_layers.append(layer)
 ```
 
 Once there is a list of `CompositedLayer`s, rastering the `CompositedLayer`s
@@ -1543,9 +1543,9 @@ order. Later items in the display list have to draw later.
 class Browser:
     def composite(self):
         for display_item in paint_commands:
-            for layer in reversed(composited_layers):
+            for layer in reversed(self.composited_layers):
                 if layer.can_merge(display_item):
-                    layer.add_display_item(display_item)
+                    layer.add_paint_chunk(display_item)
                     break
             else:
                 # ...

--- a/book/animations.md
+++ b/book/animations.md
@@ -1330,9 +1330,24 @@ class Browser:
         self.composited_layers = []
         # ...
         for display_item in paint_commands:
-            layer = CompositedLayer(skia_context)
+            layer = CompositedLayer(self.skia_context)
             layer.add_paint_chunk(display_item)
             self.composited_layers.append(layer)
+```
+
+Here, a `CompositedLayer` just stores a list of display items (and a
+surface that they'll be drawn to) and `add_paint_chunk` adds a paint
+command to the list:
+
+``` {.python replace=self.display_items.append/%20%20%20%20self.display_items.append}
+class CompositedLayer:
+    def __init__(self, skia_context):
+        self.skia_context = skia_context
+        self.surface = None
+        self.display_items = []
+
+    def add_paint_chunk(self, display_item):
+        self.display_items.append(display_item)
 ```
 
 Once there is a list of `CompositedLayer`s, rastering the `CompositedLayer`s
@@ -1740,10 +1755,10 @@ class CompositedLayer:
 
         if composited_index < len(ancestor_effects) - 1:
             self.display_items.append(
-                (ancestor_effects[composited_index + 1],
-                 self.ancestor_effects))
+                ancestor_effects[composited_index + 1],
+            )
         else:
-            self.display_items.append((display_item, ancestor_effects))
+            self.display_items.append(display_item)
 ```
 
 * `composited_bounds`: returns the union of the composited bounds of all
@@ -1755,7 +1770,7 @@ class CompositedLayer:
     # ...
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             retval.join(item.composited_bounds())
         return retval
 ```
@@ -1784,7 +1799,7 @@ class CompositedLayer:
         canvas.clear(skia.ColorTRANSPARENT)
         canvas.save()
         canvas.translate(-bounds.left(), -bounds.top())
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             item.execute(canvas)
         canvas.restore()
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -1296,18 +1296,6 @@ class Browser:
         # ...
 ```
 
-Now we can get the list of ancestor effects with a simple loop:
-
-``` {.python}
-def ancestor_effects_list(node):
-    parent = node.parent
-    effects = []
-    while parent:
-        effects = [parent] + effects
-        parent = parent.parent
-    return effects
-```
-
 When combined together, multiple paint commands form a *composited
 layer*, represented by the `CompositedLayer` class. This class will
 own a `skia.Surface` that rasters its content, and also know how to

--- a/book/animations.md
+++ b/book/animations.md
@@ -1686,15 +1686,6 @@ member variables: a Skia context, surface, list of display items to raster, and
 the list of ancestor effects. (All paint chunks in the same `CompositedLayer`
 will have the same ancestor effects.)
 
-``` {.python}
-class CompositedLayer:
-    def __init__(self, skia_context):
-        self.skia_context = skia_context
-        self.surface = None
-        self.display_items = []
-        self.ancestor_effects = []
-```
-
 Only paint chunks that have the same *nearest composited visual effect ancestor*
 will be allowed to be in the same `CompositedLayer`.[^simpler] The composited
 ancestor index is the index into the top-down list of ancestor effects
@@ -1702,17 +1693,6 @@ referring to this nearest ancestor. (If there is no composited ancestor, the
 index is -1). Here's how to compute it it. Note how we are walking *up* the
 display list tree (and therefore implicitly up the DOM tree also) via a
 reversed iteration:
-
-``` {.python}
-def composited_ancestor_index(ancestor_effects):
-    count = len(ancestor_effects) - 1
-    for ancestor_item in reversed(ancestor_effects):
-        if ancestor_item.needs_compositing():
-            return count
-            break
-        count -= 1
-    return -1
-```
 
 So all paint chunks in the same `CompositedLayer` will share the same composited
 ancestor index. However, they need not have exactly the same ancestor effects
@@ -1725,27 +1705,6 @@ highest parent display item that is not composited.
 animation".
 
 The `CompositedLayer` class will have the following methods:
-
-* `add_paint_chunk`: adds a new paint chunk to the `CompositedLayer`. The first
-  one being added will initialize its `composited_ancestor_index`.
-
-``` {.python}
-class CompositedLayer:
-    # ...
-    def add_paint_chunk(self, display_item):
-        assert self.can_merge(display_item)
-        ancestor_effects = ancestor_effects_list(display_item)
-        composited_index = composited_ancestor_index(ancestor_effects)
-        if len(self.display_items) == 0 and composited_index >= 0:
-            self.ancestor_effects = ancestor_effects[0:composited_index + 1]
-
-        if composited_index < len(ancestor_effects) - 1:
-            self.display_items.append(
-                ancestor_effects[composited_index + 1],
-            )
-        else:
-            self.display_items.append(display_item)
-```
 
 * `composited_bounds`: returns the union of the composited bounds of all
   paint chunks. The composited bounds of a paint chunk is its display item's

--- a/book/animations.md
+++ b/book/animations.md
@@ -1598,21 +1598,6 @@ Composited display items
 Before getting to finishing off `CompositedLayer`, let's add some more features
 to display items to help then support compositing.
 
-And while we're at it, add another `DisplayItem` constructor parameter
-indicating the `node` that the `DisplayItem` belongs to (the one that painted
-it); this will be useful when keeping track of mappings between `DisplayItem`s
-and GPU textures.[^cache-key]
-
-[^cache-key]: Remember that these compositing GPU textures are simply a form of
-cache, and every cache needs a stable cache key to be useful.
-
-``` {.python replace=children=/rect%2c%20children=}
-class DisplayItem:
-    def __init__(self, children=[], node=None):
-        # ...
-        self.node = node
-```
-
 Finally, we'll need to be able to get the *composited bounds* of a
 `DisplayItem`. This is necessary to figure out the size of a `skia.Surface` that
 contains the item.
@@ -1856,6 +1841,22 @@ Avoiding raster and the compositing algorithm is simple in concept: keep track
 of what is animating, and re-run `draw` with different opacity parameters on
 the `CompositedLayer`s that are animating. If nothing else changes, then
 we don't need to re-composite or re-raster anything.
+
+Add another `DisplayItem` constructor parameter
+indicating the `node` that the `DisplayItem` belongs to (the one that painted
+it); this will be useful when keeping track of mappings between `DisplayItem`s
+and GPU textures.[^cache-key]
+
+[^cache-key]: Remember that these compositing GPU textures are simply a form of
+cache, and every cache needs a stable cache key to be useful.
+
+``` {.python replace=children=/rect%2c%20children=}
+class DisplayItem:
+    def __init__(self, children=[], node=None):
+        # ...
+        self.node = node
+```
+
 
 Let's accomplish that. It will have multiple parts, starting with the main
 thread.

--- a/book/animations.md
+++ b/book/animations.md
@@ -1270,7 +1270,7 @@ don't have recursive children in `children`.
 We can find all of the paint commands in the display tree using
 `tree_to_list`:
 
-``` {.python}
+``` {.python replace=cmd.is_paint_command()/not%20cmd.needs_compositing()}
 class Browser:
     def composite(self):
         paint_commands = [cmd

--- a/book/animations.md
+++ b/book/animations.md
@@ -1316,29 +1316,11 @@ visual effects.
 
 Two paint commands can be put into the same composited layer if they
 have the exact same set of animating ancestor effects. (Otherwise the
-animations would end up applying to the wrong paint commands.)
+animations would end up applying to the wrong paint commands.) For
+now, let's focus on the simplest possible way to do that, which is to
+put every paint command into its own layer:
 
-To satisfy this constraint, we *could* just put each paint command in its own
-composited layer. But of course, for examples more complex than just one
-`DrawText` that would result in a huge number of surfaces, and most likely
-exhaust the computer's GPU memory. So the goal of the *compositing algorithm*
-is to come up with a way to pack paint chunks into only a small number of
-composited layers.^[There are many possible compositing algorithms, with their
-own tradeoffs of memory, time and code complexity. I'll present a simplified
-version of the one used by Chromium.]
-
-Below is the algorithm we'll use; as you can see it's not very complicated. It
-loops over the list of paint chunks; for each paint chunk it tries to add it to
-an existing `CompositedLayer` by walking *backwards* through the
-`CompositedLayer` list.[^why-backwards] If one is found, the paint chunk is
-added to it; if not, a new `CompositedLayer` is added with that paint chunk to
-start. The `can_merge` method on a `CompositedLayer` checks compatibility of
-the paint chunk's animating ancestor effects with the ones already on it.
-
-[^why-backwards]: Backwards, because we can't draw things in the wrong
-order. Later items in the display list have to draw later.
-
-``` {.python expected=False}
+``` {.python}
 class Browser:
     def __init__(self):
         # ...
@@ -1348,20 +1330,10 @@ class Browser:
         self.composited_layers = []
         # ...
         for display_item in paint_commands:
-            for layer in reversed(composited_layers):
-                if layer.can_merge(display_item):
-                    layer.add_display_item(display_item)
-                    break
-            else:
-                layer = CompositedLayer(skia_context)
-                layer.add_display_item(display_item)
-                composited_layers.append(layer)
+            layer = CompositedLayer(skia_context)
+            layer.add_display_item(display_item)
+            composited_layers.append(layer)
 ```
-
-The `can_merge` and `add_display_item` methods use
-`ancestor_effects_list` to make sure we group paint commands
-correctly. If you're not familiar with Python's `for ... else` syntax,
-the `else` block executes only if the loop never executed `break`.
 
 Once there is a list of `CompositedLayer`s, rastering the `CompositedLayer`s
 will be look like this:
@@ -1542,6 +1514,66 @@ and clipping.
 
 :::
 
+Grouping Paint Commands
+=======================
+
+Right now, every paint command it put in its own layer. But layers are
+expensive: each of them allocates a surface, and each of those
+allocates and holds on to GPU memory. GPU memory is limited, and we
+want to use less of it when possible. To that end, we'd like to use
+fewer layers.
+
+Below is the algorithm we'll use;^[There are many possible compositing
+algorithms, with their own tradeoffs of memory, time and code
+complexity. I'll present a simplified version of the one used by
+Chromium.] as you can see it's not very complicated. It loops over the
+list of paint chunks; for each paint chunk it tries to add it to an
+existing `CompositedLayer` by walking *backwards* through the
+`CompositedLayer` list.[^why-backwards] If one is found, the paint
+chunk is added to it; if not, a new `CompositedLayer` is added with
+that paint chunk to start. The `can_merge` method on a
+`CompositedLayer` checks compatibility of the paint chunk's animating
+ancestor effects with the ones already on it.
+
+[^why-backwards]: Backwards, because we can't draw things in the wrong
+order. Later items in the display list have to draw later.
+
+
+``` {.python}
+class Browser:
+    def composite(self):
+        for display_item in paint_commands:
+            for layer in reversed(composited_layers):
+                if layer.can_merge(display_item):
+                    layer.add_display_item(display_item)
+                    break
+            else:
+                # ...
+```
+
+If you're not familiar with Python's `for ... else` syntax, the `else`
+block executes only if the loop never executed `break`.
+
+The `can_merge` method returns whether the given paint chunk is
+compatible with being drawn into the same `CompositedLayer` as the
+existing ones. This will be true if they have the same nearest
+composited ancestor (or both have none).
+ 
+``` {.python}
+class CompositedLayer:
+    def can_merge(self, display_item):
+        ancestor_effects = ancestor_effects_list(display_item)
+        if len(self.display_items) == 0:
+            return True
+        if len(self.ancestor_effects) != len(ancestor_effects):
+            return False
+        if len(self.ancestor_effects) == 0:
+            return True
+        return self.ancestor_effects[-1] == ancestor_effects[
+            composited_ancestor_index(ancestor_effects)]
+```
+
+
 Composited display items
 ========================
 
@@ -1692,24 +1724,6 @@ highest parent display item that is not composited.
 animation".
 
 The `CompositedLayer` class will have the following methods:
-
-* `can_merge`: returns whether the given paint chunk is compatible with being
-  drawn into the same `CompositedLayer` as the existing ones. This will be true
-  if they have the same nearest composited ancestor (or both have none).
- 
-``` {.python}
-class CompositedLayer:
-    def can_merge(self, display_item):
-        ancestor_effects = ancestor_effects_list(display_item)
-        if len(self.display_items) == 0:
-            return True
-        if len(self.ancestor_effects) != len(ancestor_effects):
-            return False
-        if len(self.ancestor_effects) == 0:
-            return True
-        return self.ancestor_effects[-1] == ancestor_effects[
-            composited_ancestor_index(ancestor_effects)]
-```
 
 * `add_paint_chunk`: adds a new paint chunk to the `CompositedLayer`. The first
   one being added will initialize its `composited_ancestor_index`.

--- a/book/animations.md
+++ b/book/animations.md
@@ -1712,6 +1712,7 @@ class CompositedLayer:
   account in `draw` as well; see below.]
 
 ``` {.python}
+class CompositedLayer:
     def raster(self):
         bounds = self.composited_bounds()
         if bounds.isEmpty():
@@ -1739,7 +1740,7 @@ part is making sure to re-introduce the top and left offsets that were omitted
 from `raster`.
 
 ``` {.python}
-
+class CompositedLayer:
     def draw(self, canvas):
         bounds = self.composited_bounds()
         surface_offset_x = bounds.left()
@@ -1756,6 +1757,7 @@ The last bit is just to wire it up by generalizing `raster_and_draw` into
 renaming at all callsites), and everything should work end-to-end.
 
 ``` {.python}
+class Browser:
     def composite_raster_and_draw(self):
         # ...
         self.composite()

--- a/book/animations.md
+++ b/book/animations.md
@@ -1294,7 +1294,7 @@ animations would end up applying to the wrong paint commands.) For
 now, let's focus on the simplest possible way to do that, which is to
 put every paint command into its own layer:
 
-``` {.python expected=False}
+``` {.python}
 class Browser:
     def __init__(self):
         # ...
@@ -1568,10 +1568,6 @@ existing ones. This will be true if they have the same parent.
  
 ``` {.python}
 class CompositedLayer:
-    def __init__(self, skia_context):
-        # ...
-        self.parent = None
-
     def can_merge(self, display_item):
         if self.display_items:
             return display_item.parent == self.display_item[0].parent

--- a/book/animations.md
+++ b/book/animations.md
@@ -1280,21 +1280,7 @@ class Browser:
 ```
 
 Notice that each display item can be (individually) drawn to the screen by
-executing it and the series of *ancestor [visual] effects* on it. To
-make it easy to access those ancestor visual effects, let's add parent
-pointers to our display tree:
-
-``` {.python}
-def add_parent_pointers(nodes, parent=None):
-    for node in nodes:
-        node.parent = parent
-        add_parent_pointers(node.children, node)
-
-class Browser:
-    def composite(self):
-        add_parent_pointers(self.active_tab_display_list)
-        # ...
-```
+executing it and the series of *ancestor [visual] effects* on it. 
 
 When combined together, multiple paint commands form a *composited
 layer*, represented by the `CompositedLayer` class. This class will
@@ -1537,6 +1523,23 @@ chunk is added to it; if not, a new `CompositedLayer` is added with
 that paint chunk to start. The `can_merge` method on a
 `CompositedLayer` checks compatibility of the paint chunk's animating
 ancestor effects with the ones already on it.
+
+To make it easy to access those ancestor visual effects, let's add parent
+pointers to our display tree:
+
+``` {.python}
+def add_parent_pointers(nodes, parent=None):
+    for node in nodes:
+        node.parent = parent
+        add_parent_pointers(node.children, node)
+
+class Browser:
+    def composite(self):
+        add_parent_pointers(self.active_tab_display_list)
+        # ...
+```
+
+
 
 [^why-backwards]: Backwards, because we can't draw things in the wrong
 order. Later items in the display list have to draw later.

--- a/book/animations.md
+++ b/book/animations.md
@@ -1569,7 +1569,7 @@ composited ancestor (or both have none).
 class CompositedLayer:
     def can_merge(self, display_item):
         if self.display_items:
-            return display_item.parent == self.display_item[0].parent
+            return display_item.parent == self.display_items[0].parent
         else:
             return True
 ```
@@ -1593,7 +1593,7 @@ existing ones. This will be true if they have the same parent.
 class CompositedLayer:
     def can_merge(self, display_item):
         if self.display_items:
-            return display_item.parent == self.display_item[0].parent
+            return display_item.parent == self.display_items[0].parent
         else:
             return True
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -1581,7 +1581,7 @@ class CompositedLayer:
 
     def can_merge(self, display_item):
         if self.display_items:
-            return display_item.parent = self.display_item[0].parent
+            return display_item.parent == self.display_item[0].parent
         else:
             return True
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -1571,21 +1571,24 @@ block executes only if the loop never executed `break`.
 
 The `can_merge` method returns whether the given paint chunk is
 compatible with being drawn into the same `CompositedLayer` as the
-existing ones. This will be true if they have the same nearest
-composited ancestor (or both have none).
+existing ones. This will be true if they have the same parent.
  
 ``` {.python}
 class CompositedLayer:
+    def __init__(self, skia_context):
+        # ...
+        self.parent_effect = None
+
     def can_merge(self, display_item):
-        ancestor_effects = ancestor_effects_list(display_item)
-        if len(self.display_items) == 0:
+        if self.display_items:
+            return display_item.parent = self.display_item[0].parent
+        else:
             return True
-        if len(self.ancestor_effects) != len(ancestor_effects):
-            return False
-        if len(self.ancestor_effects) == 0:
-            return True
-        return self.ancestor_effects[-1] == ancestor_effects[
-            composited_ancestor_index(ancestor_effects)]
+
+    def add_paint_chunk(self, display_item):
+        assert self.can_merge(display_item)
+        self.parent_effect = display_item.parent
+        self.display_items.append(display_item)
 ```
 
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1071,7 +1071,7 @@ class CompositedLayer:
 
     def can_merge(self, display_item):
         if self.display_items:
-            return display_item.parent = self.display_item[0].parent
+            return display_item.parent == self.display_item[0].parent
         else:
             return True
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1067,7 +1067,6 @@ class CompositedLayer:
         self.skia_context = skia_context
         self.surface = None
         self.display_items = []
-        self.parent_effect = None
 
     def can_merge(self, display_item):
         if self.display_items:
@@ -1077,7 +1076,6 @@ class CompositedLayer:
 
     def add(self, display_item):
         assert self.can_merge(display_item)
-        self.parent_effect = display_item.parent
         self.display_items.append(display_item)
 
     def composited_bounds(self):
@@ -1687,7 +1685,8 @@ class Browser:
         self.draw_list = []
         for composited_layer in self.composited_layers:
             current_effect = DrawCompositedLayer(composited_layer)
-            parent = composited_layer.parent
+            if not composited_layer.display_list: pass
+            parent = composited_layer.display_list[0].parent
             while parent:
                 current_effect = self.clone_latest(parent, [current_effect])
                 parent = parent.parent

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1712,7 +1712,7 @@ class Browser:
         add_parent_pointers(self.active_tab_display_list)
         paint_commands = [cmd
             for cmd in tree_to_list(self.active_tab_display_list, [])
-            if not cmd.needs_compositing()
+            if not cmd.needs_compositing() and cmd.parent.needs_compositing()
         ]
         for display_item in paint_commands:
             for layer in reversed(self.composited_layers):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1099,21 +1099,21 @@ class CompositedLayer:
 
         if composited_index < len(ancestor_effects) - 1:
             self.display_items.append(
-                (ancestor_effects[composited_index + 1],
-                 self.ancestor_effects))
+                ancestor_effects[composited_index + 1],
+            )
         else:
-            self.display_items.append((display_item, ancestor_effects))
+            self.display_items.append(display_item)
 
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             retval.join(item.composited_bounds())
         return retval
 
     def absolute_bounds(self):
         retval = skia.Rect.MakeEmpty()
-        for (item, ancestor_effects) in self.display_items:
-            retval.join(absolute_bounds(item, ancestor_effects))
+        for item in self.display_items:
+            retval.join(absolute_bounds(item))
         return retval
 
     def composited_items(self):
@@ -1144,7 +1144,7 @@ class CompositedLayer:
         canvas.clear(skia.ColorTRANSPARENT)
         canvas.save()
         canvas.translate(-bounds.left(), -bounds.top())
-        for (item, ancestor_effects) in self.display_items:
+        for item in self.display_items:
             item.execute(canvas)
         canvas.restore()
 
@@ -1165,7 +1165,7 @@ class CompositedLayer:
         return ("layer: composited_bounds={} " +
             "absolute_bounds={} first_chunk={}").format(
             self.composited_bounds(), self.absolute_bounds(),
-            self.display_items[0] if len(self.display_items) > 0 else 'None')
+            self.display_items if len(self.display_items) > 0 else 'None')
 
 def raster(display_list, canvas):
     for cmd in display_list:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1089,7 +1089,7 @@ class CompositedLayer:
         else:
             return True
 
-    def add_paint_chunk(self, display_item):
+    def add(self, display_item):
         assert self.can_merge(display_item)
         self.parent_effect = display_item.parent
         self.display_items.append(display_item)
@@ -1703,18 +1703,18 @@ class Browser:
         for display_item in paint_commands:
             for layer in reversed(self.composited_layers):
                 if layer.can_merge(display_item):
-                    layer.add_paint_chunk(display_item)
+                    layer.add(display_item)
                     break
                 elif skia.Rect.Intersects(
                     layer.absolute_bounds(),
                     absolute_bounds(display_item)):
                     layer = CompositedLayer(self.skia_context)
-                    layer.add_paint_chunk(display_item)
+                    layer.add(display_item)
                     self.composited_layers.append(layer)
                     break
             else:
                 layer = CompositedLayer(self.skia_context)
-                layer.add_paint_chunk(display_item, ancestor_effects)
+                layer.add(display_item, ancestor_effects)
                 self.composited_layers.append(layer)
 
         self.active_tab_height = 0

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1698,10 +1698,10 @@ class Browser:
         self.draw_list = []
         for composited_layer in self.composited_layers:
             current_effect = DrawCompositedLayer(composited_layer)
-            for visual_effect in \
-                reversed(composited_layer.ancestor_effects):
-                current_effect = self.clone_latest(
-                    visual_effect, [current_effect])
+            parent = composited_layer.parent
+            while parent:
+                current_effect = self.clone_latest(parent, [current_effect])
+                parent = parent.parent
             self.draw_list.append(current_effect)
 
     def composite_raster_and_draw(self):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1539,14 +1539,6 @@ def add_parent_pointers(nodes, parent=None):
         node.parent = parent
         add_parent_pointers(node.children, node)
 
-def ancestor_effects_list(node):
-    parent = node.parent
-    effects = []
-    while parent:
-        effects = [parent] + effects
-        parent = parent.parent
-    return effects
-
 USE_GPU = True
 
 class Browser:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1081,32 +1081,18 @@ class CompositedLayer:
         self.skia_context = skia_context
         self.surface = None
         self.display_items = []
-        self.ancestor_effects = []
+        self.parent_effect = None
 
     def can_merge(self, display_item):
-        ancestor_effects = ancestor_effects_list(display_item)
-        if len(self.display_items) == 0:
+        if self.display_items:
+            return display_item.parent = self.display_item[0].parent
+        else:
             return True
-        if len(self.ancestor_effects) != len(ancestor_effects):
-            return False
-        if len(self.ancestor_effects) == 0:
-            return True
-        return self.ancestor_effects[-1] == ancestor_effects[
-            composited_ancestor_index(ancestor_effects)]
 
     def add_paint_chunk(self, display_item):
         assert self.can_merge(display_item)
-        ancestor_effects = ancestor_effects_list(display_item)
-        composited_index = composited_ancestor_index(ancestor_effects)
-        if len(self.display_items) == 0 and composited_index >= 0:
-            self.ancestor_effects = ancestor_effects[0:composited_index + 1]
-
-        if composited_index < len(ancestor_effects) - 1:
-            self.display_items.append(
-                ancestor_effects[composited_index + 1],
-            )
-        else:
-            self.display_items.append(display_item)
+        self.parent_effect = display_item.parent
+        self.display_items.append(display_item)
 
     def composited_bounds(self):
         retval = skia.Rect.MakeEmpty()

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -112,7 +112,7 @@ class DisplayItem:
                 cmd.composited_bounds_internal(rect)
 
     def needs_compositing(self):
-        return False
+        return any([child.needs_compositing() for child in children])
 
     def clone(self, children):
         assert False
@@ -133,7 +133,8 @@ class Transform(DisplayItem):
             canvas.restore()
 
     def needs_compositing(self):
-        return USE_COMPOSITING and self.translation
+        return USE_COMPOSITING and self.translation or \
+            any([child.needs_compositing() for child in children])
 
     def map(self, rect):
         if not self.translation:
@@ -261,9 +262,6 @@ class ClipRRect(DisplayItem):
         if self.should_clip:
             canvas.restore()
 
-    def needs_compositing(self):
-        return False
-
     def clone(self, children):
         return ClipRRect(self.rect, self.radius, children, \
             self.should_clip)
@@ -289,7 +287,8 @@ class SaveLayer(DisplayItem):
             canvas.restore()
 
     def needs_compositing(self):
-        return USE_COMPOSITING and self.should_save
+        return USE_COMPOSITING and self.should_save or \
+            any([child.needs_compositing() for child in children])
 
     def clone(self, children):
         return SaveLayer(self.sk_paint, self.node, children, \

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1064,6 +1064,11 @@ def composited_ancestor_index(ancestor_effects):
         count -= 1
     return -1
 
+def composited_ancestor(node):
+    while node and not node.needs_compositing():
+        node = node.parent
+    return node
+
 def absolute_bounds(display_item):
     retval = display_item.composited_bounds()
     effect = display_item.parent
@@ -1708,7 +1713,7 @@ class Browser:
         add_parent_pointers(self.active_tab_display_list)
         paint_commands = [cmd
             for cmd in tree_to_list(self.active_tab_display_list, [])
-            if cmd.is_paint_command()
+            if not cmd.needs_compositing()
         ]
         for display_item in paint_commands:
             for layer in reversed(self.composited_layers):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1511,17 +1511,6 @@ class TaskRunner:
 
 REFRESH_RATE_SEC = 0.016 # 16ms
 
-def print_chunks(chunks):
-    for (display_item, ancestor_effects) in chunks:
-        print('chunks:')
-        print("  chunk display items:")
-        print(" " * 4 + str(display_item))
-        print("  chunk ancestor visual effect (skipping no-ops):")
-        count = 4
-        for display_item in ancestor_effects:
-            print(" " * count + str(display_item))
-            count += 2
-
 def print_composited_layers(composited_layers):
     print("Composited layers:")
     for layer in composited_layers:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1092,13 +1092,6 @@ class CompositedLayer:
             retval.join(absolute_bounds(item))
         return retval
 
-    def composited_items(self):
-        items = []
-        for item in self.ancestor_effects:
-            if item.needs_compositing():
-                items.append(item)
-        return items
-
     def raster(self):
         bounds = self.composited_bounds()
         if bounds.isEmpty():
@@ -1682,7 +1675,7 @@ class Browser:
                     break
             else:
                 layer = CompositedLayer(self.skia_context)
-                layer.add(display_item, ancestor_effects)
+                layer.add(display_item)
                 self.composited_layers.append(layer)
 
         self.active_tab_height = 0

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1070,7 +1070,7 @@ class CompositedLayer:
 
     def can_merge(self, display_item):
         if self.display_items:
-            return display_item.parent == self.display_item[0].parent
+            return display_item.parent == self.display_items[0].parent
         else:
             return True
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1054,20 +1054,6 @@ def style(node, rules):
 
 SHOW_COMPOSITED_LAYER_BORDERS = False
 
-def composited_ancestor_index(ancestor_effects):
-    count = len(ancestor_effects) - 1
-    for ancestor_item in reversed(ancestor_effects):
-        if ancestor_item.needs_compositing():
-            return count
-            break
-        count -= 1
-    return -1
-
-def composited_ancestor(node):
-    while node and not node.needs_compositing():
-        node = node.parent
-    return node
-
 def absolute_bounds(display_item):
     retval = display_item.composited_bounds()
     effect = display_item.parent
@@ -1547,16 +1533,6 @@ def print_composited_layers(composited_layers):
     print("Composited layers:")
     for layer in composited_layers:
         print("  " * 4 + str(layer))
-
-def display_list_to_paint_chunks(
-    display_list, ancestor_effects, chunks):
-    for display_item in display_list:
-        if display_item.is_paint_command():
-            chunks.append((display_item, ancestor_effects))
-        else:
-            display_list_to_paint_chunks(
-                display_item.children,
-                ancestor_effects + [display_item], chunks)
 
 def add_parent_pointers(nodes, parent=None):
     for node in nodes:


### PR DESCRIPTION
This PR should only be merged after #495. After #495, which makes makes all non-composited effects have non-composited children, `CompositedLayer` can be massively simplified, since we can consider non-composited subtrees as a whole and two subtrees are allowed in the same layer if they just have the same parent.

This PR also renames `add_paint_chunk` to `add` (since paint chunks aren't a thing any more) and removes a bunch of unused methods.