### PR TITLE
More refactors to the compiler

### DIFF
--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -1,0 +1,122 @@
+import ast
+
+def is_doc_string(cmd):
+    return isinstance(cmd, ast.Expr) and \
+        isinstance(cmd.value, ast.Constant) and isinstance(cmd.value.value, str)
+
+def is_sys_modules_hack(cmd):
+    return isinstance(cmd, ast.Assign) and len(cmd.targets) == 1 and \
+        isinstance(cmd.targets[0], ast.Attribute) and \
+        isinstance(cmd.targets[0].value, ast.Subscript) and \
+        isinstance(cmd.targets[0].value.value, ast.Attribute) and \
+        isinstance(cmd.targets[0].value.value.value, ast.Name) and \
+        cmd.targets[0].value.value.value.id == 'sys' and \
+        cmd.targets[0].value.value.attr == 'modules'
+
+def is_if_main(cmd):
+    return isinstance(cmd, ast.If) and isinstance(cmd.test, ast.Compare) and \
+        isinstance(cmd.test.left, ast.Name) and cmd.test.left.id == "__name__" and \
+        len(cmd.test.comparators) == 1 and isinstance(cmd.test.comparators[0], ast.Constant) and \
+        cmd.test.comparators[0].value == "__main__" and len(cmd.test.ops) == 1 and \
+        isinstance(cmd.test.ops[0], ast.Eq)
+
+def iter_defs(module):
+    assert isinstance(module, ast.Module)
+    for item in module.body:
+        if isinstance(item, ast.Import): pass
+        elif isinstance(item, ast.ImportFrom): pass
+        elif is_doc_string(item): pass
+        elif is_sys_modules_hack(item): pass
+        elif is_if_main(item): pass
+        elif isinstance(item, ast.ClassDef):
+            yield item.name, item
+        elif isinstance(item, ast.FunctionDef):
+            yield item.name, item
+        elif isinstance(item, ast.Assign) and len(item.targets) == 1:
+            if isinstance(item.targets[0], ast.Name):
+                yield item.targets[0].id, item
+            elif isinstance(item.targets[0], ast.Tuple):
+                assert isinstance(item.value, ast.Tuple)
+                for var, val in zip(item.targets[0].elts, item.value.elts):
+                    yield var.id, ast.Assign([var], val)
+            else:
+                raise Exception("Invalid module member: " + ast.dump(cmd))
+        else:
+            raise Exception("Invalid module member: " + ast.dump(cmd))
+
+def iter_methods(cls):
+    assert isinstance(cls, ast.ClassDef)
+    for item in cls.body:
+        if is_doc_string(item): pass
+        elif isinstance(item, ast.Assign) and len(item.targets) == 1:
+            if isinstance(item.targets[0], ast.Name):
+                yield item.targets[0].id, item
+            elif isinstance(item.targets[0], ast.Tuple):
+                assert isinstance(item.value, ast.Tuple)
+                for var, val in zip(item.targets[0].elts, item.value.elts):
+                    yield var.id, ast.Assign([var], val)
+            else:
+                raise Exception("Invalid class member: " + ast.dump(cmd))
+        else:
+            raise Exception("Invalid class member: " + ast.dump(cmd))
+
+class ResolveImports(ast.NodeTransformer):
+    def visit_ImportFrom(self, cmd):
+        assert cmd.level == 0
+        assert cmd.module
+        assert all(name.asname is None for name in cmd.names)
+        names = [name.name for name in cmd.names]
+        filename = "src/{}.py".format(cmd.module)
+        objs = []
+
+        with open(filename) as file:
+            subast = ast.parse(file.read(), filename)
+
+        for name in names:
+            (defn,) = [item for item_name, item in iter_defs(subast) if item_name == name]
+            if defn:
+                objs.append(defn)
+            else:
+                Exception("Could not find {} in module {}".format(name, cmd.module))
+
+        return objs
+
+class AST39(ast.NodeTransformer):
+    def visit_Num(self, node):
+        return ast.Constant(node.n)
+    def visit_Str(self, node):
+        return ast.Constant(node.s)
+    def visit_NameConstant(self, node):
+        return ast.Constant(node.value)
+    def visit_Ellipsis(self, node):
+        return ast.Constant(node)
+    def visit_ExtSlice(self, node):
+        return ast.Tuple([self.generic_visit(d) for d in node.dims])
+    def visit_Index(self, node):
+        return node.value
+
+    @classmethod
+    def parse(cls, str, name='<unknown>'):
+        tree = ast.parse(str, name)
+        if hasattr(ast, "NameConstant"):
+            return ast.fix_missing_locations(cls().visit(tree))
+        else:
+            return tree
+
+    @staticmethod
+    def unparse(tree, explain=False):
+        if hasattr(ast, "unparse"):
+            return ast.unparse(tree)
+        elif explain:
+            return "/* Please convert to Python: " + ast.dump(tree) + " */"
+        else:
+            return ast.dump(tree)
+
+def parse(source, filename='<unknown>'):
+    return AST39.parse(source, filename)
+
+def inline(tree):
+    return ast.fix_missing_locations(ResolveImports().visit(tree))
+
+def unparse(tree):
+    return AST39.unparse(tree)

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -40,26 +40,19 @@ def iter_defs(module):
                 for var, val in zip(item.targets[0].elts, item.value.elts):
                     yield var.id, ast.Assign([var], val)
             else:
