### PR TITLE
Compiler cleanup

### DIFF
--- a/infra/compile.py
+++ b/infra/compile.py
@@ -545,7 +545,7 @@ def compile_expr(tree, ctx):
             raise AssertionError(f"Could not find variable {tree.id}")
     elif isinstance(tree, ast.Constant):
         if isinstance(tree.value, str):
-            return compile_str(tree.value)
+            return json.dumps(tree.value)
         elif isinstance(tree.value, bool):
             return "true" if tree.value else "false"
         elif isinstance(tree.value, int):
@@ -558,12 +558,6 @@ def compile_expr(tree, ctx):
             raise UnsupportedConstruct()
     else:
         raise UnsupportedConstruct()
-
-def compile_str(s):
-    out = repr(s)
-    if out[0] == out[-1] == "'" and '"' not in out:
-        out = '"' + out[1:-1] + '"'
-    return out
 
 def flatten_ifs(tree):
     parts = [(tree.test, tree.body)]

--- a/infra/linecount.py
+++ b/infra/linecount.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import ast
+import outlines
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Count how many lines chapter has, after resolving imports")
+    parser.add_argument("file", type=argparse.FileType(), nargs="+")
+    args = parser.parse_args()
+
+    for f in args.file:
+        tree = ast.parse(f.read(), f.name)
+        tree2 = outlines.ResolveImports().visit(tree)
+        print(f.name, ast.unparse(ast.fix_missing_locations(tree2)).count("\n"), sep="\t")

--- a/infra/outlines.py
+++ b/infra/outlines.py
@@ -93,21 +93,77 @@ def write_html(objs, indent=0):
             write_html(subs, indent=indent+4)
         print("</code>")
 
+def is_doc_string(cmd):
+    return isinstance(cmd, ast.Expr) and \
+        isinstance(cmd.value, ast.Constant) and isinstance(cmd.value.value, str)
+
+def is_sys_modules_hack(cmd):
+    return isinstance(cmd, ast.Assign) and len(cmd.targets) == 1 and \
+        isinstance(cmd.targets[0], ast.Attribute) and \
+        isinstance(cmd.targets[0].value, ast.Subscript) and \
+        isinstance(cmd.targets[0].value.value, ast.Attribute) and \
+        isinstance(cmd.targets[0].value.value.value, ast.Name) and \
+        cmd.targets[0].value.value.value.id == 'sys' and \
+        cmd.targets[0].value.value.attr == 'modules'
+
+def is_if_main(cmd):
+    return isinstance(cmd, ast.If) and isinstance(cmd.test, ast.Compare) and \
+        isinstance(cmd.test.left, ast.Name) and cmd.test.left.id == "__name__" and \
+        len(cmd.test.comparators) == 1 and isinstance(cmd.test.comparators[0], ast.Constant) and \
+        cmd.test.comparators[0].value == "__main__" and len(cmd.test.ops) == 1 and \
+        isinstance(cmd.test.ops[0], ast.Eq)
+
+def get_name(module, name):
+    assert isinstance(module, ast.Module)
+    for item in module.body:
+        if isinstance(item, ast.Import): pass
+        elif isinstance(item, ast.ImportFrom): pass
+        elif is_doc_string(item): pass
+        elif is_sys_modules_hack(item): pass
+        elif is_if_main(item): pass
+        elif isinstance(item, ast.ClassDef):
+            if item.name == name:
+                return item
+        elif isinstance(item, ast.FunctionDef):
+            if item.name == name:
+                return item
+        elif isinstance(item, ast.Assign) and len(item.targets) == 1:
+            if isinstance(item.targets[0], ast.Name):
+                if item.targets[0].id == name:
+                    return item
+            elif isinstance(item.targets[0], ast.Tuple):
+                assert isinstance(item.value, ast.Tuple)
+                for var, val in zip(item.targets[0].elts, item.value.elts):
+                    if var.id == name:
+                        return ast.Assign([var], val)
+            else:
+                raise Exception(ast.dump(cmd))
+            
+class ResolveImports(ast.NodeTransformer):
+    def visit_ImportFrom(self, cmd):
+        assert cmd.level == 0
+        assert cmd.module
+        assert all(name.asname is None for name in cmd.names)
+        names = [name.name for name in cmd.names]
+        filename = "src/{}.py".format(cmd.module)
+        objs = []
+
+        with open(filename) as file:
+            subast = ast.parse(file.read(), filename)
+
+        for name in names:
+            defn = get_name(subast, name)
+            if defn:
+                objs.append(defn)
+            else:
+                Exception("Could not find {} in module {}".format(name, cmd.module))
+
+        return objs
+
 def to_item(cmd):
-    if isinstance(cmd, ast.Assign) and len(cmd.targets) == 1 and \
-         isinstance(cmd.targets[0], ast.Attribute) and \
-         isinstance(cmd.targets[0].value, ast.Subscript) and \
-         isinstance(cmd.targets[0].value.value, ast.Attribute) and \
-         isinstance(cmd.targets[0].value.value.value, ast.Name) and \
-         cmd.targets[0].value.value.value.id == 'sys' and \
-         cmd.targets[0].value.value.attr == 'modules':
-        return
-    elif isinstance(cmd, ast.If) and isinstance(cmd.test, ast.Compare) and \
-         isinstance(cmd.test.left, ast.Name) and cmd.test.left.id == "__name__" and \
-         len(cmd.test.comparators) == 1 and isinstance(cmd.test.comparators[0], ast.Constant) and \
-         cmd.test.comparators[0].value == "__main__" and len(cmd.test.ops) == 1 and \
-         isinstance(cmd.test.ops[0], ast.Eq):
-        return IfMain()
+    if is_sys_modules_hack(cmd): return
+    elif is_if_main(cmd): return IfMain()
+    elif is_doc_string(cmd): return
     elif isinstance(cmd, ast.ClassDef):
         return Class(cmd.name, [to_item(scmd) for scmd in cmd.body])
     elif isinstance(cmd, ast.FunctionDef):
