### PR TITLE
Implement Dukpy in widgets using SharedArrayBuffers

### DIFF
--- a/infra/server.py
+++ b/infra/server.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from http import server
+
+# Based on code from https://stackoverflow.com/questions/12499171/
+class WBEServer(server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin");
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp");
+        self.send_header('Cache-Control', 'no-store, must-revalidate')
+        self.send_header('Expires', '0')
+
+        server.SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    server.test(HandlerClass=WBEServer)

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -1,0 +1,40 @@
+dukpy = {}
+$$COMMARRAY = null;
+$$READARRAY = null;
+$$FLAGARRAY = null;
+
+addEventListener("message", (e) => {
+    switch (e.data.type) {
+    case "eval":
+        dukpy = e.data.bindings;
+        let val = eval(e.data.body);
+        postMessage({"type": "return", "data": val});
+        break;
+
+    case "array":
+        $$COMMARRAY = e.data.buffer;
+        $$READARRAY = new Int32Array($$COMMARRAY, 4);
+        $$FLAGARRAY = new Int32Array($$COMMARRAY, 0, 1);
+        break;
+    }
+});
+
+
+function call_python() {
+    let args = Array.from(arguments);
+    let fn = args.shift();
+    postMessage({
+        "type": "call",
+        "fn": fn,
+        "args": args,
+    });
+    Atomics.wait($$FLAGARRAY, 0, 0);
+    let len = $$FLAGARRAY[0];
+    Atomics.store($$FLAGARRAY, 0, 0);
+    let buffer = new Uint8Array(len);
+    for (let i = 0; i < buffer.length; i++) {
+        buffer[i] = $$READARRAY[i];
+    }
+    let result = JSON.parse(new TextDecoder().decode(buffer));
+    return result;
+}


### PR DESCRIPTION
This PR implements a mock `dukpy` module for our online widgets. It is pretty tricky, but it works like a dream:

```
> i = dukpy.JSInterpreter()
> i.export_function("ret1", function() { return 1; });
> await i.evaljs("call_python('ret1')")
1
```

Here's how it works. When a `JSInterpreter` is created, it spawns a `Worker` (running the code in `dukpy.js`) and a `SharedArrayBuffer` that it shares with the worker. Every `evaljs` call sends a message to the worker with the code, which then `eval`s it and sends a `postMessage` back with the result. So this works pretty much how you'd expect it to. However, `call_python` is trickier. When a worker runs `call_python`, it sends a `postMessage` to the main thread with the function it wants to run and the arguments it wants to run it with. It then immediately waits on the first dword of the SAB using `Atomics.wait`. This effectively pauses the thread until awoken by the main thread. The main thread, at some point, receives the `postMessage`, runs the function, JSON-encodes the result, writes it to the SAB (writing the length to the first dword and the JSON result to the rest of the dwords), and wakes the worker. The worker then JSON-decodes the result and returns it.

One annoying limitation is that there is a maximum length for responses. In principle, this would break a very long `querySelectorAll`. That said, right now responses are allowed to run up to 255 characters, which should be plenty for widgets. It's easy to bump if we need to.