-                raise Exception("Invalid module member: " + ast.dump(cmd))
+                raise Exception("Invalid module member: " + ast.dump(item))
         else:
-            raise Exception("Invalid module member: " + ast.dump(cmd))
+            raise Exception("Invalid module member: " + ast.dump(item))
 
 def iter_methods(cls):
     assert isinstance(cls, ast.ClassDef)
     for item in cls.body:
         if is_doc_string(item): pass
-        elif isinstance(item, ast.Assign) and len(item.targets) == 1:
-            if isinstance(item.targets[0], ast.Name):
-                yield item.targets[0].id, item
-            elif isinstance(item.targets[0], ast.Tuple):
-                assert isinstance(item.value, ast.Tuple)
-                for var, val in zip(item.targets[0].elts, item.value.elts):
-                    yield var.id, ast.Assign([var], val)
-            else:
-                raise Exception("Invalid class member: " + ast.dump(cmd))
+        elif isinstance(item, ast.FunctionDef):
+            yield item.name, item
         else:
-            raise Exception("Invalid class member: " + ast.dump(cmd))
-
+            raise Exception("Invalid class member: " + ast.dump(item))
+        
 class ResolveImports(ast.NodeTransformer):
     def __init__(self):
         self.cache = {}
@@ -130,5 +123,5 @@ def parse(source, filename='<unknown>'):
 def inline(tree):
     return ast.fix_missing_locations(ResolveImports().visit(tree))
 
-def unparse(tree):
-    return AST39.unparse(tree)
+def unparse(tree, explain=False):
+    return AST39.unparse(tree, explain=explain)

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -763,10 +763,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Compiles each chapter's Python code to JavaScript")
     parser.add_argument("--hints", default=None, type=argparse.FileType())
     parser.add_argument("--indent", default=2, type=int)
+    parser.add_argument("--debug", action="store_true")
     parser.add_argument("--use-js-modules", action="store_true", default=False)
     parser.add_argument("python", type=argparse.FileType())
     parser.add_argument("javascript", type=argparse.FileType("w"))
     args = parser.parse_args()
+
+    if args.debug:
+        test_mode()
 
     name = os.path.basename(args.python.name)
     assert name.endswith(".py")

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -159,7 +159,7 @@ def load_outline(module):
                 if isinstance(subitem, ast.Assign): continue
                 elif isinstance(subitem, ast.ClassDef): continue
                 elif isinstance(subitem, ast.FunctionDef):
-                    OUR_METHODS.append(name)
+                    OUR_METHODS.append(subname)
                 else:
                     raise ValueError(subitem)
         else:

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -9,6 +9,7 @@ First, some helper code for tests. We need import the compiler:
     >>> import sys
     >>> sys.path.append("infra")
     >>> from compile import *
+    >>> import asttools
     >>> test_mode()
 
 Then, this fake context pretends all variables are in scope, which is
@@ -18,20 +19,19 @@ useful for short tests:
     ...    type = "module"
     ...    def __getitem__(self, i): return True
     ...    def __contains__(self, i): return True
-    ...    def is_global_constant(self, i): return False
 
 Finally, this class has some helper methods:
 
     >>> class Test:
     ...     @staticmethod
     ...     def expr(s):
