### PR TITLE
Allow elements that have tabindex to be focusable

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -407,10 +407,10 @@ class Browser:
 Each time `tab` is presseed, we'll advance focus to the next thing in order.
 This will first require a definition of which elements are focusable:
 
-``` {.python}
-    def is_focusable(node):
-        return node.tag == "input" or node.tag == "button" \
-        	or node.tag == "a"
+``` {.python expected=False}
+def is_focusable(node):
+    return node.tag == "input" or node.tag == "button" \
+    	or node.tag == "a"
 ```
 
 And then each iterating through them. When `tab` is pressed and we're at the
@@ -421,7 +421,7 @@ class Tab:
     def advance_tab(self):
         focusable_nodes = [node
             for node in tree_to_list(self.nodes, [])
-            if isinstance(node, Element) and Tab.is_focusable(node)]
+            if isinstance(node, Element) and is_focusable(node)]
         if not focusable_nodes:
             self.apply_focus(None)
         elif not self.focus:

--- a/src/example14-focus.html
+++ b/src/example14-focus.html
@@ -3,3 +3,4 @@
 This is an input element: <input> and
 <a tabindex=1 href="http://localhost:8000/">this is a link.</a>
 <div>Not focusable</div>
+<div tabindex=3>Tabbable element</div>

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -130,6 +130,28 @@ And then the `input`:
      DrawText(text=Link)
      DrawLine top=21.62109375 left=13.0 bottom=39.49609375 right=13.0
 
+Regular elements aren't focusable, but if the `tabindex` attribute is set, they
+are:
+
+    >>> focus_tabindex_url = 'http://test.test/focus-tabindex'
+    >>> test.socket.respond(focus_tabindex_url, b"HTTP/1.0 200 OK\r\n" +
+    ... b"content-type: text/html\r\n\r\n" +
+    ... b'<div>Not focusable</div><div tabindex=1>Is focusable</div>')
+
+    >>> browser = lab14.Browser()
+    >>> browser.load(focus_tabindex_url)
+    >>> browser.render()
+
+The first `div` is not focusable.
+
+    >>> lab14.is_focusable(browser.tabs[0].nodes.children[0].children[0])
+    False
+
+But the second one is, because it has a `tabindex` attribute.
+
+    >>> lab14.is_focusable(browser.tabs[0].nodes.children[0].children[1])
+    True
+
 Accessibility
 =============
 
@@ -147,7 +169,7 @@ The accessibility tree is automatically created.
 Rendering will read out the accessibility instructions:
 
     >>> browser.render()
-    Here are the document contents:  Input box Link: Link Link
+    Here are the document contents:  Input box Link Link
 
 From this tree:
 


### PR DESCRIPTION
* Implement it
* Add accessibilty support
* Fix a bug in accessibility where text nodes were announced twice when announcing the whole document