### PR TITLE
Merged and tightened the first few sections

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -23,7 +23,7 @@ Browsers also use animations in response to user actions like
 scrolling, resizing, and pinch-zoom. And some types of animated media,
 like videos, can also be included in web pages.[^video-anim] In this
 chapter we'll focus mostly on web page animations, though we'll touch
-on scrolling at the end.[^excuse]
+on scrolling at the end.
 
 [^general-movement]: Here *movement* should be construed broadly to
 encompass all of the kinds of visual changes humans are used to seeing

--- a/book/animations.md
+++ b/book/animations.md
@@ -30,8 +30,8 @@ encompass all of the kinds of visual changes humans are used to seeing
 and good at recognizing---not just movement from side to side, but
 growing, shrinking, rotating, fading, blurring, and sharpening. The
 point is that an animation is not an *arbitrary* sequence of pictures;
-the sequence must feel, to a human mind trained by experience in the
-real world, to be a continuous motion.
+the sequence must feel continuous to a human mind trained by experience in the
+real world.
 
 [animation]: https://en.wikipedia.org/wiki/Animation
 
@@ -45,7 +45,7 @@ topic is beyond the scope of this book, but it has its own
 Let's write a simple animation using the `requestAnimationFrame` API
 [implemented in Chapter 12](scheduling.md#animating-frames). This
 animation lets us request that some JavaScript code run on the next
-*frame*, and we can have that code change the page slightly.
+frame, and we can have that code change the page slightly.
 To do this repeatedly, we'll need code like this:
 
 ``` {.javascript file=example-opacity-js}
@@ -104,7 +104,7 @@ animation from the beginning.
 
 This animation will almost run in our browser, except that our browser
 doesn't yet support JavaScript changing an element's `style`
-attribute. Let's go ahead and add that feature. We'll need to register
+attribute. Let's go ahead and add that feature. Register
 a setter on the `style` attribute of `Node` in the JavaScript runtime:
 
 ``` {.javascript file=runtime}
@@ -115,7 +115,7 @@ Object.defineProperty(Node.prototype, 'style', {
 });
 ```
 
-Then, inside the browser, we'll need to define a handler for `style_set`:
+Then, inside the browser, define a handler for `style_set`:
 
 ``` {.python}
 class JSContext:

--- a/book/animations.md
+++ b/book/animations.md
@@ -8,7 +8,7 @@ next: skipped
 Complex web application use *animations* when transitioning between
 DOM states. These transitions improve usability by helping users
 understand what changes are occuring. They also improve visual polish
-by replacing sudden jumps with gradual change. But to execute these
+by replacing sudden jumps with gradual changes. But to execute these
 animations smoothly, the browser must make use of the computer's GPU
 and minimize work using compositing.
 
@@ -20,7 +20,7 @@ succession that create an illusion of *movement* to the human
 eye.[^general-movement] Web pages typically animate effects like
 changing color, fading an element in or out, or resizing an element.
 Browsers also use animations in response to user actions like
-scrolling, resizing, and pinch-zoom. And some types of animated edia,
+scrolling, resizing, and pinch-zoom. And some types of animated media,
 like videos, can also be included in web pages.[^video-anim] In this
 chapter we'll focus mostly on web page animations, though we'll touch
 on scrolling at the end.[^excuse]
@@ -44,8 +44,8 @@ topic is beyond the scope of this book, but it has its own
 
 Let's write a simple animation using the `requestAnimationFrame` API
 [implemented in Chapter 12](scheduling.md#animating-frames). This
-animation lets us request that some JavaScript run on the next
-*frame*, and we can have that JavaScript change the page slightly.
+animation lets us request that some JavaScript code run on the next
+*frame*, and we can have that code change the page slightly.
 To do this repeatedly, we'll need code like this:
 
 ``` {.javascript file=example-opacity-js}

--- a/book/animations.md
+++ b/book/animations.md
@@ -78,7 +78,7 @@ from 1.0 is imperceptible.
 For example, let's animate this `div` containing the word "Test":
 
 ``` {.html file=example-opacity-html}
-<div>Test</div>
+<div>This text fades out</div>
 ```
 
 The `animate` function will track how many frames have occurred and 
@@ -90,10 +90,8 @@ var current_frame = 0;
 var change_per_frame = 0.999 / total_frames;
 function animate() {
     current_frame++;
-    var new_opacity = current_frame * change_per_frame
-    div.style = "opacity:" +
-        (percent_remaining * 0.999 +
-            (1 - percent_remaining) * 0.1);
+    var new_opacity = current_frame * change_per_frame;
+    div.style = "opacity:" + new_opacity;
     return current_frame < total_frames;
 }
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -86,7 +86,7 @@ The `animate` function will track how many frames have occurred and
 var div = document.querySelectorAll("div")[0];
 var total_frames = 120;
 var current_frame = 0;
-var change_per_frame = 0.899 / total_frames;
+var change_per_frame = (0.999 - 0.1) / total_frames;
 function animate() {
     current_frame++;
     var new_opacity = current_frame * change_per_frame + 0.1;

--- a/book/animations.md
+++ b/book/animations.md
@@ -98,16 +98,16 @@ function animate() {
 }
 ```
 
-Here's how it looks:
+Here's how it looks; you'll probably need to refresh the page or [open
+it full-screen](examples/example13-opacity-raf.html) to watch the
+animation from the beginning.
 
 <iframe src="examples/example13-opacity-raf.html"></iframe>
-(click [here](examples/example13-opacity-raf.html) to load the example in
-your browser)
 
-This code will almost run in our browser, except that we haven't yet
-added support changing an element's `style` attribute from JavaScript.
-Let's go ahead and add that feature. We'll need to register a setter on
-the `style` attribute of `Node` in the JavaScript runtime:
+This animation will almost run in our browser, except that our browser
+doesn't yet support JavaScript changing an element's `style`
+attribute. Let's go ahead and add that feature. We'll need to register
+a setter on the `style` attribute of `Node` in the JavaScript runtime:
 
 ``` {.javascript file=runtime}
 Object.defineProperty(Node.prototype, 'style', {

--- a/book/animations.md
+++ b/book/animations.md
@@ -48,7 +48,7 @@ animation lets us request that some JavaScript code run on the next
 frame, and we can have that code change the page slightly.
 To do this repeatedly, we'll need code like this:
 
-``` {.javascript file=example-opacity-js}
+``` {.javascript file=example-opacity-js replace=animate/fade_out,animation_frame/fade_out}
 function run_animation_frame() {
     if (animate())
         requestAnimationFrame(run_animation_frame);
@@ -62,18 +62,17 @@ animating, and then stops. By changing what `animate` does we can
 change what animation occurs.
 
 Let's write a fade animation. We can fade in something out by smoothly
-transitioning its `opacity` value from 0.0 to 0.999.[^why-not-one] If we
+transitioning its `opacity` value from 0.1 to 0.999.[^why-not-one] If we
 want to do this animation over 120 frames (about two seconds), that
 means we need to increase the opacity by about 0.008 on each frame.
 
 [^why-not-one]: Real browsers apply certain optimizations when opacity
-is exactly 1, so real-world websites often start animations at 0.999.
-That way, the animation is smooth. So it's easier to dig into the
-performance of this example on a real browser with 0.999 opacity.
-Starting animations at 0.999 is also a common trick used on web sites
-that want to avoid visual popping of the content as it goes in and out
-of GPU-accelerated mode. I chose 0.999 because the visual difference
-from 1.0 is imperceptible.
+is exactly 1, so real-world websites often start and end animations at
+0.999 so that each frame is drawn the same way and the animation is
+smooth. Starting animations at 0.999 is also a common trick used on
+web sites that want to avoid visual popping of the content as it goes
+in and out of GPU-accelerated mode. I chose 0.999 because the visual
+difference from 1.0 is imperceptible.
 
 For example, let's animate this `div` containing the word "Test":
 
@@ -83,22 +82,21 @@ For example, let's animate this `div` containing the word "Test":
 
 The `animate` function will track how many frames have occurred and 
 
-``` {.javascript file=example-opacity-js}
+``` {.javascript file=example-opacity-js replace=animate/fade_in}
 var div = document.querySelectorAll("div")[0];
 var total_frames = 120;
 var current_frame = 0;
-var change_per_frame = 0.999 / total_frames;
+var change_per_frame = 0.899 / total_frames;
 function animate() {
     current_frame++;
-    var new_opacity = current_frame * change_per_frame;
+    var new_opacity = current_frame * change_per_frame + 0.1;
     div.style = "opacity:" + new_opacity;
     return current_frame < total_frames;
 }
 ```
 
-Here's how it looks; you'll probably need to refresh the page or [open
-it full-screen](examples/example13-opacity-raf.html) to watch the
-animation from the beginning.
+You could, of course, fade the text out by making `change_per_frame`
+negative. Here's how it looks; click the buttons to start a fade:
 
 <iframe src="examples/example13-opacity-raf.html"></iframe>
 

--- a/src/example13-opacity-raf.html
+++ b/src/example13-opacity-raf.html
@@ -1,4 +1,4 @@
-<button onclick="start_fade_in()">Fade in</button>
-<button onclick="start_fade_out()">Fade out</button>
+<button>Fade out</button>
+<button>Fade in</button>
 <div>This text fades</div>
 <script src="example13-opacity-raf.js"></script>

--- a/src/example13-opacity-raf.html
+++ b/src/example13-opacity-raf.html
@@ -1,2 +1,4 @@
-<div>This text fades out</div>
+<button onclick="start_fade_in()">Fade in</button>
+<button onclick="start_fade_out()">Fade out</button>
+<div>This text fades</div>
 <script src="example13-opacity-raf.js"></script>

--- a/src/example13-opacity-raf.html
+++ b/src/example13-opacity-raf.html
@@ -1,2 +1,2 @@
-<div>Test</div>
+<div>This text fades out</div>
 <script src="example13-opacity-raf.js"></script>

--- a/src/example13-opacity-raf.js
+++ b/src/example13-opacity-raf.js
@@ -1,17 +1,12 @@
-var frames_remaining = 120;
-var go_down = true;
 var div = document.querySelectorAll("div")[0];
+var total_frames = 120;
+var current_frame = 0;
+var change_per_frame = 0.999 / total_frames;
 function animate() {
-    var percent_remaining = frames_remaining / 120;
-    if (!go_down) percent_remaining = 1 - percent_remaining;
-    div.style = "opacity:" +
-        (percent_remaining * 0.999 +
-            (1 - percent_remaining) * 0.1);
-    if (frames_remaining-- == 0) {
-        go_down = !go_down
-        frames_remaining = 120;
-    }
-    return true;
+    current_frame++;
+    var new_opacity = current_frame * change_per_frame;
+    div.style = "opacity:" + new_opacity;
+    return current_frame < total_frames;
 }
 
 function run_animation_frame() {

--- a/src/example13-opacity-raf.js
+++ b/src/example13-opacity-raf.js
@@ -1,16 +1,38 @@
 var div = document.querySelectorAll("div")[0];
 var total_frames = 120;
 var current_frame = 0;
-var change_per_frame = 0.999 / total_frames;
-function animate() {
+var change_per_frame = 0.899 / total_frames;
+
+function fade_in() {
     current_frame++;
-    var new_opacity = current_frame * change_per_frame;
+    var new_opacity = current_frame * change_per_frame + 0.1;
     div.style = "opacity:" + new_opacity;
     return current_frame < total_frames;
 }
 
-function run_animation_frame() {
-    if (animate())
-        requestAnimationFrame(run_animation_frame);
+function run_fade_in() {
+    if (fade_in())
+        requestAnimationFrame(run_fade_in);
 }
-requestAnimationFrame(run_animation_frame);
+
+function start_fade_in() {
+    current_frame = 0;
+    requestAnimationFrame(run_fade_in);
+}
+
+function fade_out() {
+    current_frame++;
+    var new_opacity = 0.999 - current_frame * change_per_frame;
+    div.style = "opacity:" + new_opacity;
+    return current_frame < total_frames;
+}
+
+function run_fade_out() {
+    if (fade_out())
+        requestAnimationFrame(run_fade_out);
+}
+
+function start_fade_out() {
+    current_frame = 0;
+    requestAnimationFrame(run_fade_out);
+}

--- a/src/example13-opacity-raf.js
+++ b/src/example13-opacity-raf.js
@@ -36,3 +36,6 @@ function start_fade_out() {
     current_frame = 0;
     requestAnimationFrame(run_fade_out);
 }
+
+document.querySelectorAll("button")[0].addEventListener("click", start_fade_out);
+document.querySelectorAll("button")[1].addEventListener("click", start_fade_in);

--- a/src/example13-opacity-raf.js
+++ b/src/example13-opacity-raf.js
@@ -1,7 +1,7 @@
 var div = document.querySelectorAll("div")[0];
 var total_frames = 120;
 var current_frame = 0;
-var change_per_frame = 0.899 / total_frames;
+var change_per_frame = (0.999 - 0.1) / total_frames;
 
 function fade_in() {
     current_frame++;

--- a/src/example13-opacity-raf.js
+++ b/src/example13-opacity-raf.js
@@ -15,9 +15,10 @@ function run_fade_in() {
         requestAnimationFrame(run_fade_in);
 }
 
-function start_fade_in() {
+function start_fade_in(e) {
     current_frame = 0;
     requestAnimationFrame(run_fade_in);
+    e.preventDefault();
 }
 
 function fade_out() {
@@ -32,9 +33,10 @@ function run_fade_out() {
         requestAnimationFrame(run_fade_out);
 }
 
-function start_fade_out() {
+function start_fade_out(e) {
     current_frame = 0;
     requestAnimationFrame(run_fade_out);
+    e.preventDefault();
 }
 
 document.querySelectorAll("button")[0].addEventListener("click", start_fade_out);


### PR DESCRIPTION
This PR merged the sections on "Types of animations", "The animation loop", and "Opacity animations" and tightened up the text so that it is shorter. Parts of those sections were forward reference regarding layout transformations, and those parts were moved forward.

I also simplified the opacity animation to just do a single fade. This does mean the reader will have to refresh the page to see it happen, but it makes the animation code shorter and more similar to the kinds of animations the reader will see later in the chapter. I'm willing to undo this if you don't agree.