### PR TITLE
Mock `gtts` library to avoid crashes in tests

### DIFF
--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -8,6 +8,7 @@ This file contains tests for Chapter 14 (Accessibility).
     >>> import test14 as test
     >>> _ = test.socket.patch().start()
     >>> _ = test.ssl.patch().start()
+    >>> _ = test.gtts.patch()
     >>> threading.Lock = test.MockLock
     >>> import lab13
     >>> import lab14

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -8,6 +8,7 @@ This file contains tests for Chapter 15 (Embedded Content).
     >>> import test14 as test
     >>> _ = test.socket.patch().start()
     >>> _ = test.ssl.patch().start()
+    >>> _ = test.gtts.patch()
     >>> threading.Lock = test.MockLock
     >>> import lab13
     >>> import lab15

--- a/src/test11.py
+++ b/src/test11.py
@@ -91,6 +91,20 @@ class ssl:
     def patch(cls):
         return mock.patch("ssl.create_default_context", wraps=cls)
 
+class gtts:
+    class gTTS:
+        def __init__(self, text):
+            pass
+        def save(self, file):
+            pass
+
+    @classmethod
+    def patch(cls):
+        import sys
+        sys.modules["gtts"] = cls()
+
+
+
 def SDL_GetWindowSurfacePatched(window):
     return None
 


### PR DESCRIPTION
I'm not sure why this started crashing but this fixes it and I guess is a good idea in general?