### PR TITLE
Handle @patch correctly in outlines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ test:
 	python3 -m doctest infra/annotate_code.md
 	set -e; \
 	for i in $$(seq 1 14); do \
-		(cd src/ && PYTHONBREAKPOINT=0 python3 -m doctest lab$$i-tests.md); \
+		(cd src/ && python3 -m doctest lab$$i-tests.md); \
 	done

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ of Chapter 3 like so:
 
 ```
 cd src/
-PYTHONBREAKPOINT=0 python3 lab3.py https://browser.engineering
+python3 lab3.py https://browser.engineering
 ```
 
 Every chapter can be run in a similar fashion.
@@ -61,7 +61,7 @@ which you can run with:
 
 ```
 cd src/
-PYTHONBREAKPOINT=0 python3 server8.py
+python3 server8.py
 ```
 
 Like the browser, there are different versions of the server for

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -203,6 +203,10 @@ def compile_method(base, name, args, ctx):
     elif name == "export_function": # Needs special handling due to "this"
         assert len(args) == 2
         return base_js + ".export_function(" + args_js[0] + ", (...args) => " + args_js[1] + "(...args))"
+    elif base_js == "wbetools" and name == "record":
+        assert isinstance(args[0], ast.Constant)
+        assert isinstance(args[0].value, str)
+        return "await breakpoint.event(" + ", ".join(args_js) + ")"
     elif name in RT_METHODS:
         return "await " + base_js + "." + name + "(" + ", ".join(args_js) + ")"
     elif name in LIBRARY_METHODS:
@@ -307,10 +311,6 @@ def compile_function(name, args, ctx):
             return args_js[0] + ".reduce((a, v) => Math.max(a, v))"
         else:
             return "Math.max(" + args_js[0] + ", " + args_js[1] + ")"
-    elif name == "breakpoint":
-        assert isinstance(args[0], ast.Constant)
-        assert isinstance(args[0].value, str)
-        return "await breakpoint.event(" + ", ".join(args_js) + ")"
     elif name == "min":
         assert 1 <= len(args) <= 2
         if len(args) == 1:

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -167,11 +167,13 @@ key functions to a comparator:
     >>> Test.expr("sorted(rules, key=cascade_priority)")
     (rules.slice().sort(comparator(cascade_priority)))
 
-Finally there is the special `breakpoint` builtin, which we use for
-pausing widgets. It compiles to a `breakpoint.event` function, which
-has to use `await` in order to capture the continuation.
+Finally there is the special `wbetools.record` function, which we use
+for pausing widgets. It compiles to a `breakpoint.event` function,
+which has to use `await` in order to capture the continuation.
 
-    >>> Test.expr("breakpoint('layout_pre', self)")
+    >>> Test.stmt("import wbetools")
+    // Please configure the 'wbetools' module
+    >>> Test.expr("wbetools.record('layout_pre', self)")
     (await breakpoint.event("layout_pre", this))
 
 Compiling Expressions

--- a/src/lab2.py
+++ b/src/lab2.py
@@ -4,6 +4,7 @@ up to and including Chapter 2 (Drawing to the Screen),
 without exercises.
 """
 
+import wbetools
 import socket
 import ssl
 import tkinter
@@ -19,7 +20,7 @@ def lex(body):
             in_angle = False
         elif not in_angle:
             text += c
-        breakpoint("lex", text)
+        wbetools.record("lex", text)
     return text
 
 WIDTH, HEIGHT = 800, 600
@@ -36,7 +37,7 @@ def layout(text):
         if cursor_x >= WIDTH - HSTEP:
             cursor_y += VSTEP
             cursor_x = HSTEP
-        breakpoint("layout", display_list)
+        wbetools.record("layout", display_list)
     return display_list
 
 class Browser:
@@ -62,7 +63,7 @@ class Browser:
     def draw(self):
         self.canvas.delete("all")
         for x, y, c in self.display_list:
-            breakpoint("draw")
+            wbetools.record("draw")
             if y > self.scroll + HEIGHT: continue
             if y + VSTEP < self.scroll: continue
             self.canvas.create_text(x, y - self.scroll, text=c)

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -4,6 +4,7 @@ up to and including Chapter 3 (Formatting Text),
 without exercises.
 """
 
+import wbetools
 import socket
 import ssl
 import tkinter
@@ -105,22 +106,22 @@ class Layout:
 
     def flush(self):
         if not self.line: return
-        breakpoint("initial_y", self.cursor_y, self.line);
+        wbetools.record("initial_y", self.cursor_y, self.line);
         metrics = [font.metrics() for x, word, font in self.line]
-        breakpoint("metrics", metrics)
+        wbetools.record("metrics", metrics)
         max_ascent = max([metric["ascent"] for metric in metrics])
         baseline = self.cursor_y + 1.25 * max_ascent
-        breakpoint("max_ascent", max_ascent);
+        wbetools.record("max_ascent", max_ascent);
         for x, word, font in self.line:
             y = baseline - font.metrics("ascent")
             self.display_list.append((x, y, word, font))
-            breakpoint("aligned", self.display_list);
+            wbetools.record("aligned", self.display_list);
         self.cursor_x = HSTEP
         self.line = []
         max_descent = max([metric["descent"] for metric in metrics])
