### PR TITLE
Commit the a11y tree to the browser process and access it there

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1614,7 +1614,7 @@ tabs requires re-running both of those rendering steps.
 
 ``` {.python}
 class Tab:
-    def rendrun_animation_frame(self, scroll):
+    def run_animation_frame(self, scroll):
         # ...
         commit_data = CommitData(
             accessibility_tree=self.accessibility_tree,

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1597,7 +1597,7 @@ to the browser thread. That'll be a straightforward extension of the commit
 concept introduced in [Chapter 12][ch12-commit]. First we'll add the tree
 to `CommitData`: 
 
-```
+``` {.python}
 class CommitData:
     def __init__(self, url, scroll, height,
         display_list, composited_updates, accessibility_tree,
@@ -1612,9 +1612,9 @@ accessibility tree other than to build it/ Note that now that the accessibility
 tree is present in the browser thread, and not just the display list, changing
 tabs requires re-running both of those rendering steps.
 
-```
+``` {.python}
 class Tab:
-    def render(self):
+    def rendrun_animation_frame(self, scroll):
         # ...
         commit_data = CommitData(
             accessibility_tree=self.accessibility_tree,
@@ -1624,7 +1624,7 @@ class Tab:
         self.accessibility_tree = None
 ```
 
-```
+``` {.python}
 class Browser:
     def commit(self, tab, data):
         # ...
@@ -1739,13 +1739,13 @@ which is used by the `Tab` to start building and commiting accessibilty trees:
 
 ``` {.python}
 class Tab:
-    def set_needs_accessiblity(self):
+    def set_needs_accessibility(self):
         self.needs_accessibility = True
         self.browser.set_needs_animation_frame(self)
 
     def toggle_accessibility(self):
         self.accessibility_is_on = not self.accessibility_is_on
-        self.set_needs_accessiblity()
+        self.set_needs_accessibility()
 
 ```
 
@@ -1771,7 +1771,6 @@ DOM context. For each node, we'll figure out its text via the `announce_text`
 function. For text nodes it's just the text, and otherwise it
 describes the element tag, plus whether it's focused.
 
-``` {.python}
 ``` {.python expected=False}
 def announce_text(node):
     text = ""
@@ -1846,7 +1845,7 @@ class Browser:
         if text and node.children and \
             node.children[0].role == "StaticText":
             text += " " + \
-            self.node.children[0].role
+            node.children[0].text
 
         print(text)
         if text:
@@ -2302,7 +2301,7 @@ class Tab:
         if not self.accessibility_is_on:
             return
         self.queued_alerts.append(alert)
