### PR TITLE
Add support for cross-origin ifames

### DIFF
--- a/src/runtime15.js
+++ b/src/runtime15.js
@@ -152,8 +152,15 @@ Object.defineProperty(Window.prototype, 'parent', {
   get: function() {
     handle = call_python('parent', window._id);
     if (handle != undefined) {
-        target_window = eval("window_" + handle);
-        return target_window
+        try {
+            target_window = eval("window_" + handle);
+            // Same-origin
+            return target_window;
+        } catch (e) {
+            // Cross-origin
+            return new Window(handle)
+        }
+
     }
     return undefined;
   }


### PR DESCRIPTION
Notes:

* move various pieces of logic into `Tab` instead of `JSContext` or `Document` because not every document has the same JS interpreter, and we therefore need to map from document id to document at the tab level.
* Uses a try/catch with eval to detect cross-origin when finding `window.parent`