-    ...         mod = AST39.parse(s)
+    ...         mod = asttools.parse(s)
     ...         assert isinstance(mod, ast.Module) and len(mod.body) == 1
     ...         stmt = mod.body[0]
     ...         assert isinstance(stmt, ast.Expr)
     ...         print(compile_expr(stmt.value, ctx=FakeCtx()))
     ...     def stmt(s):
-    ...         mod = AST39.parse(s)
+    ...         mod = asttools.parse(s)
     ...         assert isinstance(mod, ast.Module) and len(mod.body) == 1
     ...         print(compile(mod.body[0], ctx=FakeCtx()))
 
@@ -280,21 +280,17 @@ deduplicate the code a bit:
 
     >>> Test.stmt("from lab1 import request")
     import { request } from "./lab1.js";
-    >>> assert "request" in LAB_IMPORT_FNS
     >>> Test.stmt("from lab2 import HSTEP")
     import { constants as lab2_constants } from "./lab2.js";
     constants.HSTEP = lab2_constants.HSTEP;
-    >>> assert "HSTEP" in LAB_IMPORT_CONSTANTS
     >>> Test.stmt("from lab4 import Element")
     import { Element } from "./lab4.js";
-    >>> assert "Element" in LAB_IMPORT_CLASSES
     >>> Test.stmt("from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP")
     import { constants as lab2_constants } from "./lab2.js";
     constants.WIDTH = lab2_constants.WIDTH;
     constants.HEIGHT = lab2_constants.HEIGHT;
     constants.HSTEP = lab2_constants.HSTEP;
     constants.VSTEP = lab2_constants.VSTEP;
-    >>> assert "WIDTH" in LAB_IMPORT_CONSTANTS
     
 Note that `from ... import` statements for constants are complex, due
 to the use of a global collector object for constants.

--- a/infra/outlines.py
+++ b/infra/outlines.py
@@ -112,6 +112,8 @@ def outline(tree):
     for name, cmd in asttools.iter_defs(tree):
         item = to_item(cmd)
         if item: objs.append(item)
+    if any(asttools.is_if_main(x) for x in tree.body):
+        objs.append(IfMain())
     return objs
 
 if __name__ == "__main__":

--- a/infra/outlines.py
+++ b/infra/outlines.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
 import argparse
-import ast
+import ast, asttools
 from dataclasses import dataclass
 import sys
 from typing import List
-
-groups = [ "Node", "Layout", "Draw" ]
 
 class Item: pass
 
@@ -93,73 +91,6 @@ def write_html(objs, indent=0):
             write_html(subs, indent=indent+4)
         print("</code>")
 
-def is_doc_string(cmd):
-    return isinstance(cmd, ast.Expr) and \
-        isinstance(cmd.value, ast.Constant) and isinstance(cmd.value.value, str)
-
-def is_sys_modules_hack(cmd):
-    return isinstance(cmd, ast.Assign) and len(cmd.targets) == 1 and \
-        isinstance(cmd.targets[0], ast.Attribute) and \
-        isinstance(cmd.targets[0].value, ast.Subscript) and \
-        isinstance(cmd.targets[0].value.value, ast.Attribute) and \
-        isinstance(cmd.targets[0].value.value.value, ast.Name) and \
-        cmd.targets[0].value.value.value.id == 'sys' and \
-        cmd.targets[0].value.value.attr == 'modules'
-
-def is_if_main(cmd):
-    return isinstance(cmd, ast.If) and isinstance(cmd.test, ast.Compare) and \
-        isinstance(cmd.test.left, ast.Name) and cmd.test.left.id == "__name__" and \
-        len(cmd.test.comparators) == 1 and isinstance(cmd.test.comparators[0], ast.Constant) and \
-        cmd.test.comparators[0].value == "__main__" and len(cmd.test.ops) == 1 and \
-        isinstance(cmd.test.ops[0], ast.Eq)
-
-def get_name(module, name):
-    assert isinstance(module, ast.Module)
-    for item in module.body:
-        if isinstance(item, ast.Import): pass
-        elif isinstance(item, ast.ImportFrom): pass
-        elif is_doc_string(item): pass
-        elif is_sys_modules_hack(item): pass
-        elif is_if_main(item): pass
-        elif isinstance(item, ast.ClassDef):
-            if item.name == name:
-                return item
-        elif isinstance(item, ast.FunctionDef):
-            if item.name == name:
-                return item
-        elif isinstance(item, ast.Assign) and len(item.targets) == 1:
-            if isinstance(item.targets[0], ast.Name):
-                if item.targets[0].id == name:
-                    return item
-            elif isinstance(item.targets[0], ast.Tuple):
-                assert isinstance(item.value, ast.Tuple)
-                for var, val in zip(item.targets[0].elts, item.value.elts):
-                    if var.id == name:
-                        return ast.Assign([var], val)
-            else:
-                raise Exception(ast.dump(cmd))
-            
-class ResolveImports(ast.NodeTransformer):
-    def visit_ImportFrom(self, cmd):
-        assert cmd.level == 0
-        assert cmd.module
-        assert all(name.asname is None for name in cmd.names)
-        names = [name.name for name in cmd.names]
-        filename = "src/{}.py".format(cmd.module)
-        objs = []
-
-        with open(filename) as file:
-            subast = ast.parse(file.read(), filename)
-
-        for name in names:
-            defn = get_name(subast, name)
-            if defn:
-                objs.append(defn)
-            else:
-                Exception("Could not find {} in module {}".format(name, cmd.module))
-
-        return objs
-
 def to_item(cmd):
     if is_sys_modules_hack(cmd): return
     elif is_if_main(cmd): return IfMain()
