### PR TITLE
Megapass on Chapter 13

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1777,7 +1777,7 @@ Basically, when considering which composited layer a display item goes
 in, also check if it overlaps with an existing composited layer. If
 so, start a new `CompositedLayer` for this display item:
 
-``` {.python}
+``` {.python replace=layer.composited_bounds/layer.absolute_bounds,cmd.rect/absolute_bounds(cmd)}
 class Browser:
     def composite(self):
         # ...
@@ -1787,7 +1787,7 @@ class Browser:
                     # ...
                 elif skia.Rect.Intersects(
                     layer.composited_bounds(),
-                    cmd.composited_bounds()):
+                    cmd.rect):
                     layer = CompositedLayer(self.skia_context, cmd)
                     self.composited_layers.append(layer)
                     break
@@ -2001,12 +2001,7 @@ left solving this to an exercise.
 While we're here, let's also make transforms animatable via a new
 `TranslateAnimation` class:
 
-``` {.python replace=True)/USE_COMPOSITING)}
-ANIMATED_PROPERTIES = {
-    # ...
-    "transform": TranslateAnimation,
-}
-
+``` {.python}
 class TranslateAnimation:
     def __init__(self, old_value, new_value, num_frames):
         (self.old_x, self.old_y) = parse_transform(old_value)
@@ -2027,6 +2022,11 @@ class TranslateAnimation:
         new_y = self.old_y + \
             self.change_per_frame_y * self.frame_count
         return "translate({}px,{}px)".format(new_x, new_y)
+
+ANIMATED_PROPERTIES = {
+    # ...
+    "transform": TranslateAnimation,
+}
 ```
 
 You should now be able to create this animation:^[In this

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -997,12 +997,11 @@ class TranslateAnimation:
             self.change_per_frame_y * self.frame_count
         return "translate({}px,{}px)".format(new_x, new_y)
 
-    
 ANIMATED_PROPERTIES = {
     "opacity": NumericAnimation,
     "transform": TranslateAnimation,
 }
-
+    
 def style(node, rules, tab):
     old_style = node.style
 
@@ -1026,15 +1025,15 @@ def style(node, rules, tab):
 
     if old_style:
         transitions = diff_styles(old_style, node.style)
-        for property, (old_value, new_value, num_frames) in \
-            transitions.items():
+        for property, (old_value, new_value, num_frames) \
+            in transitions.items():
             if property in ANIMATED_PROPERTIES:
                 tab.set_needs_render()
                 AnimationClass = ANIMATED_PROPERTIES[property]
                 animation = AnimationClass(
                     old_value, new_value, num_frames)
                 node.animations[property] = animation
-                node.style[property] = old_value
+                node.style[property] = animation.animate()
 
     for child in node.children:
         style(child, rules, tab)
@@ -1079,8 +1078,7 @@ class CompositedLayer:
 
     def raster(self):
         bounds = self.composited_bounds()
-        if bounds.isEmpty():
-            return
+        if bounds.isEmpty(): return
         irect = bounds.roundOut()
 
         if not self.surface:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -109,9 +109,6 @@ class DisplayItem:
         return any([child.needs_compositing() \
             for child in self.children])
 
-    def clone(self, children):
-        assert False
-
 class Transform(DisplayItem):
     def __init__(self, translation, rect, node, children):
         super().__init__(rect, children=children, node=node)
@@ -311,10 +308,7 @@ class DrawCompositedLayer(DisplayItem):
         layer = self.composited_layer
         if not layer.surface: return
         bounds = layer.composited_bounds()
-        surface_offset_x = bounds.left()
-        surface_offset_y = bounds.top()
-        layer.surface.draw(
-            canvas, surface_offset_x, surface_offset_y)
+        layer.surface.draw(canvas, bounds.left(), bounds.top())
 
     def __repr__(self):
         return "DrawCompositedLayer()"
@@ -961,7 +955,7 @@ class NumericAnimation:
         if self.frame_count >= self.num_frames: return
         current_value = self.old_value + \
             self.change_per_frame * self.frame_count
-        return "{}".format(current_value)
+        return str(current_value)
 
     def __repr__(self):
         return ("NumericAnimation(" + \
@@ -1057,17 +1051,15 @@ def absolute_bounds(display_item):
     return rect
 
 class CompositedLayer:
-    def __init__(self, skia_context):
+    def __init__(self, skia_context, display_item):
         self.skia_context = skia_context
         self.surface = None
-        self.display_items = []
+        self.display_items = [display_item]
+        self.parent = display_item.parent
 
     def can_merge(self, display_item):
-        if self.display_items:
-            return display_item.parent == \
-                self.display_items[0].parent
-        else:
-            return True
+        return display_item.parent == \
+            self.display_items[0].parent
 
     def add(self, display_item):
         assert self.can_merge(display_item)
@@ -1624,21 +1616,19 @@ class Browser:
                 (not cmd.parent or \
                  cmd.parent.needs_compositing())
         ]
-        for display_item in non_composited_commands:
+        for cmd in non_composited_commands:
             for layer in reversed(self.composited_layers):
-                if layer.can_merge(display_item):
-                    layer.add(display_item)
+                if layer.can_merge(cmd):
+                    layer.add(cmd)
                     break
                 elif skia.Rect.Intersects(
                     layer.absolute_bounds(),
-                    absolute_bounds(display_item)):
-                    layer = CompositedLayer(self.skia_context)
-                    layer.add(display_item)
+                    absolute_bounds(cmd)):
+                    layer = CompositedLayer(self.skia_context, cmd)
                     self.composited_layers.append(layer)
                     break
             else:
-                layer = CompositedLayer(self.skia_context)
-                layer.add(display_item)
+                layer = CompositedLayer(self.skia_context, cmd)
                 self.composited_layers.append(layer)
 
         self.active_tab_height = 0


### PR DESCRIPTION
Hi Chris, sorry that this PR is late (I'm still getting the hang of fatherhood). This is mostly a language pass over Chapter 13. Once something like this is merged I'm ready to release chapter 13. Here are the major changes:

- Fix an issue wherein we used parent pointers earlier in the chapter than we introduced them
- Change the `CompositedLayer` API so that a composited layer always has at least one element (simplifies the code)
- Add extra text clarifying why we need identities on display items
- Update the overlap testing text to no longer refer to paint chunks

Also, a quick question:

- Do we need to make `transform` animatable? I reorganized that section a bit and realized that all of the animation code is now in one chunk at the end. I guess if it's not animatable, the reader might ask why we don't just set its `needs_compositing` to `False` (that wouldn't work, since the transform might contain a composited effect, but the reader might miss that) but we could clarify that. And implementing animated transforms sounds like a great exercise.