### PR TITLE
Fix bug in parsing transforms

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1740,8 +1740,8 @@ class Browser:
         # ...
         non_composited_commands = [cmd
             for cmd in all_commands
-            if not cmd.needs_compositing() and cmd.parent and \
-                cmd.parent.needs_compositing()
+            if not cmd.needs_compositing() and (not cmd.parent or \
+                cmd.parent.needs_compositing())
         ]
         # ...
 ```
@@ -2253,7 +2253,7 @@ standardized transform syntax.
 ``` {.python}
 def parse_transform(transform_str):
     if transform_str.find('translate') < 0:
-        return (0, 0)
+        return None
     left_paren = transform_str.find('(')
     right_paren = transform_str.find(')')
     (x_px, y_px) = \

--- a/src/lab13-tests.md
+++ b/src/lab13-tests.md
@@ -33,14 +33,7 @@ The draw display list should be generated as well:
 
     >>> for item in browser.draw_list:
     ...     lab13.print_tree(item)
-     Transform(translate(0, 0))
-       SaveLayer(<no-op>)
-         ClipRRect(<no-op>)
-           Transform(translate(0, 0))
-             SaveLayer(<no-op>)
-               ClipRRect(<no-op>)
-                 Transform(translate(0, 0))
-                   DrawCompositedLayer()
+     DrawCompositedLayer()
 
     >>> tab = browser.tabs[browser.active_tab]
     >>> body = tab.nodes.children[0]
@@ -92,29 +85,27 @@ Testing CSS transtions
 
     >>> for item in browser.draw_list:
     ...     lab13.print_tree(item)
-     Transform(translate(0, 0))
+     DrawCompositedLayer()
+     Transform(<no-op>)
        SaveLayer(<no-op>)
          ClipRRect(<no-op>)
-           Transform(translate(0, 0))
-             DrawCompositedLayer()
-     Transform(translate(0, 0))
+           DrawCompositedLayer()
+     Transform(<no-op>)
        SaveLayer(<no-op>)
          ClipRRect(<no-op>)
-           Transform(translate(0, 0))
+           Transform(<no-op>)
              SaveLayer(<no-op>)
                ClipRRect(<no-op>)
-                 Transform(translate(0, 0))
+                 Transform(<no-op>)
                    SaveLayer(alpha=0.5)
                      DrawCompositedLayer()
-     Transform(translate(0, 0))
+     Transform(<no-op>)
        SaveLayer(<no-op>)
          ClipRRect(<no-op>)
-           Transform(translate(0, 0))
+           Transform(<no-op>)
              SaveLayer(<no-op>)
                ClipRRect(<no-op>)
-                 Transform(translate(0, 0))
-                   DrawCompositedLayer()
-
+                 DrawCompositedLayer()
     >>> tab = browser.tabs[browser.active_tab]
     >>> div = tab.nodes.children[1].children[0]
 
@@ -180,7 +171,6 @@ The `parse_transform` function parses the value of the `transform` CSS property.
 Unsupported values are ignored.
 
     >>> lab13.parse_transform("rotate(45deg)")
-    (0, 0)
 
 Animations work:
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -315,7 +315,7 @@ class DrawCompositedLayer(DisplayItem):
 
 def parse_transform(transform_str):
     if transform_str.find('translate') < 0:
-        return (0, 0)
+        return None
     left_paren = transform_str.find('(')
     right_paren = transform_str.find(')')
     (x_px, y_px) = \
@@ -1662,8 +1662,8 @@ class Browser:
                 tree_to_list(cmd, all_commands)
         non_composited_commands = [cmd
             for cmd in all_commands
-            if not cmd.needs_compositing() and cmd.parent and \
-                cmd.parent.needs_compositing()
+            if not cmd.needs_compositing() and (not cmd.parent or \
+                cmd.parent.needs_compositing())
         ]
         for display_item in non_composited_commands:
             for layer in reversed(self.composited_layers):


### PR DESCRIPTION
Previously, we always returned a (0,0) translation rather than a no-op.
Fixing this revelaed a bug in `composite` where it had the wrong definition of a non-composited subtree.
There is also finally unittesting for some of this.