### PR TITLE
Pass over the accessibility tree section

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1450,7 +1450,7 @@ talk, specifically the segment from 2:36--3:54:[^whole-talk]
     Narrator. Both are largely used via keyboard shortcuts that you
     can look up.
     
-To support all this, browers structure the page as a tree and use that
+To support all this, browsers structure the page as a tree and use that
 tree to interact with the screen reader. The higher levels of the tree
 represent items like paragraphs, headings, or navigation menus, while
 lower levels represent text, links, or buttons.

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1411,13 +1411,13 @@ original motivation of screen readers was for blind users, but it's
 also sometimes useful for situations where the user shouldn't be
 looking at the screen (such as driving), or for devices with no
 screen.] screen-reader software is typically used instead. The name
-kind of explains it all: screen-reader software reads the text on the
-screen, so that users know what it says without having to see it.
+kind of explains it all: this software reads the text on the screen
+out loud, so that users know what it says without having to see it.
 
 So: what should we say to the user? There are basically two big
 challenges we must overcome.
 
-First, web pages contain visual hints besides text, that we need to
+First, web pages contain visual hints besides text that we need to
 reproduce for screen-reader users. For example, when focus is on an
 `<input>` or `<button>` element, the screen-reader needs to say so,
 since these users won't see the light blue or orange background.
@@ -1431,17 +1431,17 @@ of interest to them, they may want it read to them, and if some
 sentence or phrase is particularly complex, they may want the
 screen-reader to re-read it.
 
-You see an example[^imagine] of screen-reader navigation in this talk,
-specifically the segment from 2:36--3:54:[^whole-talk]
+You can see an example[^imagine] of screen-reader navigation in this
+talk, specifically the segment from 2:36--3:54:[^whole-talk]
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/qi0tY60Hd6M?start=159" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 [^whole-talk]: The whole talk is recommended; it has great examples of
     using accessibility technology.
 
-[^fast]: Though though many people who rely on screen-readers learn to
-    listen to *much* faster speech, it's still a less informationally
-    dense medium than vision.
+[^fast]: Though many people who rely on screen-readers learn to listen
+    to *much* faster speech, it's still a less informationally dense
+    medium than vision.
 
 [^imagine] I encourage you to test out your operating system's
     built-in screen reader to get a feel for what screen-reader
@@ -1450,10 +1450,10 @@ specifically the segment from 2:36--3:54:[^whole-talk]
     Narrator. Both are largely used via keyboard shortcuts that you
     can look up.
     
-To support all this, screen readers structure the page as a tree. The
-higher levels of the tree represent items like paragraphs, headings,
-or navigation menus, while lower levels represent text, links, or
-buttons.
+To support all this, browers structure the page as a tree and use that
+tree to interact with the screen reader. The higher levels of the tree
+represent items like paragraphs, headings, or navigation menus, while
+lower levels represent text, links, or buttons.
 
 This probably sounds a lot like HTML---and it is quite similar! But,
 just like the HTML tree does not exactly match the layout tree,
@@ -1470,7 +1470,8 @@ screen-reader users. The browser therefore builds a separate
 several other ways in real browsers that elements can be made
 invisible, such as with the `visibility` or `display` CSS properties.
 
-The accessibility tree is built in a rendering phase just after layout:
+Let's implement an accessibility tree in our browser. It is built in a
+rendering phase just after layout:
 
 ``` {.python}
 class Tab:
@@ -1546,7 +1547,8 @@ class AccessibilityNode:
 ```
 
 To build the accessibility tree, we just recursively walk the HTML
-tree, adding all nodes whose role isn't `none`:
+tree. As we do so, we skip nodes like `<div>`s whose role is `none`,
+but not their children:
 
 ``` {.python}
 class AccessibilityNode:
@@ -1565,7 +1567,7 @@ class AccessibilityNode:
             parent.build_internal(child_node)
 ```
 
-The user can now direct the screen-reader to walks up or down this
+The user can now direct the screen-reader to walk up or down this
 accessibility tree and speak the text at any of the leaves
 
 Using the accessibility tree
@@ -1638,8 +1640,8 @@ standard output.
 
 :::
 
-To start with, we'll want a keybinding that turns the screen-reader on
-and off. While real operating systems typically use more obscure
+To start with, we'll want a key binding that turns the screen-reader
+on and off. While real operating systems typically use more obscure
 shortcuts, I'll use `Ctrl-A` to turn on the screen-reader:
 
 ``` {.python}
@@ -1671,7 +1673,7 @@ class Browser:
 ```
 
 The `Tab`, in turn, executes the `speak_task` method if accessibility
