### PR TITLE
Pass over the Zoom section

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -116,21 +116,49 @@ the other hand is just like a camera and does not cause layout.
 
 To implement it, we first need a way to trigger zooming. On most
 browsers, that's done with the `Ctrl-+`, `Ctrl--`, and `Ctrl-0`
-keys, but to avoid handling modifier keys like `Ctrl` let's just use
-`+`, `-`, and `0`.
+keys; using the `Ctrl` modifier key means you can type a `+`, `-`, or
+`0` into a text entry without triggering the zoom function.
+
+To handle modifier keys, we'll need to listen to both "key down" and
+"key up" events, and store whether the `Ctrl` key is pressed:
 
 ``` {.python}
+if __name__ == "__main__":
+    # ...
+    ctrl_down = False
     while True:
 		if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
 			# ...
             elif event.type == sdl2.SDL_KEYDOWN:
-                if event.key.keysym.sym == sdl2.SDLK_EQUALS:
-                    browser.increment_zoom(1)
-                elif event.key.keysym.sym == sdl2.SDLK_MINUS:
-                    browser.increment_zoom(-1)
-                elif event.key.keysym.sym == sdl2.SDLK_0:
-                    browser.reset_zoom()			
+                # ...
+                 elif event.key.keysym.sym == sdl2.SDLK_RCTRL or \
+                     event.key.keysym.sym == sdl2.SDLK_LCTRL:
+                     ctrl_down = True            	
+             elif event.type == sdl2.SDL_KEYUP:
+                 if event.key.keysym.sym == sdl2.SDLK_RCTRL or \
+                     event.key.keysym.sym == sdl2.SDLK_LCTRL:
+                     ctrl_down = False
              	# ...
+```
+
+Now we can have a case in the key handling code for "key down" events
+while the `Ctrl` key is held:
+
+``` {.python}
+if __name__ == "__main__":
+    # ...
+    ctrl_down = False
+    while True:
+		if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
+            elif event.type == sdl2.SDL_KEYDOWN:
+                if ctrl_down:
+                     if event.key.keysym.sym == sdl2.SDLK_EQUALS:
+                         browser.increment_zoom(1)
+                     elif event.key.keysym.sym == sdl2.SDLK_MINUS:
+                         browser.increment_zoom(-1)
+                     elif event.key.keysym.sym == sdl2.SDLK_0:
+                         browser.reset_zoom()
+                # ...
 ```
 
 The `Browser` code just delegates to the `Tab`, via a main thread task:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -61,10 +61,9 @@ much more convenient to go on walks with a stroller, something I'll be
 doing for years to come.[^toddler-curb-cut] And there's a good chance
 that, like many of my relatives, my eyesight will worsen as I age and
 I'll need to set my computer to a permanently larger text size. For
-more severe and permanent disabilities yet, there are more advanced
-tools like [screen readers][screen-reader].[^for-now] These take time
-to learn and use effectively, but are transformative for those who
-need them.
+more severe and permanent disabilities, there are advanced tools like
+[screen readers][screen-reader].[^for-now] These take time to learn
+and use effectively, but are transformative for those who need them.
 
 [curb-cut]: https://en.wikipedia.org/wiki/Curb_cut
 
@@ -105,11 +104,11 @@ and abilities.
 CSS zoom
 ========
 
-Let's start with the simplest accessibility problem: text on the screen that
-is too small to read. It's a problem many of us will face sooner or
-later, and possibly the most user disability issue. The simplest and
-most effective way to address this is simply increasing font and
-element sizes. This approach is called *CSS zoom*.[^zoom]
+Let's start with the simplest accessibility problem: text on the
+screen that is too small to read. It's a problem many of us will face
+sooner or later, and possibly the most common user disability issue.
+The simplest and most effective way to address this is by increasing font
+and element sizes. This approach is called *CSS zoom*.[^zoom]
 
 [^zoom]: The word zoom evokes an analogy to a camera zooming in, but
 it is not the same, because CSS zoom causes layout. *Pinch zoom*, on
@@ -155,8 +154,8 @@ Finally, the `Tab` responds to these commands by adjusting a new
 multiplier for all "CSS sizes" on the web page:[^browser-chrome]
 
 [^browser-chrome]: CSS zoom typically does not change the size of
