### PR TITLE
Rename section; fix up go further block

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -590,12 +590,12 @@ bounds would contribute to the surface size.
 
 :::
 
-Compositing paint commands
-==========================
+Compositing leaves
+==================
 
-Let's start implementing compositing. To do that we'll need to
-traverse the display list, identify all paint commands, and move them
-to composited layers. Then we'll need to create the draw display list
+Let's start implementing compositing. To do that we'll need to traverse the
+display list, identify all paint commands (the leaves of the display list), and
+move them to composited layers. Then we'll need to create the draw display list
 that combines the composited layers.
 
 Let's start by identifying paint commands with an `is_paint_command`
@@ -774,8 +774,8 @@ there is more than one tree, due to the complex
 
 :::
 
-Composited raster and draw
-==========================
+Composited raster/draw
+======================
 
 Now that we've split the display list into composited layers and a
 draw display list, we need to update the rest of the browser to use

--- a/src/example13-nested-opacity.html
+++ b/src/example13-nested-opacity.html
@@ -1,8 +1,6 @@
 <div style="opacity:0.999">
-  <p>
-    Hello, World!
-  </p>
+  Text
   <div style="opacity:0.5">
-    <p>More text</p>
+    Nested
   </div>
 </div>


### PR DESCRIPTION
* "splitting the display list" is now called "compositing leaves"
* Shortened "Composited raster and draw" to "composited raster/draw" to avoid line breaking
* Reworked the render surfaces go-further block to add back the nested opacity example, and also link to it from the exercise