-is on, which is actually produce sound:
+is on, which is what actually produces sound:
 
 ``` {.python}
 class Tab:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -548,6 +548,9 @@ def is_focusable(node):
         return True
     else:
         return node.tag in ["input", "button", "a"]
+    
+def compute_role(node):
+    return AccessibilityNode(node).role
 
 def announce_text(node):
     role = compute_role(node)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -7,9 +7,9 @@ without exercises.
 import ctypes
 import dukpy
 import io
-import gtts
 import math
 import os
+import gtts
 import playsound
 import sdl2
 import skia
@@ -549,32 +549,6 @@ def is_focusable(node):
     else:
         return node.tag in ["input", "button", "a"]
 
-def compute_role(node):
-    if isinstance(node, Text):
-        if node.parent.tag == "a":
-            return "link"
-        elif compute_role(node.parent)  == "textbox":
-            return "none"
-        elif is_focusable(node.parent):
-            return "focusable text"
-        else:
-            return "StaticText"
-    else:
-        if node.tag == "a":
-            return "link"
-        elif node.tag == "input":
-            return "textbox"
-        elif node.tag == "button":
-            return "button"
-        elif node.tag == "html":
-            return "document"
-        elif "role" in node.attributes:
-            return node.attributes["role"]
-        elif is_focusable(node):
-            return "focusable"
-        else:
-            return "none"
-
 def announce_text(node):
     role = compute_role(node)
     text = ""
@@ -607,19 +581,42 @@ class AccessibilityNode:
         self.previous = None
         self.children = []
 
+        if isinstance(node, Text):
+            if node.parent.tag == "a":
+                self.role = "link"
+            elif is_focusable(node.parent):
+                self.role = "focusable text"
+            else:
+                self.role = "StaticText"
+        else:
+            if "role" in node.attributes:
+                self.role = node.attributes["role"]
+            elif node.tag == "a":
+                self.role = "link"
+            elif node.tag == "input":
+                self.role = "textbox"
+            elif node.tag == "button":
+                self.role = "button"
+            elif node.tag == "html":
+                self.role = "document"
+            elif is_focusable(node):
+                self.role = "focusable"
+            else:
+                self.role = "none"
+
     def build(self):
         for child_node in self.node.children:
-            AccessibilityNode.build_internal(child_node, self)
-        pass
+            self.build_internal(child_node)
 
-    def build_internal(node, parent):
-        role = compute_role(node)
-        if role != "none":
-            child = AccessibilityNode(node)
-            parent.children.append(child)
+    def build_internal(self, node):
+        child = AccessibilityNode(node)
+        if child.role != "none":
+            self.children.append(child)
             parent = child
+        else:
+            parent = self
         for child_node in node.children:
-            AccessibilityNode.build_internal(child_node, parent)
+            parent.build_internal(child_node)
 
     def intersects(self, x, y):
         if hasattr(self.node, "layout_object"):
@@ -642,7 +639,7 @@ class AccessibilityNode:
 
     def __repr__(self):
         return "AccessibilityNode(node={} role={}".format(
-            str(self.node), compute_role(self.node))
+            str(self.node), self.role)
 
 SPEECH_FILE = "/tmp/speech-fragment.mp3"
 
@@ -1153,10 +1150,8 @@ class Tab:
         if self.needs_layout:
             self.document = DocumentLayout(self.nodes)
             self.document.layout(self.zoom)
-            if self.accessibility_is_on:
-                self.needs_accessibility = True
-            else:
-                self.needs_paint = True
+            self.needs_accessibility = True
+            self.needs_paint = True
             self.needs_layout = False
 
         if self.needs_accessibility:
@@ -1165,8 +1160,9 @@ class Tab:
             self.needs_accessibility = False
             self.needs_paint = True
 
-            task = Task(self.speak_update)
-            self.task_runner.schedule_task(task)
+            if self.accessibility_is_on:
+                task = Task(self.speak_update)
+                self.task_runner.schedule_task(task)
 
         if self.pending_hover:
             if self.accessibility_tree:


### PR DESCRIPTION
This PR moves the accessibility tree section to go before we start implementing the screen reader in earnest, and makes some minor code cleanups.

I still need to pass over the "screen-reader" section, which was broken by some of these changes.