### PR TITLE
Change accessibility parsing

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1832,7 +1832,7 @@ class Tab:
                     self.hovered_node.is_hovered = True
 ```
 
-And match it in `TagSelector`:
+And match it in `PseudoclassSelector`:
 
 ``` {.python}
 INTERNAL_ACCESSIBILITY_HOVER = "-internal-accessibility-hover"

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -219,13 +219,13 @@ The rules parsed by the browser style sheet should also indicate dark mode:
     >>> for selector, body, preferred_color_scheme in browser.tabs[0].rules:
     ...     if preferred_color_scheme == "dark":
     ...         print(str(selector) + " " + str(body))
-    TagSelector(tag=a, priority=1 pseudoclass=None) {'color': 'lightblue'}
-    TagSelector(tag=input, priority=1 pseudoclass=None) {'background-color': 'blue'}
-    TagSelector(tag=button, priority=1 pseudoclass=None) {'background-color': 'orangered'}
-    TagSelector(tag=input, priority=1 pseudoclass=focus) {'outline': '2px solid white'}
-    TagSelector(tag=button, priority=1 pseudoclass=focus) {'outline': '2px solid white'}
-    TagSelector(tag=div, priority=1 pseudoclass=focus) {'outline': '2px solid white'}
-    TagSelector(tag=a, priority=1 pseudoclass=focus) {'outline': '2px solid white'}
+    TagSelector(tag=a, priority=1) {'color': 'lightblue'}
+    TagSelector(tag=input, priority=1) {'background-color': 'blue'}
+    TagSelector(tag=button, priority=1) {'background-color': 'orangered'}
+    PseudoclassSelector(focus, TagSelector(tag=input, priority=1)) {'outline': '2px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=button, priority=1)) {'outline': '2px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=div, priority=1)) {'outline': '2px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=a, priority=1)) {'outline': '2px solid white'}
 
 Focus
 =====

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -216,8 +216,8 @@ But when we toggle to dark, it switches:
 
 The rules parsed by the browser style sheet should also indicate dark mode:
 
-    >>> for selector, body, preferred_color_scheme in browser.tabs[0].rules:
-    ...     if preferred_color_scheme == "dark":
+    >>> for guard, selector, body in browser.tabs[0].rules:
+    ...     if guard == "dark":
     ...         print(str(selector) + " " + str(body))
     TagSelector(tag=a, priority=1) {'color': 'lightblue'}
     TagSelector(tag=input, priority=1) {'background-color': 'blue'}

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -773,8 +773,9 @@ class CSSParser:
         if self.i < len(self.s) and self.s[self.i] == ":":
             self.literal(":")
             pseudoclass = self.word().lower()
-            if pseudoclass != INTERNAL_ACCESSIBILITY_HOVER or is_internal:
-                out = PseudoclassSelector(pseudoclass, out)
+            if pseudoclass == INTERNAL_ACCESSIBILITY_HOVER:
+                assert is_internal
+            out = PseudoclassSelector(pseudoclass, out)
         return out
 
     def selector(self, is_internal):


### PR DESCRIPTION
This PR redoes some of the parsing code in the accessibility chapter.

- [x] Pseudoclasses are represented with a new `PseudoclassSelector`. This avoids the need to modify `TagSelector` and is a bit cleaner in general.
- [x] Parsing for pseudoclasses is moved into a new `simple_selector` method. This avoids duplicate code in descendant selectors.
- [x] The `is_internal` parameter is moved into the `CSSParser` instead of being passed between methods.
- [x] Minor changes to how media queries are parsed, using a local variable instead of parser state.