### PR TITLE
Pass over the hover section

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -2131,7 +2131,7 @@ basically have two different outputs: a display list for visual
 interaction, and an accessibility tree for screen-reader interaction.
 Many users will use just one or the other. However, it can also be
 valuable to use both together. For example, a user might have limited
-vision, able to make out the general items on a web page but unable to
+vision---able to make out the general items on a web page but unable to
 read the text. Such a user might use their mouse to navigate the page,
 but need the items under the mouse to be read to them by a
 screen-reader.


### PR DESCRIPTION
This PR reorganizes the flow in the hover section a bit but the only two code changes are making `layout_object` a proper field on `Element` (to avoid using `hasattr`, which I'm trying to avoid in the book) and rewriting `hit_test` to be a bit simpler.