### PR TITLE
Quick quickly and cleanly

### DIFF
--- a/src/lab12.py
+++ b/src/lab12.py
@@ -461,7 +461,7 @@ class TaskRunner:
                 task.run()
 
             self.condition.acquire(blocking=True)
-            if len(self.tasks) == 0:
+            if len(self.tasks) == 0 or self.needs_quit:
                 self.condition.wait()
             self.condition.release()
 


### PR DESCRIPTION
Our browser has a nasty bug wherein quitting doesn't always happen immediately. It turns out that happens when there are no tasks to run when you quit; this causes a deadlock. The fix is to treat quitting as a kind of phantom task.