### PR TITLE
Fix painting of inlines

### DIFF
--- a/src/lab5.hints
+++ b/src/lab5.hints
@@ -1,3 +1,5 @@
 [
-{"code": "child.tag in BLOCK_ELEMENTS", "type": "list"}
+{"code": "child.tag in BLOCK_ELEMENTS", "type": "list"},
+{"code": "node.tag not in BLOCK_ELEMENTS", "type": "bool"},
+{"code": "node.tag not in BLOCK_ELEMENTS", "js": "!(node.tag in BLOCK_ELEMENTS)"}
 ]

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -31,6 +31,8 @@ def layout_mode(node):
             if child.tag in BLOCK_ELEMENTS:
                 return "block"
         return "inline"
+    elif node.tag not in BLOCK_ELEMENTS:
+        return "inline"
     else:
         return "block"
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -91,6 +91,13 @@ class TextLayout:
         self.height = self.font.metrics("linespace")
 
     def paint(self, display_list):
+        bgcolor = self.node.parent.style.get("background-color",
+                                             "transparent")
+        if bgcolor != "transparent":
+            x2, y2 = self.x + self.width, self.y + self.height
+            rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
+            display_list.append(rect)
+
         color = self.node.style["color"]
         display_list.append(
             DrawText(self.x, self.y, self.word, self.font, color))
@@ -202,12 +209,6 @@ class InlineLayout:
             self.cursor_x += w + font.measure(" ")
 
     def paint(self, display_list):
-        bgcolor = self.node.style.get("background-color",
-                                      "transparent")
-        if bgcolor != "transparent":
-            x2, y2 = self.x + self.width, self.y + self.height
-            rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
         for child in self.children:
             child.paint(display_list)
 

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -250,12 +250,6 @@ class InlineLayout:
         self.cursor_x += w + font.measure(" ")
 
     def paint(self, display_list):
-        bgcolor = self.node.style.get("background-color",
-                                      "transparent")
-        if bgcolor != "transparent":
-            x2, y2 = self.x + self.width, self.y + self.height
-            rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
         for child in self.children:
             child.paint(display_list)
 
@@ -332,7 +326,8 @@ class Tab:
 
         if self.focus:
             obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus][0]
+                   if obj.node == self.focus and \
+                   isinstance(obj, InputLayout)][0]
             text = self.focus.attributes.get("value", "")
             x = obj.x + obj.font.measure(text)
             y = obj.y - self.scroll + CHROME_PX


### PR DESCRIPTION
Previously:

* Painting the background of an inline only worked if there was one inline element on the line, and it was not an input
* Inlines with no children were incorrectly marked as block

Now:
* We support painting of all leaf inlines, including both inlines like `<span>` and `<input>`
* Nested inline painting is still not supported.