### PR TITLE
Mock Skia fonts to avoid OS issues in tests

### DIFF
--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -27,11 +27,11 @@ Opacity can be applied.
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
     saveLayer(color=80000000, alpha=128)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(0, 0), color=ff0000ff)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(0, 0), color=ff0000ff)
-    drawString(text=Text, x=13.0, y=36.10546875, color=ff000000)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
+    drawString(text=Text, x=13.0, y=33.0, color=ff000000)
     restore()
-    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
+    drawString(text=), x=13.0, y=53.0, color=ff000000)
 
 So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
 
@@ -47,17 +47,17 @@ So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
     saveLayer(color=ff000000, blend_mode=BlendMode.kMultiply)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(0, 0), color=ff0000ff)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(0, 0), color=ff0000ff)
-    drawString(text=Mult, x=13.0, y=36.10546875, color=ff000000)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
+    drawString(text=Mult, x=13.0, y=33.0, color=ff000000)
     restore()
-    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
+    drawString(text=), x=13.0, y=53.0, color=ff000000)
     saveLayer(color=ff000000, blend_mode=BlendMode.kDifference)
-    drawRRect(bounds=Rect(13, 62.6875, 787, 85.0312), radius=Point(0, 0), color=ff0000ff)
-    drawRRect(bounds=Rect(13, 62.6875, 787, 85.0312), radius=Point(0, 0), color=ff0000ff)
-    drawString(text=Diff, x=13.0, y=80.79296875, color=ff000000)
+    drawRRect(bounds=Rect(13, 58, 787, 78), radius=Point(0, 0), color=ff0000ff)
+    drawRRect(bounds=Rect(13, 58, 787, 78), radius=Point(0, 0), color=ff0000ff)
+    drawString(text=Diff, x=13.0, y=73.0, color=ff000000)
     restore()
-    drawString(text=), x=13.0, y=103.13671875, color=ff000000)
+    drawString(text=), x=13.0, y=93.0, color=ff000000)
 
 Non-rectangular clips via `clip-path:circle` are supported.
 
@@ -77,13 +77,13 @@ make a canvas in which to draw the circular clip mask.
     clear(color=ffffffff)
     saveLayer(color=ff000000)
     save()
-    clipRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(5, 5))
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(5, 5), color=ff0000ff)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(0, 0), color=ff0000ff)
-    drawString(text=Clip, x=13.0, y=36.10546875, color=ff000000)
+    clipRRect(bounds=Rect(13, 18, 787, 38), radius=Point(5, 5))
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(5, 5), color=ff0000ff)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
+    drawString(text=Clip, x=13.0, y=33.0, color=ff000000)
     restore()
     restore()
-    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
+    drawString(text=), x=13.0, y=53.0, color=ff000000)
 
 `border-radius` clipping is also supported, but if `overflow:clip` is not
 present, then just the the background is clipped by using `drawRRect`.
@@ -102,10 +102,10 @@ radius equal to the `20px` radius specified above.
     >>> browser.load(size_and_border_radius_url)
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(11.1719, 11.1719), color=ff0000ff)
-    drawRRect(bounds=Rect(13, 18, 787, 40.3438), radius=Point(0, 0), color=ff0000ff)
-    drawString(text=Border-radius, x=13.0, y=36.10546875, color=ff000000)
-    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(10, 10), color=ff0000ff)
+    drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
+    drawString(text=Border-radius, x=13.0, y=33.0, color=ff000000)
+    drawString(text=), x=13.0, y=53.0, color=ff000000)
 
 Testing example compositing and blending functions
 ==================================================

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -44,7 +44,7 @@ Once the Tab has loaded, the browser should need raster and draw.
 The Tab has already committed:
 
 	>>> browser.active_tab_height
-	81
+	76
     >>> len(browser.active_tab_display_list)
     1
 
@@ -59,8 +59,8 @@ After performing raster and draw, the display list should be present.
     >>> browser.raster_and_draw()
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
-    drawString(text=Text, x=13.0, y=36.10546875, color=ff000000)
-    drawString(text=), x=13.0, y=58.44921875, color=ff000000)
+    drawString(text=Text, x=13.0, y=33.0, color=ff000000)
+    drawString(text=), x=13.0, y=53.0, color=ff000000)
 
     >>> browser.needs_raster_and_draw
     False

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -66,7 +66,7 @@ Focus
 On load, nothing is focused:
 
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
 
