### PR TITLE
Pass over second section on image layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,10 @@ widgets: \
 src/lab%.full.py: src/lab%.py
 	python3 infra/inline.py $< > $@
 
+CHAPTER=all
+
 lint: book/*.md src/*.py
-	python3 infra/compare.py --config config.json
+	python3 infra/compare.py --config config.json --chapter $(CHAPTER)
 	! grep -n '^```' book/*.md | awk '(NR % 2) {print}' | grep -v '{.'
 
 PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json $(FLAGS)

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1065,7 +1065,7 @@ And set here:
 class IframeLayout(EmbedLayout):
     def layout(self, zoom):
         # ...
-        self.node.frame.frame_height haelf.height - 2
+        self.node.frame.frame_height = self.height - 2
         self.node.frame.frame_width = self.width - 2
 ```
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -5,19 +5,13 @@ prev: accessibility
 next: invalidation
 ...
 
-Our toy browser has a lot of rendering features, but is still missing a few
-present on pretty much every website. The most obvious is *images*---given how
-ubiquitous they are, it seems silly to have even a toy browser without images.
-But images are only the simplest form of *embedded content* within a web page,
-a much bigger topic, and one that has a lot of interesting implications for how
-browser engines work. That's mostly due to how powerful *iframes* are, since
-they allow you to embed one website in another.
-
-The fact is, a toy browser without images or iframes simply wouldn't cover some
-very important architectural aspects of real browsers with important
-performance, security and open information access implications. So let's now
-implement them to see. And in keeping with the pattern you've already seen,
-basic support for these features is easy enough to implement in one chapter!
+While our toy browser can render complex styles, visual effects, and
+animations, all of those apply basically just to text. Yet web pages
+contain a variety of non-text *embedded content*, from images through
+to iframes that embed one web page inside another. Embedded content of
+this sort has been essential throughout the web's history, and support
+for embedded content has powerful implications for browser
+architecture, performance, security, and open information access.
 
 Images
 ======

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -160,6 +160,7 @@ if __name__ == "__main__":
     import sys, argparse
     argparser = argparse.ArgumentParser(description="Compare book blocks to teacher's copy")
     argparser.add_argument("--config", type=str)
+    argparser.add_argument("--chapter", type=str)
     argparser.add_argument("--book", metavar="book.md", type=argparse.FileType("r"))
     argparser.add_argument("--code", metavar="code.py", type=argparse.FileType("r"))
     argparser.add_argument("--file", dest="file", help="Only consider code blocks from this file")
@@ -172,6 +173,7 @@ if __name__ == "__main__":
 
             chapters = data["chapters"]
             for chapter, metadata in data["chapters"].items():
+                if args.chapter and args.chapter != "all" and chapter != args.chapter: continue
                 for key in metadata:
                     value = metadata[key]
                     if key == "disabled":

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -45,7 +45,7 @@ Let's verify that we can request the image:
 Moreover, the `download_image` method works directly:
 
     >>> frame.nodes.children[0].children[0].image #doctest: +ELLIPSIS
-    Image(5, 5, ColorType.kRGBA_8888_ColorType, AlphaType.kPremul_AlphaType)
+    Image(5, 5, ..., AlphaType.kPremul_AlphaType)
     
 The `...` in the image description is because Skia will convert to the
 native byte order, and that can differ between platforms.

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -46,11 +46,14 @@ Moreover, the `download_image` method works directly:
 
     >>> body, img = lab15.download_image("/img.png", frame)
     >>> img # doctest: +ELLIPSIS
-    Image(5, 5, ColorType.kRGBA_8888_ColorType, AlphaType.kPremul_AlphaType)
+    Image(5, 5, ..., AlphaType.kPremul_AlphaType)
     >>> img.width()
     5
     >>> img.height()
     5
+    
+The `...` in the image description is because Skia will convert to the
+native byte order, and that can differ between platforms.
     
 Now let's make sure it actually renders:
 

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -22,26 +22,42 @@ This file contains tests for Chapter 15 (Embedded Content).
 Test images
 ===========
 
-This image is 5px wide and 16 px tall:
+This image is 5px wide and 5px tall:
 
     >>> image_url = 'http://test.test/img.png'
     >>> test.socket.respond(image_url, b"HTTP/1.0 200 OK\r\n" +
     ... b"content-type: image/png\r\n\r\n" +
     ... b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x05\x00\x00\x00\x05\x08\x03\x00\x00\x00\xba\xb1\xd6\xd7\x00\x00\x00\x08acTL\x00\x00\x00\x02\x00\x00\x00\x07m\xe9\x06\xd3\x00\x00\x00\x0fPLTE\x00\x00\x00?\x95d\x8f(\x1b\x00\x00\x00\xae\x00\x00|\xbf\xb9\xc7\x00\x00\x00\x03tRNS\x00\x8e\xd1\xae\xa2\x93Y\x00\x00\x00\x1bIDAT\x08\xd7=\x86\xb1\t\x00\x00\x00\x82\x84\xfe\xff\xb9\\R\x04\x89\x10X\xfa\x97\x02\x03\x1b\x004\xee\xba\xc9\xa4\x00\x00\x00\x1afcTL\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00Z\xc7\x00\x00\x00\x0c\xb5\xcf\x19\x00\x00\x00\x13fdAT\x00\x00\x00\x01\x08\xd7\x01\x04\x00\xfb\xff\x01\x04\x00\x00\x00\x14\x00\x06cS\x8f\xf5\x00\x00\x00\x1afcTL\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x02\x00\xc8\x00d\x00\x01Uz\x1dN\x00\x00\x00\x17fdAT\x00\x00\x00\x03\x08\xd7\x01\x08\x00\xf7\xff\x00\x01\x00\x01\x00\x01\x01\x01\x00\x1a\x00\x061`\xa4\t\x00\x00\x00\x00IEND\xaeB`\x82")
-
-Let's verify that a basic image loads and has the correct dimensions:
+    
+Let's verify that we can request the image:
 
     >>> url = 'http://test.test/'
     >>> test.socket.respond(url, b'HTTP/1.0 200 OK\r\n' +
     ... b'content-type: text/html\r\n\r\n' +
     ... b'<img src="http://test.test/img.png">')
-
     >>> browser = lab15.Browser()
     >>> browser.load(url)
+    >>> frame = browser.tabs[0].root_frame
+    >>> headers, body = lab15.request(image_url, frame)
+    >>> type(body)
+    <class 'bytes'>
+
+Moreover, the `download_image` method works directly:
+
+    >>> img = lab15.download_image("/img.png", frame)
+    >>> img # doctest: +ELLIPSIS
+    <PIL.PngImagePlugin.PngImageFile image mode=P size=5x5 at ...>
+    >>> img.width
+    5
+    >>> img.height
+    5
+    
+Now let's make sure it actually renders:
+
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     DrawImage(rect=Rect(13, 18, 18, 34))
+     DrawImage(rect=Rect(13, 29, 18, 34))
 
 Now let's test setting a different width and height:
 
@@ -75,7 +91,7 @@ Let's load the original image in an iframe.
      SaveLayer(alpha=1.0)
        ClipRRect(RRect(13, 18, 315, 170, 1))
          Transform(translate(14.0, 19.0))
-           DrawImage(rect=Rect(13, 18, 18, 34))
+           DrawImage(rect=Rect(13, 29, 18, 34))
          DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=2)
 
 And the sized one:
@@ -137,7 +153,7 @@ Iframes can be sized too:
      SaveLayer(alpha=1.0)
        ClipRRect(RRect(45, 478, 95, 508, 1))
          Transform(translate(46.0, 479.0))
-           DrawImage(rect=Rect(13, 18, 18, 34))
+           DrawImage(rect=Rect(13, 29, 18, 34))
          DrawOutline(top=478.0 left=45.0 bottom=508.0 right=95.0 border_color=black thickness=2)
 
 Now let's test scrolling of the root frame:

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -44,13 +44,8 @@ Let's verify that we can request the image:
 
 Moreover, the `download_image` method works directly:
 
-    >>> body, img = lab15.download_image("/img.png", frame)
-    >>> img # doctest: +ELLIPSIS
-    Image(5, 5, ..., AlphaType.kPremul_AlphaType)
-    >>> img.width()
-    5
-    >>> img.height()
-    5
+    >>> frame.nodes.children[0].children[0].image #doctest: +ELLIPSIS
+    Image(5, 5, ColorType.kRGBA_8888_ColorType, AlphaType.kPremul_AlphaType)
     
 The `...` in the image description is because Skia will convert to the
 native byte order, and that can differ between platforms.

--- a/src/test11.py
+++ b/src/test11.py
@@ -49,7 +49,6 @@ class socket:
             assert self.body == self.URLs[url][2], (self.body, self.URLs[url][2])
         stream = io.BytesIO(output)
         if encoding:
-            encoding = io.text_encoding(encoding)
             stream = io.TextIOWrapper(stream, encoding=encoding, newline=newline)
             stream.mode = mode
         else:

--- a/src/test11.py
+++ b/src/test11.py
@@ -47,11 +47,15 @@ class socket:
         output = self.URLs[url][1]
         if self.URLs[url][2]:
             assert self.body == self.URLs[url][2], (self.body, self.URLs[url][2])
+        stream = io.BytesIO(output)
         if encoding:
-            return io.StringIO(output.decode(encoding).replace(newline, "\n"), newline)
+            encoding = io.text_encoding(encoding)
+            stream = io.TextIOWrapper(stream, encoding=encoding, newline=newline)
+            stream.mode = mode
         else:
-            assert mode == "b"
-            return io.BytesIO(output)
+            assert mode == "b", "If no file encoding is passed, must pass 'b' mode"
+
+        return stream
 
     def close(self):
         self.connected = False


### PR DESCRIPTION
This PR contains a pass over the second section on image layout. It's probably worth reading, but there are some TODO items below that need discussion:

- [x] I moved loading out of `ImageLayout` and into the main `Frame.load` method. This make the already-long `load` method even longer, which I'm not thrilled with, but at least it parallels existing code and gets all the loading done on initial page load. It also didn't make sense to have a separate `download_image` method at this point.
- [x] I also described `EmbedLayout` a bit different, as if it's a renamed `InputLayout` that's been hollowed out. I'm not sure if this is exactly right, but we should try to make it right.
- [x] I split the `width` and `height` attributes to their own section. I'll maybe merge it back after I pass on that.

Still needs discussion:

- [x] We need to update Chapter 15 to use the unified `BlockLayout`
- [x] We also don't have good behavior when an image fails to load. At the very least, we need to make that not crash
- [x] I'm not thrilled that we have parallel `image`, `input`,`text`, and `iframe` methods in `InlineLayout` soon to be `BlockLayout`—could reinforce the abstraction layer here.
- [-] It would be nice to clean up `load`, probably in the `Task` chapter.