### PR TITLE
Pass over the first section on downloading & decoding images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ widgets: \
 src/lab%.full.py: src/lab%.py
 	python3 infra/inline.py $< > $@
 
+CHAPTER=all
+
 lint: book/*.md src/*.py
-	python3 infra/compare.py --config config.json
+	python3 infra/compare.py --config config.json --chapter $(CHAPTER)
 	! grep -n '^```' book/*.md | awk '(NR % 2) {print}' | grep -v '{.'
 
 PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json $(FLAGS)

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -172,11 +172,11 @@ several algorithms for decoding, some of which result in a
 worse-looking image but are faster than the default.[^lossy] For
 example, just for resizing an image, there's fast, simple, "nearest
 neighbor" resizing and the slower but higher-quality "bilinear" or
-even "[Lanczos][lanczos]" resizing algorithm.
+even "[Lanczos][lanczos]" resizing algorithms.
 
 [lanczos]: https://en.wikipedia.org/wiki/Lanczos_resampling
 
-To give web page authors control over this performance bottleneck, can
+To give web page authors control over this performance bottleneck,
 there's an [`image-rendering`][image-rendering] CSS property that
 indicates which algorithm to use. Let's add that as an argument to
 `DrawImage`:
@@ -199,9 +199,9 @@ class DrawImage(DisplayItem):
         canvas.drawImageRect(self.image, self.rect, paint)
 ```
 
-So we've now got the helper functions we need to downloading and
-decoding images. But to actually put images into web pages, we're
-going to need to add images into our browser's layout tree.
+So we've now got the helper functions we need to download and decode
+images. But to actually put images into web pages, we're going to need
+to add images into our browser's layout tree.
 
 [^lossy]: Image formats like JPEG are [*lossy*][lossy], meaning that
     they don't faithfully represent all of the information in the
@@ -223,8 +223,8 @@ Interestingly, when we used Skia's `MakeFromEncoded`, we didn't need
 to pass in the image format. That's because many image formats start
 with ["magic bytes"][magic-bytes]; for example, PNG files always start
 with byte 137 followed by the letters "PNG". These magic bytes are
-often more reliable than server-send MIME types, so this kind of
-"format sniffing" is common inside browsers and their supporting
+often more reliable than web-server-provided MIME types, so this kind
+of "format sniffing" is common inside browsers and their supporting
 libraries.
 :::
 
@@ -252,10 +252,11 @@ it reaches the end of the available space.
 
 But it's different than a text *node*, because the text in a text node is not
 just one glyph, but an entire run of text of a potentially arbitrary length,
-and that can be split into words and lines across multiple lines. An image, on
-the other hand, is an [atomic inline][atomic-inline]---it doesn't make sense to
-split it across multiple lines.^[There are other elements that can be atomic
-inlines, and we'll encounter more later in this chapter.]
+and that can be split into multiple words and lines. An image, on the
+other hand, is an [atomic inline][atomic-inline]---it doesn't make
+sense to split it across multiple lines.^[There are other elements
+that can be atomic inlines, and we'll encounter more later in this
+chapter.]
 
 
 [atomic-inline]: https://drafts.csswg.org/css-display-3/#atomic-inline

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1065,7 +1065,7 @@ And set here:
 class IframeLayout(EmbedLayout):
     def layout(self, zoom):
         # ...
-        self.node.frame.frame_height haelf.height - 2
+        self.node.frame.frame_height = self.height - 2
         self.node.frame.frame_width = self.width - 2
 ```
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -94,7 +94,7 @@ class Tab:
 
 Make sure to make this change everywhere in your browser that you call
 `request`, including inside `XMLHttpRequest_send` and in several other
-places in `request`. When we download images, however, we _won't_ call
+places in `load`. When we download images, however, we _won't_ call
 `decode`, and just use the binary data directly:
 
 ``` {.python replace=tab/frame}

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -5,19 +5,13 @@ prev: accessibility
 next: invalidation
 ...
 
-Our toy browser has a lot of rendering features, but is still missing a few
-present on pretty much every website. The most obvious is *images*---given how
-ubiquitous they are, it seems silly to have even a toy browser without images.
-But images are only the simplest form of *embedded content* within a web page,
-a much bigger topic, and one that has a lot of interesting implications for how
-browser engines work. That's mostly due to how powerful *iframes* are, since
-they allow you to embed one website in another.
-
-The fact is, a toy browser without images or iframes simply wouldn't cover some
-very important architectural aspects of real browsers with important
-performance, security and open information access implications. So let's now
-implement them to see. And in keeping with the pattern you've already seen,
-basic support for these features is easy enough to implement in one chapter!
+While our toy browser can render complex styles, visual effects, and
+animations, all of those apply basically just to text. Yet web pages
+contain a variety of non-text *embedded content*, from images through
+to iframes that embed one web page inside another. Embedded content of
+this sort has been essential throughout the web's history, and support
+for embedded content has powerful implications for browser
+architecture, performance, security, and open information access.
 
 Images
 ======

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -122,11 +122,12 @@ copying that data wastes memory and time. But that means that the
 the `body` from `download_image` and need to make sure to store it
 somewhere for at least as long as we're using the image.[^memoryview]
 
-[^memoryview]: This is a bit of a hack. Perhaps a better solution
-    would be to write the request contents directly into a Skia `Data`
-    object; the `writable_data` API could permit that, but it would
-    require some refactoring of the rest of the browser that I'm
-    choosing to avoid.
+[^memoryview]: I admit it's a bit of a hack to work around the garbage
+    collector like this, but it's just part an parcel of bridging
+    between Python and a C++ library. An alternative would be to write
+    the request contents directly into a Skia `Data` object; the
+    `writable_data` API could permit that, but it would require some
+    refactoring of the `request` method.
     
 Once that `Data` object is created, it is passed to `MakeFromEncoded`.
 The name of this method hints that the image we've downloaded isn't

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -160,6 +160,7 @@ if __name__ == "__main__":
     import sys, argparse
     argparser = argparse.ArgumentParser(description="Compare book blocks to teacher's copy")
     argparser.add_argument("--config", type=str)
+    argparser.add_argument("--chapter", type=str)
     argparser.add_argument("--book", metavar="book.md", type=argparse.FileType("r"))
     argparser.add_argument("--code", metavar="code.py", type=argparse.FileType("r"))
     argparser.add_argument("--file", dest="file", help="Only consider code blocks from this file")
@@ -172,6 +173,7 @@ if __name__ == "__main__":
 
             chapters = data["chapters"]
             for chapter, metadata in data["chapters"].items():
+                if args.chapter and args.chapter != "all" and chapter != args.chapter: continue
                 for key in metadata:
                     value = metadata[key]
                     if key == "disabled":

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -46,11 +46,14 @@ Moreover, the `download_image` method works directly:
 
     >>> body, img = lab15.download_image("/img.png", frame)
     >>> img # doctest: +ELLIPSIS
-    Image(5, 5, ColorType.kRGBA_8888_ColorType, AlphaType.kPremul_AlphaType)
+    Image(5, 5, ..., AlphaType.kPremul_AlphaType)
     >>> img.width()
     5
     >>> img.height()
     5
+    
+The `...` in the image description is because Skia will convert to the
+native byte order, and that can differ between platforms.
     
 Now let's make sure it actually renders:
 

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -22,26 +22,42 @@ This file contains tests for Chapter 15 (Embedded Content).
 Test images
 ===========
 
-This image is 5px wide and 16 px tall:
+This image is 5px wide and 5px tall:
 
     >>> image_url = 'http://test.test/img.png'
     >>> test.socket.respond(image_url, b"HTTP/1.0 200 OK\r\n" +
     ... b"content-type: image/png\r\n\r\n" +
     ... b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x05\x00\x00\x00\x05\x08\x03\x00\x00\x00\xba\xb1\xd6\xd7\x00\x00\x00\x08acTL\x00\x00\x00\x02\x00\x00\x00\x07m\xe9\x06\xd3\x00\x00\x00\x0fPLTE\x00\x00\x00?\x95d\x8f(\x1b\x00\x00\x00\xae\x00\x00|\xbf\xb9\xc7\x00\x00\x00\x03tRNS\x00\x8e\xd1\xae\xa2\x93Y\x00\x00\x00\x1bIDAT\x08\xd7=\x86\xb1\t\x00\x00\x00\x82\x84\xfe\xff\xb9\\R\x04\x89\x10X\xfa\x97\x02\x03\x1b\x004\xee\xba\xc9\xa4\x00\x00\x00\x1afcTL\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00Z\xc7\x00\x00\x00\x0c\xb5\xcf\x19\x00\x00\x00\x13fdAT\x00\x00\x00\x01\x08\xd7\x01\x04\x00\xfb\xff\x01\x04\x00\x00\x00\x14\x00\x06cS\x8f\xf5\x00\x00\x00\x1afcTL\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\x00\xc8\x00d\x00\x01Uz\x1dN\x00\x00\x00\x17fdAT\x00\x00\x00\x03\x08\xd7\x01\x08\x00\xf7\xff\x00\x01\x00\x01\x00\x01\x01\x01\x00\x1a\x00\x061`\xa4\t\x00\x00\x00\x00IEND\xaeB`\x82")
-
-Let's verify that a basic image loads and has the correct dimensions:
+    
+Let's verify that we can request the image:
 
     >>> url = 'http://test.test/'
     >>> test.socket.respond(url, b'HTTP/1.0 200 OK\r\n' +
     ... b'content-type: text/html\r\n\r\n' +
     ... b'<img src="http://test.test/img.png">')
-
     >>> browser = lab15.Browser()
     >>> browser.load(url)
+    >>> frame = browser.tabs[0].root_frame
+    >>> headers, body = lab15.request(image_url, frame)
+    >>> type(body)
+    <class 'bytes'>
+
+Moreover, the `download_image` method works directly:
+
+    >>> img = lab15.download_image("/img.png", frame)
+    >>> img # doctest: +ELLIPSIS
+    <PIL.PngImagePlugin.PngImageFile image mode=P size=5x5 at ...>
+    >>> img.width
+    5
+    >>> img.height
+    5
+    
+Now let's make sure it actually renders:
+
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawImage(rect=Rect(13, 18, 18, 34))
+     DrawImage(rect=Rect(13, 29, 18, 34))
 
 Now let's test setting a different width and height:
 
@@ -75,7 +91,7 @@ Let's load the original image in an iframe.
      SaveLayer(alpha=1.0)
        ClipRRect(RRect(13, 18, 315, 170, 1))
          Transform(translate(14.0, 19.0))
-           DrawImage(rect=Rect(13, 18, 18, 34))
+           DrawImage(rect=Rect(13, 29, 18, 34))
          DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=2)
 
 And the sized one:
@@ -137,7 +153,7 @@ Iframes can be sized too:
      SaveLayer(alpha=1.0)
        ClipRRect(RRect(45, 478, 95, 508, 1))
          Transform(translate(46.0, 479.0))
-           DrawImage(rect=Rect(13, 18, 18, 34))
+           DrawImage(rect=Rect(13, 29, 18, 34))
          DrawOutline(top=478.0 left=45.0 bottom=508.0 right=95.0 border_color=black thickness=2)
 
 Now let's test scrolling of the root frame:

--- a/src/test11.py
+++ b/src/test11.py
@@ -49,7 +49,6 @@ class socket:
             assert self.body == self.URLs[url][2], (self.body, self.URLs[url][2])
         stream = io.BytesIO(output)
         if encoding:
-            encoding = io.text_encoding(encoding)
             stream = io.TextIOWrapper(stream, encoding=encoding, newline=newline)
             stream.mode = mode
         else:

--- a/src/test11.py
+++ b/src/test11.py
@@ -47,11 +47,15 @@ class socket:
         output = self.URLs[url][1]
         if self.URLs[url][2]:
             assert self.body == self.URLs[url][2], (self.body, self.URLs[url][2])
+        stream = io.BytesIO(output)
         if encoding:
-            return io.StringIO(output.decode(encoding).replace(newline, "\n"), newline)
+            encoding = io.text_encoding(encoding)
+            stream = io.TextIOWrapper(stream, encoding=encoding, newline=newline)
+            stream.mode = mode
         else:
-            assert mode == "b"
-            return io.BytesIO(output)
+            assert mode == "b", "If no file encoding is passed, must pass 'b' mode"
+
+        return stream
 
     def close(self):
         self.connected = False


### PR DESCRIPTION
This PR is done, sort of, but it has two "TODO" blocks inside for changes I want @chrishtr's approval on.

At a high level, this PR makes the following changes:

*MIME types*: I moved `decode` on the body out of `request` and into its callers. This avoids the whole discussion of MIME types, since we now `decode` when we expect text and don't `decode` when we expect an image. I think this change is actually important to make, because as it stands, if you put an image URL into, say, a `<script src>`, you'll get a type error inside the browser! That said, we can fix that bug without necessarily removing MIME types; perhaps the caller to `request` can indicate the MIME type it wants, and then `request` can use that information to decide whether or not to decode internally. I'm calling this out explicitly because it's removing a _lot_ of content and I want to make sure it wasn't central.

*PIL/Skia*: I'm not sure why we're using PIL to open and resize images, where as far as I can tell Skia also has an `Image` class that can load encoded data with `MakeFromEncoded`. It might be that PIL is clearer about the decoding, resizing, and so on steps, and in case that's the reason I didn't change anything. (Because that content is clearly central to this section.) But it's worth thinking about whether Skia's `Image` could have the same discussion, at the very least because it's one less library to install.

*Resizing/Quality*: I split the discussion of resizing and resizing quality into two separate steps. I also fixed a bug regarding the `image-rendering` property; we were treating `crisp-edges` as Lanczos filtering, but it should be nearest neighbor according to MDN.

*Download method*: I added a `download_image` method to parallel `decode_image`, so it felt more clearly like this section had two major parts which resulted in two methods.

*Image layout*: I also added an extra test and in the process found a bug. We were decoding images to a height of `self.height`, but that isn't actually the image height—it's the larger of image or font height. This was leading to all images smaller than current text height showing up in the wrong place (`vertical-align: top` instead of `vertical-align: baseline`). This required some changes in the next section as well as multiple changes to the tests. I haven't done a pass over the next section, so if my code changes are kind of ugly, I can change it when passing over that section.

-----

So, before we merge, we need to make at least the following decisions:

- [x] Do we keep or drop MIME types? If we drop it, should we move it into a "Go Further" block or similar?
- [x] Do we keep PIL or switch to Skia? If we switch to Skia, we need to remove the corresponding "Go Further" block. (We have plenty of replacements.)
- [x] Is the image layout change fixing a bug, or did I misinterpret things?