### PR TITLE
Fix hit testing on transformed nodes

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -2024,7 +2024,6 @@ class AccessibilityNode:
     def __init__(self, node):
         # ...
         if hasattr(node, "layout_object"):
-            obj = node.layout_object
             self.bounds = absolute_bounds_for_obj(node.layout_object)
         else:
             self.bounds = None

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -2025,7 +2025,7 @@ class AccessibilityNode:
         # ...
         if hasattr(node, "layout_object"):
             obj = node.layout_object
-            self.bounds = skia.Rect.MakeXYWH(obj.x, obj.y, obj.width, obj.height)
+            self.bounds = absolute_bounds_for_obj(node.layout_object)
         else:
             self.bounds = None
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -581,8 +581,7 @@ class AccessibilityNode:
         self.text = None
 
         if hasattr(node, "layout_object"):
-            obj = node.layout_object
-            self.bounds = skia.Rect.MakeXYWH(obj.x, obj.y, obj.width, obj.height)
+            self.bounds = absolute_bounds_for_obj(node.layout_object)
         else:
             self.bounds = None
 


### PR DESCRIPTION
When computing the bounds on the accessibility tree, we need to make sure to use absolute coordinates, not layout coordinates, to make sure that outlines and clicking work correctly.