### PR TITLE
Scaffolding for the accessibility tree

### DIFF
--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -95,3 +95,19 @@ And now it's for the `a`:
      DrawText(text=)
      DrawText(text=Link)
      DrawRect(top=21.62109375 left=217.0 bottom=39.49609375 right=247.0 border_color=black width=2 fill_color=None)
+
+Accessibility
+=============
+
+The accessibility tree is automatically created
+
+    >>> focus_url = 'http://test.test/focus'
+    >>> test.socket.respond(focus_url, b"HTTP/1.0 200 OK\r\n" +
+    ... b"content-type: text/html\r\n\r\n" +
+    ... b'<input><a href="/dest">Link</a>')
+
+    >>> browser = lab14.Browser()
+    >>> browser.load(focus_url)
+    >>> browser.render()
+    >>> lab14.print_tree(browser.tabs[0].accessibility_tree)
+     AccessibilityNode(layout_object=DocumentLayout()

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -99,7 +99,7 @@ And now it's for the `a`:
 Accessibility
 =============
 
-The accessibility tree is automatically created
+The accessibility tree is automatically created.
 
     >>> focus_url = 'http://test.test/focus'
     >>> test.socket.respond(focus_url, b"HTTP/1.0 200 OK\r\n" +

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -505,9 +505,16 @@ class InputLayout:
 class AccessibilityNode:
     def __init__(self, layout_object):
         self.layout_object = layout_object
+        self.parent = None
+        self.previous = None
+        self.children = []
 
     def build(self):
         pass
+
+    def __repr__(self):
+        return "AccessibilityNode(layout_object={}".format(
+            str(self.layout_object))
 
 class Tab:
     def __init__(self, browser):


### PR DESCRIPTION
Adds basic scaffolding. Only one node exists right now (the document).

Also renames `document` to `layout_tree` to distinguish the two.