@@ -78,21 +78,21 @@ But pressing `tab` will focus first the `input` and then the `a` element.
 The 2px wide black display list command is the focus ring for the `input`:
 
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
-     DrawRect(top=21.62109375 left=13.0 bottom=39.49609375 right=213.0 border_color=black width=2 fill_color=None)
+     DrawRect(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=black width=2 fill_color=None)
      DrawText(text=Link)
-     DrawLine top=21.62109375 left=13.0 bottom=39.49609375 right=13.0
+     DrawLine top=21.0 left=13.0 bottom=37.0 right=13.0
 
 And now it's for the `a`:
 
     >>> browser.handle_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
-     DrawRect(top=21.62109375 left=217.0 bottom=39.49609375 right=247.0 border_color=black width=2 fill_color=None)
+     DrawRect(top=21.0 left=229.0 bottom=37.0 right=293.0 border_color=black width=2 fill_color=None)
 
 Tabindex changes the order:
 
@@ -110,21 +110,21 @@ This time the `a` element is focused first:
     >>> browser.handle_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
-     DrawRect(top=21.62109375 left=217.0 bottom=39.49609375 right=247.0 border_color=black width=2 fill_color=None)
+     DrawRect(top=21.0 left=229.0 bottom=37.0 right=293.0 border_color=black width=2 fill_color=None)
 
 And then the `input`:
 
     >>> browser.handle_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
-     DrawRect(top=21.62109375 left=13.0 bottom=39.49609375 right=213.0 border_color=black width=2 fill_color=None)
+     DrawRect(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=black width=2 fill_color=None)
      DrawText(text=Link)
-     DrawLine top=21.62109375 left=13.0 bottom=39.49609375 right=13.0
+     DrawLine top=21.0 left=13.0 bottom=37.0 right=13.0
 
 Regular elements aren't focusable, but if the `tabindex` attribute is set, they
 are:
@@ -195,7 +195,7 @@ The tab contents are light:
     >>> browser.load(focus_url)
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=lightblue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
 
@@ -204,7 +204,7 @@ But when we toggle to dark, it switches:
     >>> browser.toggle_dark_mode()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=blue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=blue)
      DrawText(text=)
      DrawText(text=Link)
 
@@ -234,8 +234,8 @@ It also nd also causes a painted outline:
 
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawRRect(rect=RRect(13, 21.6211, 213, 39.4961, 1), color=blue)
+     DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=blue)
      DrawText(text=)
-     DrawRect(top=21.62109375 left=13.0 bottom=39.49609375 right=213.0 border_color=white width=2 fill_color=None)
+     DrawRect(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=white width=2 fill_color=None)
      DrawText(text=Link)
-     DrawLine top=21.62109375 left=13.0 bottom=39.49609375 right=13.0
+     DrawLine top=21.0 left=13.0 bottom=37.0 right=13.0

--- a/src/test11.py
+++ b/src/test11.py
@@ -114,6 +114,24 @@ class MockSkiaImage:
     def tobytes(self):
         return ""
 
+class MockFont:
+    def __init__(self, typeface, size):
+        self.size = size
+        self.typeface = typeface
+
+    def measureText(self, word):
+        return self.size * len(word)
+
+    def getMetrics(self, name=None):
+        m = skia.FontMetrics()
+        m.fAscent = -self.size * .75
+        m.fDescent = self.size * .25
+        return m
+
+    def __repr__(self):
+        return "Font size={} weight={} slant={} style={}".format(
+            self.size, self.weight, self.slant, self.style)
+
 class MockCanvas:
     def __init__(self):
         self.commands = []
@@ -236,3 +254,4 @@ class MockSkiaSurface:
         pass
 
 skia.Surface = MockSkiaSurface
+skia.Font = MockFont


### PR DESCRIPTION
This PR makes recent chapters (11+) use a mock font during testing. This matters because otherwise two chapter 12 tests fail on my machine. It's surprising that this never lead to issues before, but fixing it did mean adjusting several previous chapters as well.