### PR TITLE
fixed typo in preface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ __pycache__/
 infra/db.*.json
 exercises/
 videos/
+.idea/

--- a/book/preface.md
+++ b/book/preface.md
@@ -12,7 +12,7 @@ architecture. The lesson transcends the specific system studied: _all_
 computer systems, no matter how big and seemingly complex, can be
 studied and understood[^other-reasons].
 
-[^other-reasons]: Others reasons for these classes: a focus on speed; learning
+[^other-reasons]: Other reasons for these classes: a focus on speed; learning
 low-level APIs; practice with C; knowing the stack; using systems better; and
 the importance of the system covered.
 


### PR DESCRIPTION
I fixed a small typo.
I've added `.idea` to `.gitignore` in case I will add any other fixes, but you can reject this change and just fix the typo.