-        self.set_needs_accessiblity()
+        self.set_needs_accessibility()
 ```
 
 The queued alert need to be sent over to the browser thread, just like

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -161,11 +161,12 @@ The accessibility tree is automatically created.
 
     >>> browser = lab14.Browser()
     >>> browser.load(focus_url)
-    >>> browser.tabs[0].toggle_accessibility()
+    >>> browser.toggle_accessibility()
 
 Rendering will read out the accessibility instructions:
 
     >>> browser.render()
+    >>> browser.composite_raster_and_draw()
     Here are the document contents: 
     Input box: 
     Link
@@ -173,7 +174,7 @@ Rendering will read out the accessibility instructions:
 
 From this tree:
 
-    >>> lab14.print_tree(browser.tabs[0].accessibility_tree)
+    >>> lab14.print_tree(browser.accessibility_tree)
      AccessibilityNode(node=<html> role=document
        AccessibilityNode(node=<input> role=textbox
        AccessibilityNode(node=<a href="/dest"> role=link

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1049,7 +1049,7 @@ class Tab:
         self.needs_layout = True
         self.browser.set_needs_animation_frame(self)
 
-    def set_needs_accessiblity(self):
+    def set_needs_accessibility(self):
         self.needs_accessibility = True
         self.browser.set_needs_animation_frame(self)
 
@@ -1276,11 +1276,11 @@ class Tab:
         if not self.accessibility_is_on:
             return
         self.queued_alerts.append(alert)
-        self.set_needs_accessiblity()
+        self.set_needs_accessibility()
 
     def toggle_accessibility(self):
         self.accessibility_is_on = not self.accessibility_is_on
-        self.set_needs_accessiblity()
+        self.set_needs_accessibility()
 
     def toggle_dark_mode(self):
         self.dark_mode = not self.dark_mode
@@ -1577,7 +1577,7 @@ class Browser:
         self.clear_data()
         if self.active_tab != None:
             active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.set_needs_paint)
+            task = Task(active_tab.set_needs_accessibility)
             active_tab.task_runner.schedule_task(task)
         else:
             self.needs_animation_frame = True
@@ -1608,7 +1608,7 @@ class Browser:
         if text and node.children and \
             node.children[0].role == "StaticText":
             text += " " + \
-            self.node.children[0].role
+            node.children[0].text
 
         print(text)
         if text:
@@ -1632,9 +1632,6 @@ class Browser:
     def speak_update(self):
         if not self.accessibility_tree:
             return
-        for alert in self.queued_alerts:
-            self.speak_node(alert, "New alert")
-        self.queued_alerts = []
 
         if not self.has_spoken_document:
             self.speak_document()
@@ -1661,6 +1658,10 @@ class Browser:
                     self.hovered_node = a11y_node
                     self.hovered_node.is_hovered = True
             self.pending_hover = None
+
+        for alert in self.queued_alerts:
+            self.speak_node(alert, "New alert")
+        self.queued_alerts = []
 
     def toggle_mute(self):
         self.lock.acquire(blocking=True)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -614,10 +614,6 @@ class AccessibilityNode:
             self.build_internal(child_node)
 
         self.text = announce_text(self.node, self.role)
-        if self.text and self.node.children and \
-            isinstance(self.node.children[0], Text):
-            self.text += " " + \
-            announce_text(self.node.children[0], self.children[0].role)
 
     def build_internal(self, child_node):
         child = AccessibilityNode(child_node)
@@ -1609,6 +1605,11 @@ class Browser:
 
     def speak_node(self, node, text):
         text += node.text
+        if text and node.children and \
+            node.children[0].role == "StaticText":
+            text += " " + \
+            self.node.children[0].role
+
         print(text)
         if text:
             if not self.is_muted():

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1606,7 +1606,7 @@ class Browser:
                 speak_text(text)
 
     def speak_hit_test(self, node):
-        self.speak_node(node, "hit testfff ")
+        self.speak_node(node, "hit test ")
 
     def speak_document(self):
         text = "Here are the document contents: "
@@ -1639,7 +1639,6 @@ class Browser:
 
                 if a11y_node:
                     if not self.hovered_node or a11y_node.node != self.hovered_node.node:
-                        print(a11y_node)
                         self.speak_hit_test(a11y_node)
                     self.hovered_node = a11y_node
                     self.hovered_node.is_hovered = True

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -981,6 +981,7 @@ class Tab:
         self.composited_updates = []
         self.zoom = 1.0
         self.pending_hover = None
+        self.hovered_node = None
         self.queued_alerts = []
 
         with open("browser14.css") as f:
@@ -1148,6 +1149,17 @@ class Tab:
             self.accessibility_tree = AccessibilityNode(self.nodes)
             self.needs_accessibility = False
             self.needs_paint = True
+
+            if self.pending_hover:
+                (x, y) = self.pending_hover
+                a11y_node = self.accessibility_tree.hit_test(x, y)
+                if self.hovered_node:
+                    self.hovered_node.is_hovered = False
+
+                if a11y_node:
+                    self.hovered_node = a11y_node.node
+                    self.hovered_node.is_hovered = True
+        self.pending_hover = None
 
         if self.needs_paint:
             self.display_list = []
@@ -1647,7 +1659,7 @@ class Browser:
         if self.hovered_node:
             active_tab = self.tabs[self.active_tab]
             task = Task(active_tab.hover,
-                self.hovered_node.bounds.x, self.hovered_node.bounds.y)
+                self.hovered_node.bounds.x(), self.hovered_node.bounds.y())
             active_tab.task_runner.schedule_task(task)
 
         if self.tab_focus and \

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -613,19 +613,20 @@ class AccessibilityNode:
         for child_node in self.node.children:
             self.build_internal(child_node)
 
-        if self.text and node.children and \
-            isinstance(node.children[0], Text):
+        self.text = announce_text(self.node, self.role)
+        if self.text and self.node.children and \
+            isinstance(self.node.children[0], Text):
             self.text += " " + \
-            announce_text(node.children[0], self.children[0].role)
+            announce_text(self.node.children[0], self.children[0].role)
 
-    def build_internal(self, node):
-        child = AccessibilityNode(node)
+    def build_internal(self, child_node):
+        child = AccessibilityNode(child_node)
         if child.role != "none":
             self.children.append(child)
             child.build()
         else:
-            for child_node in node.children:
-                self.build_internal(child_node)
+            for grandchild_node in child_node.children:
+                self.build_internal(grandchild_node)
 
     def intersects(self, x, y):
         if self.bounds:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -577,9 +577,8 @@ def announce_text(node, role):
 class AccessibilityNode:
     def __init__(self, node):
         self.children = []
-
-        # todo: remove this
         self.node = node
+        self.text = None
 
         if hasattr(node, "layout_object"):
             obj = node.layout_object
@@ -611,22 +610,22 @@ class AccessibilityNode:
                 self.role = "none"
 
     def build(self):
-        self.text = announce_text(node, self.role)
+        for child_node in self.node.children:
+            self.build_internal(child_node)
+
         if self.text and node.children and \
             isinstance(node.children[0], Text):
             self.text += " " + \
             announce_text(node.children[0], self.children[0].role)
 
-        self.build_internal(node)
-
-    def build_internal(parent):
-        for child_node in node.children:
-            child = AccessibilityNode(child_node)
-            if child.role != "none":
-                print('add child')
-                self.children.append(child)
-                child.build(child_node)
-            else:
+    def build_internal(self, node):
+        child = AccessibilityNode(node)
+        if child.role != "none":
+            self.children.append(child)
+            child.build()
+        else:
+            for child_node in node.children:
+                self.build_internal(child_node)
 
     def intersects(self, x, y):
         if self.bounds:
@@ -1143,7 +1142,7 @@ class Tab:
 
         if self.needs_accessibility:
             self.accessibility_tree = AccessibilityNode(self.nodes)
-            self.accessibility_tree.build(self.nodes)
+            self.accessibility_tree.build()
             self.needs_accessibility = False
             self.needs_paint = True
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1615,9 +1615,6 @@ class Browser:
             if not self.is_muted():
                 speak_text(text)
 
-    def speak_hit_test(self, node):
-        self.speak_node(node, "hit test ")
-
     def speak_document(self):
         text = "Here are the document contents: "
         tree_list = tree_to_list(self.accessibility_tree, [])
@@ -1654,7 +1651,7 @@ class Browser:
 
                 if a11y_node:
                     if not self.hovered_node or a11y_node.node != self.hovered_node.node:
-                        self.speak_hit_test(a11y_node)
+                        self.speak_node(a11y_node, "Hit test ")
                     self.hovered_node = a11y_node
                     self.hovered_node.is_hovered = True
             self.pending_hover = None

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -549,9 +549,6 @@ def is_focusable(node):
     else:
         return node.tag in ["input", "button", "a"]
     
-def compute_role(node):
-    return AccessibilityNode(node).role
-
 def announce_text(node, role):
     text = ""
     if role == "StaticText":
@@ -613,24 +610,23 @@ class AccessibilityNode:
             else:
                 self.role = "none"
 
-        for child_node in node.children:
-            self.build_internal(child_node)
-
+    def build(self):
         self.text = announce_text(node, self.role)
         if self.text and node.children and \
             isinstance(node.children[0], Text):
             self.text += " " + \
             announce_text(node.children[0], self.children[0].role)
 
-    def build_internal(self, node):
-        child = AccessibilityNode(node)
-        if child.role != "none":
-            self.children.append(child)
-            parent = child
-        else:
-            parent = self
+        self.build_internal(node)
+
+    def build_internal(parent):
         for child_node in node.children:
-            parent.build_internal(child_node)
+            child = AccessibilityNode(child_node)
+            if child.role != "none":
+                print('add child')
+                self.children.append(child)
+                child.build(child_node)
+            else:
 
     def intersects(self, x, y):
         if self.bounds:
@@ -1147,6 +1143,7 @@ class Tab:
 
         if self.needs_accessibility:
             self.accessibility_tree = AccessibilityNode(self.nodes)
+            self.accessibility_tree.build(self.nodes)
             self.needs_accessibility = False
             self.needs_paint = True
 


### PR DESCRIPTION
This CL still creates the a11y tree on the `Tab` but then sends it over to the `Browser` for actual interaction, without
reference to the `Tab`. The purpose is to demonstrate why there is a tree at all instead of accessing the layout tree.

It also updates the chapter text to match the new implementation, plus adds a paragraph and some footnotes about why
it has to be in the browser thread.

This necessitates making the a11y tree self-contained, which is most of the cocde changes.