### PR TITLE
Fix iframes

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -2142,8 +2142,6 @@ Now, when we construct a layout object, we can fill in the
 like this:
 
 ``` {.python}
-class Element:
-    
 class BlockLayout:
     def __init__(self, node, parent, previous):
         # ...

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1137,8 +1137,8 @@ The server's outline is unchanged from the last chapter:
 :::
 
 If you run it, it should look something like [this
-page](lab9-browser.html); due to the browser sandbox, you will need to
-open that page in a new tab.
+page](widgets/lab9-browser.html); due to the browser sandbox, you will
+need to open that page in a new tab.
 
 Exercises
 =========

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1136,11 +1136,9 @@ The server's outline is unchanged from the last chapter:
     python3 infra/outlines.py --html src/server9.py
 :::
 
-If you run it, it should look something like this:
-
-::: {.widget height=691}
-    lab9-browser.html
-:::
+If you run it, it should look something like [this
+page](lab9-browser.html); due to the browser sandbox, you will need to
+open that page in a new tab.
 
 Exercises
 =========

--- a/book/security.md
+++ b/book/security.md
@@ -1187,11 +1187,9 @@ The server has also grown since last chapter:
     python3 infra/outlines.py --html src/server10.py
 :::
 
-If you run it, it should look something like this:
-
-::: {.widget height=691}
-    lab10-browser.html
-:::
+If you run it, it should look something like [this
+page](lab10-browser.html); due to the browser sandbox, you will need
+to open that page in a new tab.
 
 
 Exercises

--- a/book/security.md
+++ b/book/security.md
@@ -1188,8 +1188,8 @@ The server has also grown since last chapter:
 :::
 
 If you run it, it should look something like [this
-page](lab10-browser.html); due to the browser sandbox, you will need
-to open that page in a new tab.
+page](widgets/lab10-browser.html); due to the browser sandbox, you
+will need to open that page in a new tab.
 
 
 Exercises

--- a/infra/server.py
+++ b/infra/server.py
@@ -5,8 +5,9 @@ from http import server
 # Based on code from https://stackoverflow.com/questions/12499171/
 class WBEServer(server.SimpleHTTPRequestHandler):
     def end_headers(self):
-        self.send_header("Cross-Origin-Opener-Policy", "same-origin");
-        self.send_header("Cross-Origin-Embedder-Policy", "require-corp");
+        if self.path.startswith("widgets/"):
+            self.send_header("Cross-Origin-Opener-Policy", "same-origin");
+            self.send_header("Cross-Origin-Embedder-Policy", "require-corp");
         self.send_header('Cache-Control', 'no-store, must-revalidate')
         self.send_header('Expires', '0')
 

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -60,7 +60,7 @@ class socket {
     static SOCK_STREAM = "stream";
     static IPPROTO_TCP = "tcp";
 
-    static socket = wrap_class(class {
+    static socket = wrap_class(class socket {
         constructor(params) {
             console.assert(params.family == "inet", "socket family must be inet")
             console.assert(params.type == "stream", "socket type must be stream")

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -3,7 +3,7 @@
 
 export {
     breakpoint, filesystem,
-    socket, ssl, tkinter, dukpy, urllib, html, random,
+    socket, ssl, tkinter, dukpy, urllib, html, random, wbetools,
     truthy, comparator, pysplit, pyrsplit, asyncfilter,
     rt_constants, Widget, http_textarea, 
     };
@@ -421,6 +421,10 @@ class dukpy {
             }
         }
     })
+}
+
+class wbetools {
+
 }
 
 class Breakpoint {

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -47,14 +47,6 @@ class WidgetXHRError extends ExpectedError {
     }
 }
 
-class JSExecutionError extends ExpectedError {
-    constructor(fn) {
-        super("This widget can't handle the " + fn + " exported function's return value, " +
-              "but the book's Python code should work correctly.");
-        this.name = "JSExecutionError";
-    }
-}
-
 class socket {
     static AF_INET = "inet";
     static SOCK_STREAM = "stream";
@@ -355,13 +347,23 @@ class random {
     }
 }
 
-class dukpy {
-    static {
-        if (!crossOriginIsolated) {
-            console.error("No cross-origin isolation; dukpy will not be available.");
-        }
+class JSInterpreterError extends ExpectedError {
+    constructor() {
+        super("This widget cannot execute JavaScript due to sandboxing, " +
+             "but the book's Python code should work correctly.");
+        this.name = "JSEnvironmentError."
     }
+}
 
+class JSExecutionError extends ExpectedError {
+    constructor(fn) {
+        super("This widget can't handle the " + fn + " exported function's return value, " +
+              "but the book's Python code should work correctly.");
+        this.name = "JSExecutionError";
+    }
+}
+
+class dukpy {
     static JSRuntimeError = class {
         constructor(msg) {
             this.msg = msg;
@@ -370,6 +372,11 @@ class dukpy {
     
     static JSInterpreter = wrap_class(class {
         constructor() {
+
+            if (!crossOriginIsolated) {
+                throw new JSInterpreterError(this.host);               
+            }
+
             this.function_table = {};
             this.worker = new Worker("/widgets/dukpy.js");
             this.worker.onmessage = this.onmessage.bind(this);


### PR DESCRIPTION
This PR stops embedding the Chapter 9 and 10 widgets. This is necessary to fix iframes, for complicated reasons:

- Our widget, located in an `iframe`, requires `SharedArrayBuffer`
- That requires the top-level document (the book chapter) to be `crossOriginIsolated`
- That requires the top-level document to set its `Cross-Origin-Embedder-Policy` to `require-corp`
- That bans all iframes that don't send a `Cross-Origin-Resource-Policy` header
- Substack and Youtube don't send that header

There are some work-arounds, like credentialless mode, but they only work in Chrome right now.

So I've removed the COEP header from the server, and this PR removes the iframes for the JS and Security chapters, and replaces them with a note that you have to open them in their own window. If open in their own window, the server will send the COEP header and they'll work.

Longer term I'm going to investigate using a busy-wait loop around `localStorage` for the synchronous communication instead. It'll be much more CPU-intensive, which is a big loss. @chrishtr perhaps you can ask someone you know for any other workarounds?