### PR TITLE
Implement (approximation to) JS in same-origin iframes

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -19,6 +19,10 @@ Plan:
 * background-image: positioning, clipping
 
 * iframes
+  * Same-origin iframes: same interpreter, postMessage, parent
+  * Cross-origin iframes: postMessage
+
+  TODO: make all JS APIs and keyboard events properly target iframes
 
 * postMessage
 

--- a/src/example15-img.js
+++ b/src/example15-img.js
@@ -1,1 +1,1 @@
-window.parent.postMessage("hi there!", "*");
+window.parent.postMessage("This is the contents of postMessage.", "*");

--- a/src/runtime15.js
+++ b/src/runtime15.js
@@ -1,19 +1,19 @@
-console = { log: function(x) { call_python("log", x); } }
+window.console = { log: function(x) { call_python("log", x); } }
 
-document = { querySelectorAll: function(s) {
+window.document = { querySelectorAll: function(s) {
     var handles = call_python("querySelectorAll", s);
     return handles.map(function(h) { return new Node(h) });
 }}
 
-function Node(handle) { this.handle = handle; }
+window.Node = function(handle) { this.handle = handle; }
 
 Node.prototype.getAttribute = function(attr) {
     return call_python("getAttribute", this.handle, attr);
 }
 
-LISTENERS = {}
+window.LISTENERS = {}
 
-function Event(type) {
+window.Event = function(type) {
     this.type = type;
     this.do_default = true;
 }
@@ -52,22 +52,22 @@ Node.prototype.dispatchEvent = function(evt) {
     return evt.do_default;
 }
 
-SET_TIMEOUT_REQUESTS = {}
+window.SET_TIMEOUT_REQUESTS = {}
 
-function setTimeout(callback, time_delta) {
+window.setTimeout = function(callback, time_delta) {
     var handle = Object.keys(SET_TIMEOUT_REQUESTS).length;
     SET_TIMEOUT_REQUESTS[handle] = callback;
     call_python("setTimeout", handle, time_delta)
 }
 
-function __runSetTimeout(handle) {
+window.__runSetTimeout = function(handle) {
     var callback = SET_TIMEOUT_REQUESTS[handle]
     callback();
 }
 
-XHR_REQUESTS = {}
+window.XHR_REQUESTS = {}
 
-function XMLHttpRequest() {
+window.XMLHttpRequest = function() {
     this.handle = Object.keys(XHR_REQUESTS).length;
     XHR_REQUESTS[this.handle] = this;
 }
@@ -83,7 +83,7 @@ XMLHttpRequest.prototype.send = function(body) {
         this.method, this.url, this.body, this.is_async, this.handle);
 }
 
-function __runXHROnload(body, handle) {
+window.__runXHROnload = function(body, handle) {
     var obj = XHR_REQUESTS[handle];
     var evt = new Event('load');
     obj.responseText = body;
@@ -91,19 +91,19 @@ function __runXHROnload(body, handle) {
         obj.onload(evt);
 }
 
-function Date() {}
+window.Date = function() {}
 Date.now = function() {
     return call_python("now");
 }
 
-RAF_LISTENERS = [];
+window.RAF_LISTENERS = [];
 
-function requestAnimationFrame(fn) {
+window.requestAnimationFrame = function(fn) {
     RAF_LISTENERS.push(fn);
     call_python("requestAnimationFrame");
 }
 
-function __runRAFHandlers() {
+window.__runRAFHandlers = function() {
     var handlers_copy = [];
     for (var i = 0; i < RAF_LISTENERS.length; i++) {
         handlers_copy.push(RAF_LISTENERS[i]);
@@ -113,28 +113,12 @@ function __runRAFHandlers() {
         handlers_copy[i]();
     }
 }
-if (typeof global === 'undefined') {
-    (function () {
-        var global = new Function('return this;')();
-        Object.defineProperty(global, 'window', {
-            value: global,
-            writable: true,
-            enumerable: false,
-            configurable: true
-        });
-        global = window;
-    })();
-}
 
-WINDOW_LISTENERS = {}
+window.WINDOW_LISTENERS = {}
 
-function PostMessageEvent(data) {
+window.PostMessageEvent = function(data) {
     this.type = "message";
     this.data = data;
-}
-
-function Window(handle) {
-    this.handle = handle;
 }
 
 Window.prototype.postMessage = function(message, domain) {
@@ -146,7 +130,7 @@ Window.prototype.addEventListener = function(type, listener) {
     var dict = WINDOW_LISTENERS[this.handle];
     if (!dict[type]) dict[type] = [];
     var list = dict[type];
-    list.push(listener);
+    list.push({listener: listener, window: window});
 }
 
 Window.prototype.dispatchEvent = function(evt) {
@@ -159,14 +143,13 @@ Window.prototype.dispatchEvent = function(evt) {
     return evt.do_default;
 }
 
-window = new Window(0)
-
-Object.defineProperty(window, 'parent', {
+Object.defineProperty(Window.prototype, 'parent', {
   enumerable: true,
   configurable: true,
   get: function() {
     handle = call_python('parent');
-    return new Window(handle);
+    console.log('handle: ' + handle)
+    return eval(handle);
   }
 });
 

--- a/src/runtime15.js
+++ b/src/runtime15.js
@@ -57,7 +57,7 @@ window.SET_TIMEOUT_REQUESTS = {}
 window.setTimeout = function(callback, time_delta) {
     var handle = Object.keys(SET_TIMEOUT_REQUESTS).length;
     SET_TIMEOUT_REQUESTS[handle] = callback;
-    call_python("setTimeout", handle, time_delta)
+    call_python("setTimeout", handle, time_delta, self._id)
 }
 
 window.__runSetTimeout = function(handle) {
@@ -73,14 +73,15 @@ window.XMLHttpRequest = function() {
 }
 
 XMLHttpRequest.prototype.open = function(method, url, is_async) {
-    this.is_async = is_async
+    this.is_async = is_async;
     this.method = method;
     this.url = url;
 }
 
 XMLHttpRequest.prototype.send = function(body) {
     this.responseText = call_python("XMLHttpRequest_send",
-        this.method, this.url, this.body, this.is_async, this.handle);
+        this.method, this.url, this.body, this.is_async, this.handle,
+        window._id);
 }
 
 window.__runXHROnload = function(body, handle) {


### PR DESCRIPTION
Same-origin iframes share their JS interpreter and can synchronously script each other. However, they have separate global objects and prototype chains. Supporting this correctly requires a JS interpreter with more features than `dukpy`, so I've approximated it as follows:

* Make a new `Window` object for each iframe created. Store it in `window_N` for the Nth iframe created (or 0 for the root document.
* Change `runtime15.js` to store object instances inside of the `Window` object for the corresponding iframe
* Wrap all JS evals with setting the global `window` object symbol to `window_N and then using the `with` operator to inject it into the scope eval chain
* Use a window id (the number) as the handle for a window when performing JS<->Python communication related to windows. (e.g. for implementing `window.parent` or `window.postMessage`

TODO: event dispatching is still not working, debug.
TODO: test all code from prior chapters to make sure it's still working.