### PR TITLE
Add an inliner to automatically make "full" versions of a lab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ infra/db.*.json
 exercises/
 videos/
 .idea/
+src/*.full.py

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ widgets: \
 	www/widgets/lab9-browser.html www/widgets/lab9.js www/widgets/server9.js \
 	www/widgets/lab10-browser.html www/widgets/lab10.js www/widgets/server10.js
 
+src/lab%.full.py: src/lab%.py
+	python3 infra/inline.py $< > $@
+
 lint: book/*.md src/*.py
 	python3 infra/compare.py --config config.json
 	! grep -n '^```' book/*.md | awk '(NR % 2) {print}' | grep -v '{.'

--- a/infra/inline.py
+++ b/infra/inline.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-import ast
-import outlines
+import asttools
 import argparse
 
 if __name__ == "__main__":
@@ -10,6 +9,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     for f in args.file:
-        tree = ast.parse(f.read(), f.name)
-        tree2 = outlines.ResolveImports().visit(tree)
-        print(f.name, ast.unparse(ast.fix_missing_locations(tree2)).count("\n"), sep="\t")
+        tree = asttools.parse(f.read(), f.name)
+        tree = asttools.inline(tree)
+        print(asttools.unparse(tree))

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -17,7 +17,8 @@ from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
 from lab6 import TagSelector, DescendantSelector
 from lab7 import LineLayout, TextLayout, CHROME_PX
-from lab8 import DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
+from lab8 import DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
+from lab9 import EVENT_DISPATCH_CODE
 
 def url_origin(url):
     scheme_colon, _, host, _ = url.split("/", 3)
@@ -102,8 +103,6 @@ def request(url, top_level_url, payload=None):
     s.close()
 
     return headers, body
-
-from lab9 import EVENT_DISPATCH_CODE
 
 class JSContext:
     def __init__(self, tab):

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -14,8 +14,9 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
-from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
-from lab6 import TagSelector, DescendantSelector
+from lab6 import CSSParser, TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
 from lab9 import EVENT_DISPATCH_CODE

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -13,17 +13,14 @@ import skia
 import socket
 import ssl
 import urllib.parse
-from lab4 import print_tree
-from lab4 import Element
-from lab4 import Text
-from lab4 import HTMLParser
-from lab6 import cascade_priority
-from lab6 import resolve_url
-from lab6 import tree_to_list
-from lab6 import INHERITED_PROPERTIES
-from lab6 import CSSParser, compute_style, style
-from lab6 import TagSelector, DescendantSelector
-from lab8 import layout_mode
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS
+from lab6 import CSSParser, TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import resolve_url, tree_to_list
+from lab7 import CHROME_PX
+from lab8 import INPUT_WIDTH_PX, layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin, JSContext
 
@@ -389,8 +386,6 @@ class DocumentLayout:
     def __repr__(self):
         return "DocumentLayout()"
 
-INPUT_WIDTH_PX = 200
-
 class LineLayout:
     def __init__(self, node, parent, previous):
         self.node = node
@@ -560,9 +555,6 @@ def paint_visual_effects(node, cmds, rect):
         ], should_save=needs_blend_isolation),
     ]
 
-SCROLL_STEP = 100
-CHROME_PX = 100
-
 class Tab:
     def __init__(self):
         self.history = []
@@ -709,9 +701,6 @@ class Tab:
             self.history.pop()
             back = self.history.pop()
             self.load(back)
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
 
 class Browser:
     def __init__(self):

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -15,24 +15,21 @@ import ssl
 import threading
 import time
 import urllib.parse
-from lab4 import print_tree
-from lab4 import Element
-from lab4 import Text
-from lab4 import HTMLParser
-from lab6 import cascade_priority
-from lab6 import resolve_url
-from lab6 import tree_to_list
-from lab6 import INHERITED_PROPERTIES
-from lab6 import CSSParser, compute_style, style
-from lab6 import TagSelector, DescendantSelector
-from lab8 import layout_mode
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS
+from lab6 import CSSParser, TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import resolve_url, tree_to_list
+from lab7 import CHROME_PX
+from lab8 import INPUT_WIDTH_PX, layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import FONTS, get_font, parse_color, parse_blend_mode, linespace
 from lab11 import SaveLayer, DrawRRect, DrawText, DrawRect, DrawLine, ClipRRect
 from lab11 import draw_line, draw_text, draw_rect
-from lab11 import BlockLayout, InlineLayout, DocumentLayout, INPUT_WIDTH_PX, LineLayout, TextLayout, InputLayout
-from lab11 import paint_visual_effects, SCROLL_STEP, CHROME_PX
+from lab11 import BlockLayout, InlineLayout, DocumentLayout, LineLayout, TextLayout, InputLayout
+from lab11 import paint_visual_effects
 
 class MeasureTime:
     def __init__(self, name):
@@ -372,9 +369,6 @@ class Tab:
             back = self.history.pop()
             self.load(back)
 
-
-WIDTH, HEIGHT = 800, 600
-HSTEP, VSTEP = 13, 18
 
 class Task:
     def __init__(self, task_code, *args):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -16,7 +16,23 @@ import threading
 import time
 import urllib.parse
 import wbetools
-from lab4 import print_tree, Text, Element
+import OpenGL.GL as GL
+
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS
+from lab6 import TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, cascade_priority, compute_style
+from lab6 import resolve_url, tree_to_list
+from lab7 import CHROME_PX
+from lab8 import INPUT_WIDTH_PX, layout_mode
+from lab9 import EVENT_DISPATCH_CODE
+from lab10 import COOKIE_JAR, request, url_origin
+from lab11 import FONTS, get_font, parse_color, parse_blend_mode, linespace
+from lab11 import draw_line, draw_text, get_font
+from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
+from lab12 import Task, REFRESH_RATE_SEC
+
 
 @wbetools.patch(Text)
 class Text:
@@ -38,24 +54,6 @@ class Element:
 
         self.style = {}
         self.animations = {}
-
-from lab4 import HTMLParser
-from lab6 import cascade_priority
-from lab6 import layout_mode
-from lab6 import resolve_url
-from lab6 import tree_to_list
-from lab6 import INHERITED_PROPERTIES
-from lab6 import compute_style
-from lab6 import TagSelector, DescendantSelector
-from lab8 import layout_mode
-from lab9 import EVENT_DISPATCH_CODE
-from lab10 import COOKIE_JAR, request, url_origin
-from lab11 import draw_line, draw_text, get_font, linespace, \
-    parse_blend_mode, parse_color, request, CHROME_PX, SCROLL_STEP
-from lab12 import MeasureTime
-from lab12 import WIDTH, HEIGHT, SingleThreadedTaskRunner, TaskRunner, Task, \
-    REFRESH_RATE_SEC, HSTEP, VSTEP
-import OpenGL.GL as GL
 
 def center_point(rect):
     return (rect.left() + (rect.right() - rect.left()) / 2,
@@ -591,8 +589,6 @@ class DocumentLayout:
 
     def __repr__(self):
         return "DocumentLayout()"
-
-INPUT_WIDTH_PX = 200
 
 class LineLayout:
     def __init__(self, node, parent, previous):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -31,7 +31,7 @@ from lab10 import COOKIE_JAR, request, url_origin
 from lab11 import FONTS, get_font, parse_color, parse_blend_mode, linespace
 from lab11 import draw_line, draw_text, get_font
 from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
-from lab12 import Task, REFRESH_RATE_SEC
+from lab12 import Task, REFRESH_RATE_SEC, USE_BROWSER_THREAD
 
 
 @wbetools.patch(Text)
@@ -881,8 +881,6 @@ class JSContext:
 
     def requestAnimationFrame(self):
         self.tab.browser.set_needs_animation_frame(self.tab)
-
-USE_BROWSER_THREAD = True
 
 def parse_transition(value):
     properties = {}

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -19,28 +19,28 @@ import threading
 import time
 import urllib.parse
 import wbetools
-from lab4 import print_tree
-from lab4 import HTMLParser
-from lab4 import Text, Element
-from lab6 import resolve_url
-from lab6 import tree_to_list
-from lab6 import INHERITED_PROPERTIES
-from lab6 import compute_style
-from lab6 import TagSelector, DescendantSelector
-from lab8 import layout_mode
-from lab9 import EVENT_DISPATCH_CODE
-from lab10 import COOKIE_JAR, url_origin, request
-from lab11 import draw_text, get_font, linespace, \
-    parse_blend_mode, CHROME_PX, SCROLL_STEP
 import OpenGL.GL as GL
-from lab12 import MeasureTime
-from lab13 import USE_BROWSER_THREAD, JSContext, diff_styles, \
-    clamp_scroll, CompositedLayer, absolute_bounds, \
-    DrawCompositedLayer, Task, TaskRunner, SingleThreadedTaskRunner, \
-    add_parent_pointers, absolute_bounds_for_obj, \
-    DisplayItem, DrawText, \
-    DrawLine, paint_visual_effects, WIDTH, HEIGHT, INPUT_WIDTH_PX, \
-    REFRESH_RATE_SEC, HSTEP, VSTEP, DrawRRect, draw_rect
+
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab4 import Text, Element, print_tree, HTMLParser
+from lab5 import BLOCK_ELEMENTS
+from lab6 import TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, cascade_priority, compute_style
+from lab6 import resolve_url, tree_to_list
+from lab7 import CHROME_PX
+from lab8 import INPUT_WIDTH_PX, layout_mode
+from lab9 import EVENT_DISPATCH_CODE
+from lab10 import COOKIE_JAR, request, url_origin
+from lab11 import FONTS, get_font, parse_blend_mode, linespace
+from lab11 import draw_text
+from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
+from lab12 import Task, REFRESH_RATE_SEC, USE_BROWSER_THREAD
+from lab13 import JSContext, diff_styles, clamp_scroll, add_parent_pointers
+from lab13 import absolute_bounds, absolute_bounds_for_obj
+from lab13 import map_translation, parse_transform
+from lab13 import CompositedLayer, paint_visual_effects
+from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
+from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, draw_rect
 
 @wbetools.patch(Element)
 class Element:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -37,7 +37,7 @@ from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
 from lab12 import Task, REFRESH_RATE_SEC, USE_BROWSER_THREAD
 from lab13 import JSContext, diff_styles, clamp_scroll, add_parent_pointers
 from lab13 import absolute_bounds, absolute_bounds_for_obj
-from lab13 import map_translation, parse_transform
+from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
 from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
 from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, draw_rect

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -11,7 +11,7 @@ import tkinter
 import tkinter.font
 from lab1 import request
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
-from lab3 import get_font
+from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -14,7 +14,9 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
-from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab6 import CSSParser, TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import DrawText, resolve_url, tree_to_list
 
 class LineLayout:
     def __init__(self, node, parent, previous):

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -13,7 +13,9 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
-from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab6 import CSSParser, TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 
 def request(url, payload=None):

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -17,7 +17,6 @@ from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
 from lab6 import DrawText, resolve_url, tree_to_list
-from lab6 import TagSelector, DescendantSelector
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import request, layout_mode
 from lab8 import DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -14,10 +14,13 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
-from lab6 import DrawText, CSSParser, cascade_priority, style, resolve_url, tree_to_list
+from lab6 import CSSParser, TagSelector, DescendantSelector
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import DrawText, resolve_url, tree_to_list
 from lab6 import TagSelector, DescendantSelector
 from lab7 import LineLayout, TextLayout, CHROME_PX
-from lab8 import request, DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
+from lab8 import request, layout_mode
+from lab8 import DocumentLayout, BlockLayout, InlineLayout, InputLayout, INPUT_WIDTH_PX
 
 EVENT_DISPATCH_CODE = \
     "new Node(dukpy.handle).dispatchEvent(new Event(dukpy.type))"


### PR DESCRIPTION
This PR repurposes the old `linecount.py` function into an inliner. You can now make an "inlined" copy of `labN.py` by running:

    make labN.full.py

Just for fun, some stats:

```
      60 src/lab1.full.py
     106 src/lab2.full.py
     197 src/lab3.full.py
     280 src/lab4.full.py
     426 src/lab5.full.py
     598 src/lab6.full.py
     770 src/lab7.full.py
     885 src/lab8.full.py
     953 src/lab9.full.py
     982 src/lab10.full.py
    1224 src/lab11.full.py
    1541 src/lab12.full.py
    2001 src/lab13.full.py
    2535 src/lab14.full.py
```