@@ -185,8 +116,7 @@ def to_item(cmd):
 
 def outline(tree):
     objs = []
-    assert isinstance(tree, ast.Module)
-    for cmd in tree.body:
+    for name, item in asttools.iter_defs(tree):
         item = to_item(cmd)
         if item: objs.append(item)
     return objs
@@ -198,9 +128,8 @@ if __name__ == "__main__":
     parser.add_argument("--html", action="store_true", default=False)
     args = parser.parse_args()
 
-    tree = ast.parse(args.file.read(), args.file.name)
-    tree2 = ResolveImports().visit(tree)
-    ol = outline(tree2)
+    tree = asttools.inline(asttools.parse(args.file.read(), args.file.name))
+    ol = outline(tree)
     if args.html:
         write_html(ol)
     else:

--- a/infra/outlines.py
+++ b/infra/outlines.py
@@ -92,10 +92,7 @@ def write_html(objs, indent=0):
         print("</code>")
 
 def to_item(cmd):
-    if is_sys_modules_hack(cmd): return
-    elif is_if_main(cmd): return IfMain()
-    elif is_doc_string(cmd): return
-    elif isinstance(cmd, ast.ClassDef):
+    if isinstance(cmd, ast.ClassDef):
         return Class(cmd.name, [to_item(scmd) for scmd in cmd.body])
     elif isinstance(cmd, ast.FunctionDef):
         return Function(cmd.name, [arg.arg for arg in cmd.args.args])
@@ -107,16 +104,12 @@ def to_item(cmd):
         else:
             raise Exception(ast.dump(cmd))
         return Const(names)
-    elif isinstance(cmd, ast.Import):
-        return
-    elif isinstance(cmd, ast.ImportFrom):
-        return
     else:
         raise Exception(ast.dump(cmd))
 
 def outline(tree):
     objs = []
-    for name, item in asttools.iter_defs(tree):
+    for name, cmd in asttools.iter_defs(tree):
         item = to_item(cmd)
         if item: objs.append(item)
     return objs


### PR DESCRIPTION
This PR follows up on #599 with more refactors to the compiler. The biggest change is to decouple the outliner from the compiler via new `iter_defs` and `iter_methods` helper methods. But there are some other changes, too:

- The import resolver now handles transitive imports. This caught and fixed some items missing from the outlines, like `Task` in `lab14` (imported from `lab13` which in turn imports it from `lab12`)
- Removed the `LAB_IMPORT_X` constants from the compiler; imports are now handled through the inliner. This also eliminates `load_outline_for_class`
- Eliminate `is_global_constant`, this is now handled using `OUR_CONSTANTS` like classes and functions are
- Compiler does not need to handle imports on its own
- The outliner now uses `AST39`, just like the compiler, though I don't think this actually affects its operations

I've examined all changes to all outlines and compiled widgets, and they are all immaterial.