-        breakpoint("max_descent", max_descent);
+        wbetools.record("max_descent", max_descent);
         self.cursor_y = baseline + 1.25 * max_descent
-        breakpoint("final_y", self.cursor_y);
+        wbetools.record("final_y", self.cursor_y);
 
 class Browser:
     def __init__(self):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -4,6 +4,7 @@ up to and including Chapter 5 (Laying out Pages),
 without exercises.
 """
 
+import wbetools
 import socket
 import ssl
 import tkinter
@@ -46,7 +47,7 @@ class BlockLayout:
         self.height = None
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         previous = None
         for child in self.node.children:
             if layout_mode(child) == "inline":
@@ -69,7 +70,7 @@ class BlockLayout:
 
         self.height = sum([child.height for child in self.children])
 
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def paint(self, display_list):
         for child in self.children:
@@ -92,7 +93,7 @@ class InlineLayout:
         self.display_list = None
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         self.width = self.parent.width
         self.x = self.parent.x
 
@@ -113,7 +114,7 @@ class InlineLayout:
         self.flush()
 
         self.height = self.cursor_y - self.y
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def recurse(self, node):
         if isinstance(node, Text):
@@ -191,7 +192,7 @@ class DocumentLayout:
         self.children = []
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         child = BlockLayout(self.node, self, None)
         self.children.append(child)
 
@@ -200,7 +201,7 @@ class DocumentLayout:
         self.y = VSTEP
         child.layout()
         self.height = child.height + 2*VSTEP
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def paint(self, display_list):
         self.children[0].paint(display_list)

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -4,6 +4,7 @@ up to and including Chapter 6 (Applying User Styles),
 without exercises.
 """
 
+import wbetools
 import socket
 import ssl
 import tkinter
@@ -290,7 +291,7 @@ class BlockLayout:
         self.height = None
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         previous = None
         for child in self.node.children:
             if layout_mode(child) == "inline":
@@ -313,7 +314,7 @@ class BlockLayout:
 
         self.height = sum([child.height for child in self.children])
 
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def paint(self, display_list):
         for child in self.children:
@@ -331,7 +332,7 @@ class DocumentLayout:
         self.children = []
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         child = BlockLayout(self.node, self, None)
         self.children.append(child)
 
@@ -340,7 +341,7 @@ class DocumentLayout:
         self.y = VSTEP
         child.layout()
         self.height = child.height + 2*VSTEP
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def paint(self, display_list):
         self.children[0].paint(display_list)

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -4,6 +4,7 @@ up to and including Chapter 7 (Handling Buttons and Links),
 without exercises.
 """
 
+import wbetools
 import socket
 import ssl
 import tkinter
@@ -112,7 +113,7 @@ class BlockLayout:
         self.height = None
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         previous = None
         for child in self.node.children:
             if layout_mode(child) == "inline":
@@ -135,7 +136,7 @@ class BlockLayout:
 
         self.height = sum([child.height for child in self.children])
 
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def paint(self, display_list):
         for child in self.children:
@@ -223,7 +224,7 @@ class DocumentLayout:
         self.children = []
 
     def layout(self):
-        breakpoint("layout_pre", self)
+        wbetools.record("layout_pre", self)
         child = BlockLayout(self.node, self, None)
         self.children.append(child)
 
@@ -232,7 +233,7 @@ class DocumentLayout:
         self.y = VSTEP
         child.layout()
         self.height = child.height + 2*VSTEP
-        breakpoint("layout_post", self)
+        wbetools.record("layout_post", self)
 
     def paint(self, display_list):
         self.children[0].paint(display_list)

--- a/src/run_lab.sh
+++ b/src/run_lab.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-PYTHONBREAKPOINT=0 python3 lab$1.py http://browser.engineering/

--- a/src/test.py
+++ b/src/test.py
@@ -2,6 +2,7 @@
 This file contains unittests helpers for chapters 1-10
 """
 
+import wbetools
 import builtins
 import io
 import sys
@@ -181,13 +182,16 @@ def breakpoint(name, *args):
     args_str = (", " + ", ".join(["'{}'".format(arg) for arg in args]) if args else "")
     print("breakpoint(name='{}'{})".format(name, args_str))
 
-builtin_breakpoint = builtins.breakpoint
+def patch(cls):
+        return mock.patch("socket.socket", wraps=cls)
+
+builtin_breakpoint = wbetools.record
 
 def patch_breakpoint():
-    builtins.breakpoint = breakpoint
+    wbetools.record = breakpoint
 
 def unpatch_breakpoint():
-    builtins.breakpoint = builtin_breakpoint
+    wbetools.record = builtin_breakpoint
 
 class Event:
     def __init__(self, x, y):

--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -1,4 +1,7 @@
 
+def record(type, *args):
+    pass
+
 def patch(existing_cls):
     def decorator(new_cls):
         for attr in dir(new_cls):


### PR DESCRIPTION
This PR makes the outliner correctly recognize `@wbetools.patch` calls. In other words, if you do something like this:

```
from labX import Element
@wbetools.patch(Element)
class Element:
    # ...
```

Then the outline will have only one class named `Element`, placed where the import is (not the patch), but with any new methods defined in the patch.