### PR TITLE
Fix bug where InputLayout objects failed to paint or layout correctly

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -167,7 +167,7 @@ class InlineLayout:
             self.text(node, zoom)
         else:
         	# ...
-            elif node.tag == "input" or node.tag == "button":
+            elif is_input(node):
                 self.input(node, zoom)
             else:
                 for child in node.children:
@@ -409,7 +409,7 @@ This will first require a definition of which elements are focusable:
 
 ``` {.python}
     def is_focusable(node):
-        return node.tag == "input" or node.tag == "button" \
+        return is_input(node) \
         	or node.tag == "a"
 ```
 

--- a/book/forms.md
+++ b/book/forms.md
@@ -214,7 +214,7 @@ class InlineLayout:
 
 But actually, there are a couple more complications due to the way we decided
 to resolve the block-mixed-with-inline-siblings problem
-(see [Chapter 4](html.md#layout-modes). One is that if there are no children
+(see [Chapter 5](layout.md#layout-modes)). One is that if there are no children
 for a node, we assume it's a block element. But `<input>` elements don't
 have children. We can fix that with this change to `layout_mode`:
 
@@ -254,7 +254,7 @@ class InlineLayout:
 ```
 
 [^hack-inline]: This is a bit of a hack, but it's indicative of the surprising
-difficulty and complexity of all of the ways the different layout modes can mix
+difficulty and complexity in all of the ways the different layout modes can mix
 in real browsers.
 
 With these changes the browser should now draw `input` and `button`

--- a/book/forms.md
+++ b/book/forms.md
@@ -234,16 +234,22 @@ def layout_mode(node):
         return "block"
 ```
 
-The second problem is that, again due to having block siblins, sometimes an
+The second problem is that, again due to having block siblings, sometimes an
 `InputLayout` will end up wrapped in a `InlineLayout` that refers to to the
-`<input` node. But both `InlineLayout` and `InputLayout` have a `paint` method,
-which emans we're painting the `<input>` twice. We can fix that with some simple
+`<input>` node. But both `InlineLayout` and `InputLayout` have a `paint` method,
+which means we're painting the `<input>` twice. We can fix that with some simple
 logic to skip painting in `InlineLayout` in this case:[^hack-inline]
 
 ``` {.python}
 class InlineLayout:
     # ...
     def paint(self, display_list):
+        # ...
+        if not is_input(self.node):
+            if bgcolor != "transparent":
+                x2, y2 = self.x + self.width, self.y + self.height
+                rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
+                display_list.append(rect)
 
 ```
 

--- a/book/forms.md
+++ b/book/forms.md
@@ -253,9 +253,9 @@ class InlineLayout:
 
 ```
 
-[^hack-inline]: This is a bit of a hack, but it's indicative of the surprising
-difficulty and complexity in all of the ways the different layout modes can mix
-in real browsers.
+[^hack-inline]: This is a bit of a hack, but it's indicative of the
+difficulty and complexity in all the ways layout modes can mix in real
+browsers.
 
 With these changes the browser should now draw `input` and `button`
 elements as blue and orange rectangles.

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -463,7 +463,8 @@ class Tab:
         # ...
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+               if obj.node == self.focus and \
+                    isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measureText(text)
             y = obj.y

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -17,7 +17,6 @@ from lab4 import Text
 from lab4 import HTMLParser
 from lab5 import DrawRect
 from lab6 import cascade_priority
-from lab6 import layout_mode
 from lab6 import resolve_url
 from lab6 import style
 from lab6 import tree_to_list
@@ -26,7 +25,7 @@ from lab6 import TagSelector, DescendantSelector
 from lab6 import DrawText
 from lab7 import LineLayout
 from lab7 import TextLayout
-from lab8 import DocumentLayout
+from lab8 import DocumentLayout, InputLayout
 
 def url_origin(url):
     scheme_colon, _, host, _ = url.split("/", 3)
@@ -262,7 +261,8 @@ class Tab:
 
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+               if obj.node == self.focus and \
+                    isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measure(text)
             y = obj.y - self.scroll + CHROME_PX

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -18,12 +18,12 @@ from lab4 import Element
 from lab4 import Text
 from lab4 import HTMLParser
 from lab6 import cascade_priority
-from lab6 import layout_mode
 from lab6 import resolve_url
 from lab6 import tree_to_list
 from lab6 import INHERITED_PROPERTIES
 from lab6 import CSSParser, compute_style, style
 from lab6 import TagSelector, DescendantSelector
+from lab8 import is_input, layout_mode
 from lab10 import COOKIE_JAR, request, url_origin, JSContext
 
 FONTS = {}
@@ -344,16 +344,18 @@ class InlineLayout:
             self.x, self.y, self.x + self.width,
             self.y + self.height)
 
-        bgcolor = self.node.style.get("background-color",
-                                 "transparent")
-        if bgcolor != "transparent":
-            radius = float(self.node.style.get("border-radius", "0px")[:-2])
-            cmds.append(DrawRRect(rect, radius, bgcolor))
+        if not is_input(self.node):
+            bgcolor = self.node.style.get("background-color",
+                                     "transparent")
+            if bgcolor != "transparent":
+                radius = float(self.node.style.get("border-radius", "0px")[:-2])
+                cmds.append(DrawRRect(rect, radius, bgcolor))
  
         for child in self.children:
             child.paint(cmds)
 
-        cmds = paint_visual_effects(self.node, cmds, rect)
+        if not is_input(self.node):
+            cmds = paint_visual_effects(self.node, cmds, rect)
         display_list.extend(cmds)
 
     def __repr__(self):
@@ -626,7 +628,8 @@ class Tab:
 
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+               if obj.node == self.focus and \
+                    isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measureText(text)
             y = obj.y

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -20,16 +20,16 @@ from lab4 import Element
 from lab4 import Text
 from lab4 import HTMLParser
 from lab6 import cascade_priority
-from lab6 import layout_mode
 from lab6 import resolve_url
 from lab6 import tree_to_list
 from lab6 import INHERITED_PROPERTIES
 from lab6 import CSSParser, compute_style, style
 from lab6 import TagSelector, DescendantSelector
+from lab8 import layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import DocumentLayout, DrawLine, draw_line, draw_rect, \
-    draw_text, parse_color, request, CHROME_PX, SCROLL_STEP
+    draw_text, parse_color, request, CHROME_PX, SCROLL_STEP, InputLayout
 
 class MeasureTime:
     def __init__(self, name):
@@ -298,7 +298,8 @@ class Tab:
         self.document.paint(self.display_list)
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+                   if obj.node == self.focus and \
+                        isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measureText(text)
             y = obj.y

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -57,6 +57,7 @@ from lab6 import tree_to_list
 from lab6 import INHERITED_PROPERTIES
 from lab6 import compute_style
 from lab6 import TagSelector, DescendantSelector
+from lab8 import layout_mode, is_input
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import draw_line, draw_text, get_font, linespace, \
@@ -505,7 +506,7 @@ class InlineLayout:
         else:
             if node.tag == "br":
                 self.new_line()
-            elif node.tag == "input" or node.tag == "button":
+            elif is_input(node):
                 self.input(node)
             else:
                 for child in node.children:
@@ -554,16 +555,18 @@ class InlineLayout:
             self.x, self.y, self.x + self.width,
             self.y + self.height)
 
-        bgcolor = self.node.style.get("background-color",
-                                 "transparent")
-        if bgcolor != "transparent":
-            radius = float(self.node.style.get("border-radius", "0px")[:-2])
-            cmds.append(DrawRRect(rect, radius, bgcolor))
+        if not is_input(self.node):
+            bgcolor = self.node.style.get("background-color",
+                                     "transparent")
+            if bgcolor != "transparent":
+                radius = float(self.node.style.get("border-radius", "0px")[:-2])
+                cmds.append(DrawRRect(rect, radius, bgcolor))
  
         for child in self.children:
             child.paint(cmds)
 
-        cmds = paint_visual_effects(self.node, cmds, rect)
+        if not is_input(self.node):
+            cmds = paint_visual_effects(self.node, cmds, rect)
         display_list.extend(cmds)
 
     def __repr__(self):
@@ -1274,7 +1277,8 @@ class Tab:
             self.document.paint(self.display_list)
             if self.focus:
                 obj = [obj for obj in tree_to_list(self.document, [])
-                        if obj.node == self.focus][0]
+                   if obj.node == self.focus and \
+                        isinstance(obj, InputLayout)][0]
                 text = self.focus.attributes.get("value", "")
                 x = obj.x + obj.font.measureText(text)
                 y = obj.y

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -19,12 +19,12 @@ from lab4 import print_tree
 from lab4 import HTMLParser
 from lab13 import Text, Element
 from lab6 import cascade_priority
-from lab6 import layout_mode
 from lab6 import resolve_url
 from lab6 import tree_to_list
 from lab6 import INHERITED_PROPERTIES
 from lab6 import compute_style
 from lab6 import TagSelector, DescendantSelector
+from lab8 import layout_mode, is_input
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import draw_line, draw_text, get_font, linespace, \
@@ -202,7 +202,7 @@ class InlineLayout:
         else:
             if node.tag == "br":
                 self.new_line()
-            elif node.tag == "input" or node.tag == "button":
+            elif is_input(node):
                 self.input(node, zoom)
             else:
                 for child in node.children:
@@ -251,16 +251,18 @@ class InlineLayout:
             self.x, self.y, self.x + self.width,
             self.y + self.height)
 
-        bgcolor = self.node.style.get("background-color",
-                                 "transparent")
-        if bgcolor != "transparent":
-            radius = float(self.node.style.get("border-radius", "0px")[:-2])
-            cmds.append(DrawRRect(rect, radius, bgcolor))
+        if not is_input(self.node):
+            bgcolor = self.node.style.get("background-color",
+                                     "transparent")
+            if bgcolor != "transparent":
+                radius = float(self.node.style.get("border-radius", "0px")[:-2])
+                cmds.append(DrawRRect(rect, radius, bgcolor))
  
         for child in self.children:
             child.paint(cmds)
 
-        cmds = paint_visual_effects(self.node, cmds, rect)
+        if not is_input(self.node):
+            cmds = paint_visual_effects(self.node, cmds, rect)
         display_list.extend(cmds)
 
     def __repr__(self):
@@ -689,7 +691,8 @@ class Tab:
             self.layout_tree.paint(self.display_list)
             if self.focus and self.focus.tag == "input":
                 obj = [obj for obj in tree_to_list(self.layout_tree, [])
-                        if obj.node == self.focus][0]
+                   if obj.node == self.focus and \
+                        isinstance(obj, InputLayout)][0]
                 text = self.focus.attributes.get("value", "")
                 x = obj.x + obj.font.measureText(text)
                 y = obj.y
@@ -774,7 +777,7 @@ class Tab:
             self.activate_element(self.focus)
 
     def is_focusable(node):
-        return node.tag == "input" or node.tag == "button" \
+        return is_input(node) \
             or node.tag == "a"
 
     def get_tabindex(node):

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -145,12 +145,12 @@ sibling (the `<div`), they should be contianed in a `BlockLayout`, but the
 
     >>> lab8.print_tree(browser.tabs[0].document)
      DocumentLayout()
-       BlockLayout(x=13, y=18, width=774, height=15.0)
-         BlockLayout(x=13, y=18, width=774, height=15.0)
-           InlineLayout(x=13, y=18, width=774, height=15.0)
+       BlockLayout(x=13, y=18, width=774, height=15.0, node=<html>)
+         BlockLayout(x=13, y=18, width=774, height=15.0, node=<body>)
+           InlineLayout(x=13, y=18, width=774, height=15.0, node=<input>)
              LineLayout(x=13, y=18, width=774, height=15.0)
-               InputLayout(x=13, y=20.25, width=200, height=12)
-           BlockLayout(x=13, y=33.0, width=774, height=0)
+               InputLayout(x=13, y=20.25, width=200, height=12, type=input)
+           BlockLayout(x=13, y=33.0, width=774, height=0, node=<div>)
 
 The painted output also is only drawing the input as 200px wide:
 

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -123,3 +123,36 @@ POST requsts to other URLs return 404 pages:
     >>> server8.do_request("POST", "/", {}, "")
     ('404 Not Found', '<!doctype html><h1>POST / not found!</h1>')
 
+Testing layout_mode
+===================
+
+    >>> block_inline_url = 'http://test.test/example'
+    >>> test.socket.respond(block_inline_url, b"HTTP/1.0 200 OK\r\n" +
+    ... b"Header1: Value1\r\n\r\n" +
+    ... b"<input>" +
+    ... b"<div></div>")
+    >>> browser = lab8.Browser()
+    >>> browser.load(block_inline_url)
+    >>> lab8.print_tree(browser.tabs[0].document.node)
+     <html>
+       <body>
+         <input>
+         <div>
+
+In this case, because there is an inline elemnet (the `<input>`) and a block'
+sibling (the `<div`), they should be contianed in a `BlockLayout`, but the
+`<input>` element is in an `InlineLayout`:
+
+    >>> lab8.print_tree(browser.tabs[0].document)
+     DocumentLayout()
+       BlockLayout(x=13, y=18, width=774, height=15.0)
+         BlockLayout(x=13, y=18, width=774, height=15.0)
+           InlineLayout(x=13, y=18, width=774, height=15.0)
+             LineLayout(x=13, y=18, width=774, height=15.0)
+               InputLayout(x=13, y=20.25, width=200, height=12)
+           BlockLayout(x=13, y=33.0, width=774, height=0)
+
+The painted output also is only drawing the input as 200px wide:
+
+    >>> browser.tabs[0].display_list
+    [DrawRect(top=20.25 left=13 bottom=32.25 right=213 color=lightblue), DrawText(text=)]

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -12,7 +12,7 @@ import urllib.parse
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 
@@ -73,6 +73,24 @@ def request(url, payload=None):
     s.close()
 
     return headers, body
+
+def is_input(node):
+    return not isinstance(node, Text) and \
+        (node.tag == "button" or node.tag == "input")
+
+def layout_mode(node):
+    if isinstance(node, Text):
+        return "inline"
+    elif node.children:
+        for child in node.children:
+            if isinstance(child, Text): continue
+            if child.tag in BLOCK_ELEMENTS:
+                return "block"
+        return "inline"
+    elif is_input(node):
+        return "inline"
+    else:
+        return "block"
 
 INPUT_WIDTH_PX = 200
 
@@ -202,7 +220,7 @@ class InlineLayout:
         else:
             if node.tag == "br":
                 self.new_line()
-            elif node.tag == "input" or node.tag == "button":
+            elif is_input(node):
                 self.input(node)
             else:
                 for child in node.children:
@@ -248,10 +266,11 @@ class InlineLayout:
     def paint(self, display_list):
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
-        if bgcolor != "transparent":
-            x2, y2 = self.x + self.width, self.y + self.height
-            rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
+        if not is_input(self.node):
+            if bgcolor != "transparent":
+                x2, y2 = self.x + self.width, self.y + self.height
+                rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
+                display_list.append(rect)
         for child in self.children:
             child.paint(display_list)
 
@@ -328,7 +347,8 @@ class Tab:
 
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+                   if obj.node == self.focus and \
+                        isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measure(text)
             y = obj.y - self.scroll + CHROME_PX

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -13,7 +13,7 @@ import dukpy
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import request, DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
@@ -135,7 +135,8 @@ class Tab:
 
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+               if obj.node == self.focus and \
+                    isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measure(text)
             y = obj.y - self.scroll + CHROME_PX


### PR DESCRIPTION
There were two bugs:

* Putting a block layout mode on an InputLayout
* Painting them twice-- once in InlineLayout and once in InputLayout

Fixing these led to a need to change the focus code to find the object that is an `InputLayout`, not the containing
`InlineLayout`.

I also updated all of the labs that repeated the broken code, added text to forms.md explaining the fixes, and added a unittest.