-elements of the browser chrome. Browsers *can* do that too, usually
-triggered by a global OS setting.
+elements of the browser chrome. Browsers *can* do that too, but it's
+usually triggered by a global OS setting.
 
 ``` {.python}
 class Tab:
@@ -274,12 +273,12 @@ class InlineLayout:
 
 As well as the font size in `TextLayout`:[^min-font-size]
 
-[^min-font-size]: Browsers also usually have a *minimum* font size,
-but it's a lot trickier to use correctly. Since a minimum font size
-only affects *some* of the text on the page, and doesn't affect other
-CSS lengths, it can cause overflowing fonts and broken layouts.
-Because of these problems, browsers often restrict the feature to
-situations where the site seems to be using [relative font
+[^min-font-size]: Browsers also usually have a *minimum* font size
+feature, but it's a lot trickier to use correctly. Since a minimum
+font size only affects *some* of the text on the page, and doesn't
+affect other CSS lengths, it can cause overflowing fonts and broken
+layouts. Because of these problems, browsers often restrict the
+feature to situations where the site seems to be using [relative font
 sizes][relative-font-size].
 
 [relative-font-size]: https://developer.mozilla.org/en-US/docs/Web/CSS/font-size
@@ -304,7 +303,7 @@ class InlineLayout:
 
 This handles text and text boxes, but that's not the only thing that
 needs to zoom in and out. CSS property values, like `width` and
-`height`, are also specific in CSS pixels, not device pixels, so they
+`height`, are also specified in CSS pixels, not device pixels, so they
 need to be scaled. The easiest way to do that is by passing the `zoom`
 value to `style_length`, which we already use for reading CSS lengths:
 

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -125,13 +125,12 @@ keys, but to avoid handling modifier keys like `Ctrl` let's just use
 		if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
 			# ...
             elif event.type == sdl2.SDL_KEYDOWN:
-                if ctrl_down:
-                    if event.key.keysym.sym == sdl2.SDLK_EQUALS:
-                        browser.increment_zoom(1)
-                    elif event.key.keysym.sym == sdl2.SDLK_MINUS:
-                        browser.increment_zoom(-1)
-                    elif event.key.keysym.sym == sdl2.SDLK_0:
-                        browser.reset_zoom()			
+                if event.key.keysym.sym == sdl2.SDLK_EQUALS:
+                    browser.increment_zoom(1)
+                elif event.key.keysym.sym == sdl2.SDLK_MINUS:
+                    browser.increment_zoom(-1)
+                elif event.key.keysym.sym == sdl2.SDLK_0:
+                    browser.reset_zoom()			
              	# ...
 ```
 

--- a/book/skipped.md
+++ b/book/skipped.md
@@ -36,22 +36,6 @@ other languages like Python, Lua, or Java. The best way to learn about
 the insides of a modern JavaScript engine is a book on programming
 language implementation.
 
-Accessibility
-=============
-
-Web pages should be usable despite physical (blind, difficulty seeing,
-Parkinson's), mental (learning disabilities, dyslexia), or situational
-(car console, gloves, eye dilation) disabilities. The web has grown a
-rich garden of accessibility technologies. Not only is this a topic of
-technical interest and moral imperative, the developing legal landscape in
-many countries means it will only grow in importance over time.
-
-To be honest I skipped this topic because I worried that web
-accessibility was a difficult topic to engage students in. I also
-could not figure out where in the book it would go. Adding it as a
-twelfth chapter would also make the last part of the book even longer,
-while adding it earlier would add a significant maintenance burden.
-
 Connection Security
 ===================
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1881,13 +1881,13 @@ if __name__ == "__main__":
             elif event.type == sdl2.SDL_MOUSEMOTION:
                 browser.handle_hover(event.motion)
             elif event.type == sdl2.SDL_KEYDOWN:
-                if event.key.keysym.sym == sdl2.SDLK_EQUALS:
-                    browser.increment_zoom(1)
-                elif event.key.keysym.sym == sdl2.SDLK_MINUS:
-                    browser.increment_zoom(-1)
-                elif event.key.keysym.sym == sdl2.SDLK_0:
-                    browser.reset_zoom()
-                elif ctrl_down:
+                if ctrl_down:
+                    if event.key.keysym.sym == sdl2.SDLK_EQUALS:
+                        browser.increment_zoom(1)
+                    elif event.key.keysym.sym == sdl2.SDLK_MINUS:
+                        browser.increment_zoom(-1)
+                    elif event.key.keysym.sym == sdl2.SDLK_0:
+                        browser.reset_zoom()
                     if event.key.keysym.sym == sdl2.SDLK_LEFT:
                         browser.go_back()
                     elif event.key.keysym.sym == sdl2.SDLK_TAB:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1881,13 +1881,13 @@ if __name__ == "__main__":
             elif event.type == sdl2.SDL_MOUSEMOTION:
                 browser.handle_hover(event.motion)
             elif event.type == sdl2.SDL_KEYDOWN:
-                if ctrl_down:
-                    if event.key.keysym.sym == sdl2.SDLK_EQUALS:
-                        browser.increment_zoom(1)
-                    elif event.key.keysym.sym == sdl2.SDLK_MINUS:
-                        browser.increment_zoom(-1)
-                    elif event.key.keysym.sym == sdl2.SDLK_0:
-                        browser.reset_zoom()
+                if event.key.keysym.sym == sdl2.SDLK_EQUALS:
+                    browser.increment_zoom(1)
+                elif event.key.keysym.sym == sdl2.SDLK_MINUS:
+                    browser.increment_zoom(-1)
+                elif event.key.keysym.sym == sdl2.SDLK_0:
+                    browser.reset_zoom()
+                elif ctrl_down:
                     elif event.key.keysym.sym == sdl2.SDLK_LEFT:
                         browser.go_back()
                     elif event.key.keysym.sym == sdl2.SDLK_TAB:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1888,7 +1888,7 @@ if __name__ == "__main__":
                 elif event.key.keysym.sym == sdl2.SDLK_0:
                     browser.reset_zoom()
                 elif ctrl_down:
-                    elif event.key.keysym.sym == sdl2.SDLK_LEFT:
+                    if event.key.keysym.sym == sdl2.SDLK_LEFT:
                         browser.go_back()
                     elif event.key.keysym.sym == sdl2.SDLK_TAB:
                         browser.cycle_tabs()


### PR DESCRIPTION
This PR makes mostly language changes to the CSS Zoom section. The two major changes are:

- Don't require control modifier for zooming. (I don't think handling modifier keys adds anything?)
- Clarify discussion of device pixels vs CSS pixels