### PR TITLE
Pass on the dark mode section

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -679,7 +679,7 @@ buttons, and text entries:
 To implement media queries, we'll have to start with parsing this
 syntax:
 
-``` {.python}
+``` {.python replace=pair()/pair(")")}
 class CSSParser:
     def media_query(self):
         self.literal("@")

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -679,7 +679,7 @@ buttons, and text entries:
 To implement media queries, we'll have to start with parsing this
 syntax:
 
-``` {.python replace=pair()/pair(")")}
+``` {.python replace=pair()/pair(%22)%22)}
 class CSSParser:
     def media_query(self):
         self.literal("@")

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -456,7 +456,7 @@ Dark mode
 =========
 
 Another useful visual change is using darker colors to help users who
-are extra sensitive to light, or using a device at night, or just
+are extra sensitive to light, use their device at night, or just
 prefer a darker color scheme. This browser *dark mode* feature should
 switch both the browser chrome and the web page itself to use white
 text on a black background, and otherwise adjust background colors to
@@ -550,8 +550,8 @@ calls in `raster_chrome` (they're not all shown here) should use
     from one theme to another.
     
 Now, we want the web page content to change from light mode to dark
-mode as well. To start, let's informing the `Tab` when the user
-requests dark mode:
+mode as well. To start, let's inform the `Tab` when the user requests
+dark mode:
 
 ``` {.python}
 class Browser:
@@ -662,7 +662,7 @@ only in dark mode:
 }
 ```
 
-Web developers can use `prefers-color-scheme` queries it in their own
+Web developers can use `prefers-color-scheme` queries in their own
 stylesheets, adjusting their own choice of colors to fit user
 requests, but we can also use a `prefers-color-scheme` media query in
 the browser default stylesheet to adjust the default colors for links,

--- a/src/browser14.css
+++ b/src/browser14.css
@@ -39,17 +39,12 @@ a:-internal-accessibility-hover {
 }
 
 @media (prefers-color-scheme: dark) {
+  a { color: lightblue; }
+  input { background-color: blue; }
+  button { background-color: orangered; }
 
-a { color: lightblue; }
-input { background-color: blue; }
-button { background-color: orangered; }
-
-input:focus { outline: 2px solid white; }
-
-button:focus { outline: 2px solid white; }
-
-div:focus { outline: 2px solid white; }
-
-a:focus { outline: 2px solid white; }
-
+  input:focus { outline: 2px solid white; }
+  button:focus { outline: 2px solid white; }
+  div:focus { outline: 2px solid white; }
+  a:focus { outline: 2px solid white; }
 }

--- a/src/lab13-tests.md
+++ b/src/lab13-tests.md
@@ -85,7 +85,6 @@ Testing CSS transtions
 
     >>> for item in browser.draw_list:
     ...     lab13.print_tree(item)
-     DrawCompositedLayer()
      Transform(<no-op>)
        SaveLayer(<no-op>)
          ClipRRect(<no-op>)

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -597,9 +597,6 @@ class DocumentLayout:
         self.height = child.height + 2*VSTEP
 
     def paint(self, display_list):
-        display_list.append(
-            DrawRect(self.x, self.y, self.x + self.width, self.y + self.height,
-                "white"))
         self.children[0].paint(display_list)
 
     def __repr__(self):

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -47,7 +47,6 @@ An outline causes a `DrawRect` with the given width and color:
     >>> browser.render()
 
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=94.0 right=787.0 border_color=white width=0 fill_color=white)
      DrawRect(top=18.0 left=13.0 bottom=58.0 right=43.0 border_color=red width=3 fill_color=None)
 
 Focus
@@ -65,7 +64,6 @@ Focus
 On load, nothing is focused:
 
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=white width=0 fill_color=white)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
@@ -78,7 +76,6 @@ But pressing `tab` will focus first the `input` and then the `a` element.
 The 2px wide black display list command is the focus ring for the `input`:
 
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=white width=0 fill_color=white)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
      DrawText(text=)
      DrawRect(top=21.62109375 left=13.0 bottom=39.49609375 right=213.0 border_color=black width=2 fill_color=None)
@@ -90,7 +87,6 @@ And now it's for the `a`:
     >>> browser.handle_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=white width=0 fill_color=white)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
@@ -112,7 +108,6 @@ This time the `a` element is focused first:
     >>> browser.handle_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=white width=0 fill_color=white)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
@@ -123,7 +118,6 @@ And then the `input`:
     >>> browser.handle_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=white width=0 fill_color=white)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
      DrawText(text=)
      DrawRect(top=21.62109375 left=13.0 bottom=39.49609375 right=213.0 border_color=black width=2 fill_color=None)
@@ -199,7 +193,6 @@ The tab contents are light:
     >>> browser.load(focus_url)
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=white width=0 fill_color=white)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
@@ -209,7 +202,6 @@ But when we toggle to dark, it switches:
     >>> browser.toggle_dark_mode()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=black width=0 fill_color=black)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=blue)
      DrawText(text=)
      DrawText(text=Link)
@@ -240,7 +232,6 @@ It also nd also causes a painted outline:
 
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRect(top=18.0 left=13.0 bottom=76.34375 right=787.0 border_color=black width=0 fill_color=black)
      DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=blue)
      DrawText(text=)
      DrawRect(top=21.62109375 left=13.0 bottom=39.49609375 right=213.0 border_color=white width=2 fill_color=None)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -727,12 +727,12 @@ class CSSParser:
             self.i += 1
         return self.s[start:self.i]
 
-    def pair(self):
+    def pair(self, until):
         prop = self.word()
         self.whitespace()
         self.literal(":")
         self.whitespace()
-        val = self.word()
+        val = self.until_char(until)
         return prop.lower(), val
 
     def ignore_until(self, chars):
@@ -746,7 +746,7 @@ class CSSParser:
         pairs = {}
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
-                prop, val = self.pair()
+                prop, val = self.pair(";")
                 pairs[prop.lower()] = val
                 self.whitespace()
                 self.literal(";")
@@ -784,7 +784,7 @@ class CSSParser:
         assert self.word() == "media"
         self.whitespace()
         self.literal("(")
-        (prop, val) = self.pair()
+        (prop, val) = self.pair(")")
         self.whitespace()
         self.literal(")")
         return prop, val


### PR DESCRIPTION
This PR passes over the "dark mode" and "color scheme" sections. The major changes are:

- I moved the color scheme section to be right after the dark mode section so we don't have to have two copies of the browser color scheme. I thought that was likely to confuse some readers who know about `@media` rules.
- Clarified that the dark mode section has two parts, the chrome and the page contents.
- I modified `DocumentLayout.paint()` to not draw the background rectangle, instead just leaving that to `draw`. Maybe this is bad because it causes a one-frame wrong draw? I don't notice that, but if this was the underlying reason let me know and we'll do this some other way. (Can the one-frame wrong-draw still occur if the web page is shorter than the browser height?)
- I made another small change to how media queries are parsed, thinking about how the reader might want to extend their browser with more media queries.