### PR TITLE
Pass on the new screen-reader section

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1867,7 +1867,7 @@ class Browser:
 ```
 
 There's a lot more in a real screen reader: landmarks, navigating text
-at different granularities, repeating recently spoken text, and so on.
+at different granularities, repeating text when requested, and so on.
 Those features make various uses of the accessibility tree and the
 roles of the various nodes. But since the focus of this book is on the
 browser, not the screen reader itself, let's focus for the rest of

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1814,8 +1814,9 @@ class Browser:
 ```
 
 Speaking the whole document happens only once. But the user might need
-feedback as they browse the page. For example, let's speak the focused
-element to the user.
+feedback as they browse the page. For example, when the user tabs from
+one element to another, they may want the new element spoken to them
+so they know what they're interacting with.
 
 To do that, the browser thread is going to need to know which element
 is focused. Let's add that to the `CommitData`; I'm not going to show

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1745,10 +1745,9 @@ To speak the whole document, we need to know how to speak each
 `AccessibilityNode`. This has to be decided back in the `Tab`, since
 the text will include DOM content that is not accessible to the
 browser thread. So let's add a `text` field to `AccessibilityNode` and
-set it according to role and surrounding DOM context. For each node,
-we'll figure out its text via the `announce_text` function. For text
-nodes it's just the text, and otherwise it describes the element tag,
-plus whether it's focused.
+set it in `build` according to the node's role and surrounding DOM
+context. For text nodes it's just the text, and otherwise it describes
+the element tag, plus whether it's focused.
 
 ``` {.python}
 class AccessibilityNode:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1624,7 +1624,7 @@ class Browser:
         # ...
         self.accessibility_tree = data.accessibility_tree
 
-    def clear_data(self, index):
+    def clear_data(self):
         # ...
         self.accessibility_tree = None
 ```
@@ -1761,7 +1761,7 @@ class AccessibilityNode:
             self.build_internal(child_node)
 
         if self.role == "StaticText":
-            self.text = node.text
+            self.text = self.node.text
         elif self.role == "focusable text":
             self.text = "focusable text: " + self.node.text
         elif self.role == "textbox":
@@ -2346,7 +2346,6 @@ class Tab:
         if not self.accessibility_is_on:
             return
         self.queued_alerts.append(alert)
-        self.set_needs_accessibility()
 ```
 
 The queued alert need to be sent over to the browser thread, just like

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1573,7 +1573,7 @@ Screen readers
 ==============
 
 Typically, the screen reader is a separate application from the
-browser,[^why-diff] which the browser communicates with through
+browser,[^why-diff] with which the browser communicates through
 OS-specific APIs. To keep this book platform-independent, our
 discussion of screen reader support will instead include a minimal
 screen reader integrated directly into the browser.[^os-pain]
@@ -1868,7 +1868,7 @@ class Browser:
 
 There's a lot more in a real screen reader: landmarks, navigating text
 at different granularities, repeating recently spoken text, and so on.
-Those features make various use of the accessibility tree and the
+Those features make various uses of the accessibility tree and the
 roles of the various nodes. But since the focus of this book is on the
 browser, not the screen reader itself, let's focus for the rest of
 this chapter on browser features that support accessibility.

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -614,7 +614,7 @@ class AccessibilityNode:
             self.build_internal(child_node)
 
         if self.role == "StaticText":
-            self.text = node.text
+            self.text = self.node.text
         elif self.role == "focusable text":
             self.text = "focusable text: " + self.node.text
         elif self.role == "textbox":
@@ -1605,9 +1605,6 @@ class Browser:
     def toggle_accessibility(self):
         self.lock.acquire(blocking=True)
         self.accessibility_is_on = not self.accessibility_is_on
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.toggle_accessibility)
-        active_tab.task_runner.schedule_task(task)
         self.needs_accessibility = self.accessibility_is_on
         self.lock.release()
 
@@ -1620,6 +1617,7 @@ class Browser:
 
 
         if text:
+            print(text)
             if not self.is_muted():
                 speak_text(text)
 
@@ -1631,12 +1629,12 @@ class Browser:
             if new_text:
                 text += "\n"  + new_text
 
+        print(text)
         if not self.is_muted():
             speak_text(text)
 
     def speak_update(self):
-        if not self.accessibility_tree:
-            return
+        if not self.accessibility_tree: return
 
         if not self.has_spoken_document:
             self.speak_document()

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -549,31 +549,6 @@ def is_focusable(node):
     else:
         return node.tag in ["input", "button", "a"]
     
-def announce_text(node, role):
-    text = ""
-    if role == "StaticText":
-        text = node.text
-    elif role == "focusable text":
-        text = "focusable text: " + node.text
-    elif role == "textbox":
-        if "value" in node.attributes:
-            value = node.attributes["value"]
-        elif node.tag != "input" and node.children and \
-            isinstance(node.children[0], Text):
-            value = node.children[0].text
-        else:
-            value = ""
-        text = "Input box: " + value
-    elif role == "button":
-        text = "Button"
-    elif role == "link":
-        text = "Link"
-    elif role == "alert":
-        text = "Alert"
-    if is_focused(node):
-        text += " is focused"
-    return text
-
 class AccessibilityNode:
     def __init__(self, node):
         self.node = node

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -549,6 +549,31 @@ def is_focusable(node):
     else:
         return node.tag in ["input", "button", "a"]
     
+def announce_text(node, role):
+    text = ""
+    if role == "StaticText":
+        text = node.text
+    elif role == "focusable text":
+        text = "focusable text: " + node.text
+    elif role == "textbox":
+        if "value" in node.attributes:
+            value = node.attributes["value"]
+        elif node.tag != "input" and node.children and \
+            isinstance(node.children[0], Text):
+            value = node.children[0].text
+        else:
+            value = ""
+        text = "Input box: " + value
+    elif role == "button":
+        text = "Button"
+    elif role == "link":
+        text = "Link"
+    elif role == "alert":
+        text = "Alert"
+    if is_focused(node):
+        text += " is focused"
+    return text
+
 class AccessibilityNode:
     def __init__(self, node):
         self.node = node


### PR DESCRIPTION
I did a re-pass over the screen-reader section. I think I fixed a bug. I also removed the `accessibility_is_on` flag on `Tab`; why not just build the accessibility tree every time?

However, I think `has_spoken_document` isn't set back to False when you navigate between tabs. Am I right? One fix for this is to make it a `last_url` field. This wouldn't work for refreshes, but maybe that's OK?