### PR TITLE
Ban bots from indexing /draft/ and /samples/

### DIFF
--- a/www/robots.txt
+++ b/www/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /draft/
+Disallow: /examples/


### PR DESCRIPTION
This doesn't really change anything, but it hopefully will cut down on the number of Googlebot indexing errors we see.