@@ -120,9 +176,6 @@ def to_item(cmd):
         else:
             raise Exception(ast.dump(cmd))
         return Const(names)
-    elif isinstance(cmd, ast.Expr) and \
-         isinstance(cmd.value, ast.Constant) and isinstance(cmd.value.value, str):
-        return
     elif isinstance(cmd, ast.Import):
         return
     elif isinstance(cmd, ast.ImportFrom):
@@ -138,32 +191,6 @@ def outline(tree):
         if item: objs.append(item)
     return objs
 
-def get_imports(tree):
-    objs = []
-    assert isinstance(tree, ast.Module)
-    for cmd in tree.body:
-        if isinstance(cmd, ast.ImportFrom):
-            assert cmd.level == 0
-            assert cmd.module
-            assert all(name.asname is None for name in cmd.names)
-            names = [name.name for name in cmd.names]
-            filename = "src/{}.py".format(cmd.module)
-
-            with open(filename) as file:
-                suboutline = outline(ast.parse(file.read(), filename))
-
-            for item in suboutline:
-                if isinstance(item, IfMain):
-                    pass
-                elif isinstance(item, Const):
-                    if set(names) & set(item.names):
-                        assert set(item.names).issubset(names)
-                        objs.append(item)
-                else:
-                    if item.name in names:
-                        objs.append(item)
-    return objs
-
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Generates outlines for each chapter's code")
@@ -172,8 +199,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     tree = ast.parse(args.file.read(), args.file.name)
-    ol = get_imports(tree)
-    ol.extend(outline(tree))
+    tree2 = ResolveImports().visit(tree)
+    ol = outline(tree2)
     if args.html:
         write_html(ol)
     else:

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -10,22 +10,14 @@ import tkinter
 import tkinter.font
 import urllib.parse
 import dukpy
-from lab3 import get_font
-from lab4 import print_tree
-from lab4 import Element
-from lab4 import Text
-from lab4 import HTMLParser
-from lab5 import DrawRect
-from lab6 import cascade_priority
-from lab6 import resolve_url
-from lab6 import style
-from lab6 import tree_to_list
-from lab6 import CSSParser
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab3 import FONTS, get_font
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS, DrawRect
+from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
 from lab6 import TagSelector, DescendantSelector
-from lab6 import DrawText
-from lab7 import LineLayout
-from lab7 import TextLayout
-from lab8 import DocumentLayout, InputLayout
+from lab7 import LineLayout, TextLayout, CHROME_PX
+from lab8 import DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
 
 def url_origin(url):
     scheme_colon, _, host, _ = url.split("/", 3)
@@ -180,9 +172,6 @@ class JSContext:
         return out
 
 
-SCROLL_STEP = 100
-CHROME_PX = 100
-
 class Tab:
     def __init__(self):
         self.history = []
@@ -328,8 +317,6 @@ class Tab:
             self.history.pop()
             back = self.history.pop()
             self.load(back)
-
-WIDTH, HEIGHT = 800, 600
 
 class Browser:
     def __init__(self):

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -24,6 +24,7 @@ from lab6 import INHERITED_PROPERTIES
 from lab6 import CSSParser, compute_style, style
 from lab6 import TagSelector, DescendantSelector
 from lab8 import layout_mode
+from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin, JSContext
 
 FONTS = {}

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -28,8 +28,11 @@ from lab6 import TagSelector, DescendantSelector
 from lab8 import layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
-from lab11 import DocumentLayout, DrawLine, draw_line, draw_rect, \
-    draw_text, parse_color, request, CHROME_PX, SCROLL_STEP, InputLayout
+from lab11 import FONTS, get_font, parse_color, parse_blend_mode, linespace
+from lab11 import SaveLayer, DrawRRect, DrawText, DrawRect, DrawLine, ClipRRect
+from lab11 import draw_line, draw_text, draw_rect
+from lab11 import BlockLayout, InlineLayout, DocumentLayout, INPUT_WIDTH_PX, LineLayout, TextLayout, InputLayout
+from lab11 import paint_visual_effects, SCROLL_STEP, CHROME_PX
 
 class MeasureTime:
     def __init__(self, name):

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -15,6 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab6 import TagSelector, DescendantSelector
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import request, DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
 


### PR DESCRIPTION
This PR does some minor refactors to the compiler and outline tool to try to make them a bit more regular / more similar to each other. The main new feature is a line counter tool, which counts lines after resolving all imports (so that we get the size a reader would have at any given chapter. Here's the data it makes:

```
~/wbe $ python3 infra/linecount.py src/lab*.py
src/lab1.py	59
src/lab2.py	104
src/lab3.py	195
src/lab4.py	279
src/lab5.py	424
src/lab6.py	595
src/lab7.py	719
src/lab8.py	835
src/lab9.py	919
src/lab10.py	966
src/lab11.py	1218
src/lab12.py	1529
src/lab13.py	1964
src/lab14.py	2295
src/lab15.py	2419
``` 