### PR TITLE
Pass on screen-reader section

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1680,14 +1680,15 @@ class Tab:
         # ...
         self.accessibility_is_on = False
 
+    def render(self):
+        if self.needs_accessibility:
+            if self.accessibility_is_on:
+                task = Task(self.speak_update)
+                self.task_runner.schedule_task(task)
+
     def toggle_accessibility(self):
         self.accessibility_is_on = not self.accessibility_is_on
         self.set_needs_render()
-
-    def render(self):
-        if self.needs_accessibility:
-            # ...
-            self.speak_task()
 ```
 
 Let's now use this code to speak the whole document once after it's been loaded:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1470,8 +1470,7 @@ screen-reader users. The browser therefore builds a separate
 several other ways in real browsers that elements can be made
 invisible, such as with the `visibility` or `display` CSS properties.
 
-Let's implement an accessibility tree in our browser. It is built in a
-rendering phase just after layout:
+The accessibility tree is built in a rendering phase just after layout:
 
 ``` {.python}
 class Tab:
@@ -1681,15 +1680,14 @@ class Tab:
         # ...
         self.accessibility_is_on = False
 
-    def render(self):
-        if self.needs_accessibility:
-            if self.accessibility_is_on:
-                task = Task(self.speak_update)
-                self.task_runner.schedule_task(task)
-
     def toggle_accessibility(self):
         self.accessibility_is_on = not self.accessibility_is_on
         self.set_needs_render()
+
+    def render(self):
+        if self.needs_accessibility:
+            # ...
+            self.speak_task()
 ```
 
 Let's now use this code to speak the whole document once after it's been loaded:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1470,7 +1470,8 @@ screen-reader users. The browser therefore builds a separate
 several other ways in real browsers that elements can be made
 invisible, such as with the `visibility` or `display` CSS properties.
 
-The accessibility tree is built in a rendering phase just after layout:
+Let's implement an accessibility tree in our browser. It is built in a
+rendering phase just after layout:
 
 ``` {.python}
 class Tab:

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -152,32 +152,41 @@ But the second one is, because it has a `tabindex` attribute.
 Accessibility
 =============
 
+Let's make it not actually make noise:
+
+    >>> lab14.speak_text = print
+
 The accessibility tree is automatically created.
 
     >>> focus_url = 'http://test.test/focus'
     >>> test.socket.respond(focus_url, b"HTTP/1.0 200 OK\r\n" +
     ... b"content-type: text/html\r\n\r\n" +
-    ... b'<input><a href="/dest">Link</a>')
+    ... b'<input value=val><a href="/dest">Link text</a>')
 
     >>> browser = lab14.Browser()
     >>> browser.load(focus_url)
     >>> browser.tabs[0].toggle_accessibility()
+    >>> browser.tabs[0].toggle_accessibility_reading()
 
 Rendering will read out the accessibility instructions:
 
     >>> browser.render()
-    Here are the document contents: 
-    Input box: 
+    >>> browser.render()
+    Web page contents
+    >>> browser.render()
+    Input box: val
+    >>> browser.render()
     Link
-    Link
+    >>> browser.render()
+    Link text
 
 From this tree:
 
     >>> lab14.print_tree(browser.tabs[0].accessibility_tree)
-     AccessibilityNode(node=<html> role=document
-       AccessibilityNode(node=<input> role=textbox
-       AccessibilityNode(node=<a href="/dest"> role=link
-         AccessibilityNode(node='Link' role=link
+     AccessibilityNode(node=<html> role=document)
+       AccessibilityNode(node=<input value="val"> role=textbox)
+       AccessibilityNode(node=<a href="/dest"> role=link)
+         AccessibilityNode(node='Link text' role=StaticText)
 
 
 Dark mode

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -621,6 +621,26 @@ class AccessibilityNode:
         for child_node in node.children:
             parent.build_internal(child_node)
 
+    def description(self):
+        text = ""
+        if self.role == "StaticText":
+            text = self.node.text
+        elif self.role == "focusable text":
+            text = "Focusable text: " + self.node.text
+        elif self.role == "textbox":
+            text = "Input box: "
+            if self.node.tag == "input":
+                text += self.node.attributes.get("value", "")
+        elif role == "button":
+            text = "Button"
+        elif role == "link":
+            text = "Link"
+        elif role == "alert":
+            text = "Alert"
+        if is_focused(node):
+            text = "Focused " + text
+        return text
+
     def intersects(self, x, y):
         if hasattr(self.node, "layout_object"):
             obj = self.node.layout_object

--- a/src/test12.py
+++ b/src/test12.py
@@ -47,8 +47,14 @@ class MockLock:
 	def __init__(self):
 		pass
 
-	def acquire(self, blocking):
+	def acquire(self, blocking=False):
 		pass
 
 	def release(self, ):
 		pass
+
+	def __enter__(self):
+		self.acquire()
+
+	def __exit__(self, *args):
+		self.release()


### PR DESCRIPTION
I'm not really sure this PR is even good, but hear me out.

My biggest concern with the accessibility tree section is that we haven't really justified why there needs to be a tree. My attempted solution to this was to actually implement moving in / out of the accessibility tree, which a real screen reader does support. I do think this is probably a good idea.

To implement this, you need a pointer for where in the document you currently are reading. (In the existing version of the chapter, that pointer can actually only point to focusable things.) I ended up making an `accessibility_focus` field that points to an accessibility node instead of just an HTML element. This way you can easily go to the previous / next / parent / child node. That works nicely.

However, since we rebuild the accessibility tree every so often, we need to "fix up" the `accessibility_focus` pointer (make it point into the new, not the old, tree). I think this is kind of ugly and I wish I could avoid it.

Plus, I also need to sync the accessibility focus back to the actual focus when you move over to a focusable element with the accessibility controls. I don't implement that because it's not 100% obvious the best way to do this. I think this is another ugliness of this approach.

Anyway, I'm looking for feedback on this direction. I think letting the user traverse the accessibility tree is good, but the implementation is not as clean as we'd like.