### PR TITLE
Get Chapter 9 compiling and running in a widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ www/blog/*.html
 www/onepage/*.html
 www/widgets/lab*.js
 www/widgets/server*.js
-www/widgets/lab*-browser.html
 www/widgets/rt-module.js
 www/rss.xml
 www/examples/*

--- a/Makefile
+++ b/Makefile
@@ -66,18 +66,15 @@ wc:
 	@ printf " Words  Code  File\n"; awk -f infra/wc.awk book/*.md | sort -rn
 
 publish:
-	rsync -rtu --exclude=*.pickle --exclude=*.hash www/ server:/home/www/browseng/
+	rsync -rtu --exclude=db.json --exclude=*.hash www/ server:/home/www/browseng/
 	ssh server chmod -Rf a+r /home/www/browseng/ || true
 
 restart:
 	rsync infra/api.py server:/home/www/browseng/
 	ssh server sudo systemctl restart browser-engineering.service
 
-download:
-	rsync -r 'server:/home/www/browseng/*.pickle' www/
-
 backup:
-	rsync server:/home/www/browseng/db.pickle infra/db.$(shell date +%Y-%m-%d).pickle
+	rsync server:/home/www/browseng/db.json infra/db.$(shell date +%Y-%m-%d).pickle
 
 test:
 	python3 -m doctest infra/compiler.md

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,9 @@ backup:
 	rsync server:/home/www/browseng/db.pickle infra/db.$(shell date +%Y-%m-%d).pickle
 
 test:
+	python3 -m doctest infra/compiler.md
+	python3 -m doctest infra/annotate_code.md
 	set -e; \
 	for i in $$(seq 1 14); do \
 		(cd src/ && PYTHONBREAKPOINT=0 python3 -m doctest lab$$i-tests.md); \
 	done
-	python3 -m doctest infra/compiler.md
-	python3 -m doctest infra/annotate_code.md

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,19 @@ EXAMPLE_CSS=$(patsubst src/example%.css,%,$(wildcard src/example*.css))
 
 book: $(patsubst %,www/%.html,$(CHAPTERS)) www/rss.xml widgets examples
 draft: $(patsubst %,www/draft/%.html,$(CHAPTERS)) www/onepage.html widgets
-widgets: $(patsubst lab%,www/widgets/lab%-browser.html,$(WIDGET_LAB_CODE)) $(patsubst lab%,www/widgets/lab%.js,$(WIDGET_LAB_CODE))
 examples: $(patsubst %,www/examples/example%.html,$(EXAMPLE_HTML)) \
 	$(patsubst %,www/examples/example%.js,$(EXAMPLE_JS)) \
 	$(patsubst %,www/examples/example%.css,$(EXAMPLE_CSS))
+
+widgets: \
+	www/widgets/lab2-browser.html www/widgets/lab2.js \
+	www/widgets/lab3-browser.html www/widgets/lab3.js \
+	www/widgets/lab4-browser.html www/widgets/lab4.js \
+	www/widgets/lab5-browser.html www/widgets/lab5.js \
+	www/widgets/lab6-browser.html www/widgets/lab6.js \
+	www/widgets/lab7-browser.html www/widgets/lab7.js \
+	www/widgets/lab8-browser.html www/widgets/lab8.js www/widgets/server8.js \
+	www/widgets/lab9-browser.html www/widgets/lab9.js www/widgets/server9.js
 
 lint: book/*.md src/*.py
 	python3 infra/compare.py --config config.json
@@ -36,9 +45,6 @@ www/widgets/lab%.js: src/lab%.py src/lab%.hints infra/compile.py
 
 www/widgets/server%.js: src/server%.py src/server%.hints infra/compile.py
 	python3 infra/compile.py $< $@ --hints src/server$*.hints --use-js-modules
-
-www/widgets/lab%-browser.html: infra/labN-browser.html infra/labN-browser.lua config.json www/widgets/lab%.js
-	pandoc --lua-filter=infra/labN-browser.lua --metadata-file=config.json --metadata chapter=$* --template $< book/index.md -o $@
 
 www/examples/%.html: src/%.html
 	cp $< www/examples

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -504,7 +504,7 @@ exist yet:
 class JSContext:
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle.keys())
+            handle = len(self.node_to_handle)
             self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt
         else:

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -504,7 +504,7 @@ exist yet:
 class JSContext:
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle)
+            handle = len(self.node_to_handle.keys())
             self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt
         else:

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1136,6 +1136,12 @@ The server's outline is unchanged from the last chapter:
     python3 infra/outlines.py --html src/server9.py
 :::
 
+If you run it, it should look something like this:
+
+::: {.widget height=691}
+    lab9-browser.html
+:::
+
 Exercises
 =========
 

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -764,7 +764,7 @@ def compile(tree, ctx, indent=0):
     else:
         raise UnsupportedConstruct()
     
-def compile_module(tree, name, use_js_modules):
+def compile_module(tree, use_js_modules):
     assert isinstance(tree, ast.Module)
     ctx = Context("module", {})
 
@@ -815,7 +815,7 @@ if __name__ == "__main__":
     INDENT = args.indent
     tree = asttools.parse(args.python.read(), args.python.name)
     load_outline(asttools.inline(tree))
-    js = compile_module(tree, name[:-len(".py")], args.use_js_modules)
+    js = compile_module(tree, args.use_js_modules)
 
     for fn in FILES:
         path = os.path.join(os.path.dirname(args.python.name), fn)

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -753,7 +753,7 @@ def compile(tree, ctx, indent=0):
         val = compile_expr(item.context_expr, ctx)
         out = " " * indent + "let " + var + " = " + val + ";\n"
         out += "\n".join([compile(line, indent=indent, ctx=ctx) for line in tree.body]) + "\n"
-        out += " " * indent + var + ".close();\n"
+        out += " " * indent + var + ".close();"
         return out
     elif isinstance(tree, ast.Continue):
         return " " * indent + "continue;"

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -698,7 +698,7 @@ def compile(tree, ctx, indent=0):
             intros = set.intersection(*[set(ctx2) for ctx2 in ctxs]) - set(ctx)
             if intros:
                 for name in intros: ctx[name] =   {"is_class": False}
-                out += "let " + ",".join(intros) + ";\n" + " " * indent
+                out += "let " + ",".join(sorted(intros)) + ";\n" + " " * indent
 
             for i, (test, body) in enumerate(parts):
                 ctx2 = Context(ctx.type, ctx)
@@ -781,7 +781,7 @@ def compile_module(tree, name, use_js_modules):
 
         rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'asyncfilter', 'pysplit', 'pyrsplit', 'truthy' ]
         rt_imports_arr += set([ mod.split(".")[0] for mod in RT_IMPORTS])
-        rt_imports = imports_str.format(", ".join(rt_imports_arr), "rt")
+        rt_imports = imports_str.format(", ".join(sorted(rt_imports_arr)), "rt")
 
         constants_export = "export " + constants_export
 

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -747,12 +747,13 @@ def compile(tree, ctx, indent=0):
         assert not tree.type_comment
         assert len(tree.items) == 1
         item = tree.items[0]
-        var = item.optional_vars if item.optional_vars else ast.Name("_ctx")
-        assert isinstance(var, ast.Name)
-        out = compile(ast.Assign([var], item.context_expr), indent=indent, ctx=ctx) + "\n"
+        if item.optional_vars:
+            assert isinstance(item.optional_vars, ast.Name)
+        var = compile_lhs(item.optional_vars if item.optional_vars else ast.Name("_ctx"), ctx)
+        val = compile_expr(item.context_expr, ctx)
+        out = " " * indent + "let " + var + " = " + val + ";\n"
         out += "\n".join([compile(line, indent=indent, ctx=ctx) for line in tree.body]) + "\n"
-        out += compile(ast.Expr(ast.Call(ast.Attribute(var, "close"), [], [])),
-                       indent=indent, ctx=ctx)
+        out += " " * indent + var + ".close();\n"
         return out
     elif isinstance(tree, ast.Continue):
         return " " * indent + "continue;"

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -486,8 +486,8 @@ def compile_expr(tree, ctx):
             out = "(await asyncfilter(async (" + arg + ") => " + e + ", " + out + "))"
         e = compile_expr(tree.elt, ctx2)
         if e != arg:
-            out += ".map(async (" + arg + ") => " + e + ")"
-        return "(await Promise.all(" + out + "))"
+            out = "(await Promise.all(" + out + ".map(async (" + arg + ") => " + e + ")))"
+        return out
     elif isinstance(tree, ast.Attribute):
         base = compile_expr(tree.value, ctx)
         return base + "." + tree.attr

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -407,7 +407,7 @@ The `with` statement in Python has no analog in JS (which also has a
 compile it into `open` and `close` statements:
 
     >>> Test.stmt("with open('browser.css') as f:\n f.read()")
-    f = (filesystem.open("browser.css"));
+    let f = (filesystem.open("browser.css"));
     (f.read());
     f.close();
 

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -409,7 +409,7 @@ compile it into `open` and `close` statements:
     >>> Test.stmt("with open('browser.css') as f:\n f.read()")
     f = (filesystem.open("browser.css"));
     (f.read());
-    (f.close());
+    f.close();
 
 But `if` statements are weird. First, there's the top-level `if`
 statement, which we elide. But then also there are one-line `if`

--- a/src/comment9.css
+++ b/src/comment9.css
@@ -1,1 +1,1 @@
-#errors { font-weight: bold; color: red; }
+label { font-weight: bold; color: red; }

--- a/src/lab9.hints
+++ b/src/lab9.hints
@@ -4,5 +4,10 @@
  {"code": "'name' in node.attributes", "type": "dict"},
  {"code": "print", "js": "console.log"},
  {"code": "'src' in node.attributes", "type": "dict"},
- {"code": "elt not in self.node_to_handle", "type": "dict"}
+ {"code": "elt not in self.node_to_handle", "js": "!this.node_to_handle.has(elt)"},
+ {"code": "self.node_to_handle = {}", "js": "    this.node_to_handle = new Map();"},
+ {"code": "self.node_to_handle.get(elt, -1)", "js": "this.node_to_handle.get(elt) ?? -1"},
+ {"code": "self.node_to_handle[elt]", "js": "this.node_to_handle.get(elt)"},
+ {"code": "len(self.node_to_handle.keys())", "js": "this.node_to_handle.size"},
+ {"code": "self.node_to_handle[elt] = handle", "js": "      this.node_to_handle.set(elt, handle);"}
 ]

--- a/src/lab9.hints
+++ b/src/lab9.hints
@@ -8,6 +8,6 @@
  {"code": "self.node_to_handle = {}", "js": "    this.node_to_handle = new Map();"},
  {"code": "self.node_to_handle.get(elt, -1)", "js": "this.node_to_handle.get(elt) ?? -1"},
  {"code": "self.node_to_handle[elt]", "js": "this.node_to_handle.get(elt)"},
- {"code": "len(self.node_to_handle.keys())", "js": "this.node_to_handle.size"},
+ {"code": "len(self.node_to_handle)", "js": "this.node_to_handle.size"},
  {"code": "self.node_to_handle[elt] = handle", "js": "      this.node_to_handle.set(elt, handle);"}
 ]

--- a/src/lab9.hints
+++ b/src/lab9.hints
@@ -1,0 +1,8 @@
+[{"code": "'href' in node.attributes", "type": "dict"},
+ {"code": "'action' in elt.attributes", "type": "dict"},
+ {"code": "'href' in elt.attributes", "type": "dict"},
+ {"code": "'name' in node.attributes", "type": "dict"},
+ {"code": "print", "js": "console.log"},
+ {"code": "'src' in node.attributes", "type": "dict"},
+ {"code": "elt not in self.node_to_handle", "type": "dict"}
+]

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -50,7 +50,7 @@ class JSContext:
 
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle)
+            handle = len(self.node_to_handle.keys())
             self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt
         else:

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -50,7 +50,7 @@ class JSContext:
 
     def get_handle(self, elt):
         if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle.keys())
+            handle = len(self.node_to_handle)
             self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt
         else:

--- a/src/server8.hints
+++ b/src/server8.hints
@@ -1,5 +1,4 @@
 [
   {"code": "'content-length' in headers", "type": "dict"},
-  {"code": "'guest' in params", "type": "dict"},
-  {"code": "conx.makefile('b')", "js": "await conx.makefile('b')"}
+  {"code": "'guest' in params", "type": "dict"}
 ]

--- a/src/server9.hints
+++ b/src/server9.hints
@@ -1,5 +1,4 @@
 [
   {"code": "'content-length' in headers", "type": "dict"},
-  {"code": "'guest' in params", "type": "dict"},
-  {"code": "conx.makefile('b')", "js": "await conx.makefile('b')"}
+  {"code": "'guest' in params", "type": "dict"}
 ]

--- a/src/server9.hints
+++ b/src/server9.hints
@@ -1,0 +1,5 @@
+[
+  {"code": "'content-length' in headers", "type": "dict"},
+  {"code": "'guest' in params", "type": "dict"},
+  {"code": "conx.makefile('b')", "js": "await conx.makefile('b')"}
+]

--- a/src/server9.py
+++ b/src/server9.py
@@ -7,8 +7,8 @@ def handle_connection(conx):
     method, url, version = reqline.split(" ", 2)
     assert method in ["GET", "POST"]
     headers = {}
-    for line in req:
-        line = line.decode('utf8')
+    while True:
+        line = req.readline().decode('utf8')
         if line == '\r\n': break
         header, value = line.split(":", 1)
         headers[header.lower()] = value.strip()

--- a/src/server9.py
+++ b/src/server9.py
@@ -58,7 +58,7 @@ def show_comments():
     out += "</form>"
     for entry in ENTRIES:
         out += "<p>" + entry + "</p>"
-    out += "<link rel=stylesheet src=/comment.css>"
+    out += "<link rel=stylesheet href=/comment.css>"
     out += "<label></label>"
     out += "<script src=/comment.js></script>"
     return out

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -8,6 +8,7 @@ addEventListener("message", (e) => {
     case "eval":
         dukpy = e.data.bindings;
         let val = eval(e.data.body);
+        if (val instanceof Function) val = null;
         postMessage({"type": "return", "data": val});
         break;
 

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -2,14 +2,18 @@ dukpy = {}
 $$COMMARRAY = null;
 $$READARRAY = null;
 $$FLAGARRAY = null;
+$$CONSOLE = console;
+$$POSTMESSAGE = postMessage;
+
+$$SCOPE = {};
 
 addEventListener("message", (e) => {
     switch (e.data.type) {
     case "eval":
         dukpy = e.data.bindings;
-        let val = eval(e.data.body);
+        let val = eval?.(e.data.body);
         if (val instanceof Function) val = null;
-        postMessage({"type": "return", "data": val});
+        $$POSTMESSAGE({"type": "return", "data": val});
         break;
 
     case "array":
@@ -24,7 +28,7 @@ addEventListener("message", (e) => {
 function call_python() {
     let args = Array.from(arguments);
     let fn = args.shift();
-    postMessage({
+    $$POSTMESSAGE({
         "type": "call",
         "fn": fn,
         "args": args,

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -36,10 +36,12 @@ function call_python() {
     Atomics.wait($$FLAGARRAY, 0, 0);
     let len = $$FLAGARRAY[0];
     Atomics.store($$FLAGARRAY, 0, 0);
-    let buffer = new Uint8Array(len);
-    for (let i = 0; i < buffer.length; i++) {
-        buffer[i] = $$READARRAY[i];
+    if (len > 0) {
+        let buffer = new Uint8Array(len);
+        for (let i = 0; i < buffer.length; i++) {
+            buffer[i] = $$READARRAY[i];
+        }
+        let result = JSON.parse(new TextDecoder().decode(buffer));
+        return result;
     }
-    let result = JSON.parse(new TextDecoder().decode(buffer));
-    return result;
 }

--- a/www/widgets/lab2-browser.html
+++ b/www/widgets/lab2-browser.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 2 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://browser.engineering/<input id="input" class="continue" type="url" value="graphics.html" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab2.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab2.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://browser.engineering/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab3-browser.html
+++ b/www/widgets/lab3-browser.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 3 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://browser.engineering/<input id="input" class="continue" type="url" value="text.html" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab3.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab3.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://browser.engineering/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab4-browser.html
+++ b/www/widgets/lab4-browser.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 4 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://browser.engineering/<input id="input" class="continue" type="url" value="html.html" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab4.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab4.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://browser.engineering/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab5-browser.html
+++ b/www/widgets/lab5-browser.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 5 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://browser.engineering/<input id="input" class="continue" type="url" value="layout.html" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab5.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab5.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://browser.engineering/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab6-browser.html
+++ b/www/widgets/lab6-browser.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 6 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://browser.engineering/<input id="input" class="continue" type="url" value="styles.html" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab6.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab6.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://browser.engineering/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab7-browser.html
+++ b/www/widgets/lab7-browser.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 7 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://browser.engineering/<input id="input" class="continue" type="url" value="chrome.html" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab7.js"></script>
+<script type="module">
+import { rt_constants, Widget } from "./rt.js";
+import { Browser, constants } from "./lab7.js";
+
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://browser.engineering/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab8-browser.html
+++ b/www/widgets/lab8-browser.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 8 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://localhost:8000/<input id="input" class="continue" type="url" value="" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab8.js"></script>
+<script type="module">
+import { rt_constants, socket, Widget } from "./rt.js";
+import { Browser, constants } from "./lab8.js";
+import { handle_connection } from "./server8.js";
+
+socket.accept(8000, handle_connection);
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://localhost:8000/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>

--- a/www/widgets/lab9-browser.html
+++ b/www/widgets/lab9-browser.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="widget.css" />
+
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>The Chapter 9 Browser</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepf right"><span>Go</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <kbd>https://localhost:8000/<input id="input" class="continue" type="url" value="" /></kbd>
+  </fieldset>
+</form>
+<figure id="widget">
+  <canvas id="canvas" width="352" height="160"></canvas>
+</figure>
+
+<script type="module" src="rt.js"></script>
+<script type="module" src="lab9.js"></script>
+<script type="module">
+import { rt_constants, socket, Widget } from "./rt.js";
+import { Browser, constants } from "./lab9.js";
+import { handle_connection } from "./server9.js";
+
+socket.accept(8000, handle_connection);
+rt_constants.TKELEMENT = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "https://localhost:8000/" + document.getElementById("input").value;
+    let b = await (new Browser()).init();
+    await b.load(url)
+});
+widget.next();
+</script>


### PR DESCRIPTION
Getting Chapter 9 running required a bunch of changes throughout the compiler, including some small bug fixes and also:

- Better handling of list comprehensions, which now compile in a way that allows calling async functions
- Better support for `try`/`catch`, which now correctly checks the type of the exception
- Fix `dukpy.js` to use async handler functions
- In `dukpy.js`, save a private copy of `console` and `postMessage` for when they are overwritten by the browser runtime
- Avoid accidentally returning the last-defined function from `dukpy.js`
- Using indirect eval, a truly hellish hack, in `dukpy.js` for ""reasons""