### PR TITLE
Refactor child methods of InlineLayout to reduce repeated code

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -941,7 +941,7 @@ class Tab:
 
 All of this activation code is copied from the `click` method on
 `Tab`s, which can now be rewritten to call `activate_element`
-directly:
+directly. Code is also needed in `keypress` to activate if needed:
 
 ``` {.python}
 class Tab:
@@ -955,6 +955,11 @@ class Tab:
                 self.set_needs_render()
                 return
             elt = elt.parent
+
+    def keypress(self, char):
+        if self.focus and self.focus.tag == "input":
+            if not "value" in self.focus.attributes:
+                self.activate_element(self.focus)
 ```
 
 Note that hitting `Enter` when focused on a text entry clears the text

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -367,12 +367,15 @@ varies depending on the child type.
 
 ``` {.python}
 class BlockLayout(LayoutObject):
-    def add_inline_child(self, node, zoom, w, child_class, extra_param):
+    def add_inline_child(self, node, zoom, w, child_class, frame, word=None):
         font = self.font(node, zoom)
         if self.cursor_x + w > self.x + self.width:
             self.new_line()
         line = self.children[-1]
-        child = child_class(node, line, self.previous_word, extra_param)
+        if word:
+            child = child_class(node, line, self.previous_word, word)
+        else:
+            child = child_class(node, line, self.previous_word, frame)
         line.children.append(child)
         self.previous_word = child
         self.cursor_x += w + font.measureText(" ")
@@ -387,7 +390,7 @@ class BlockLayout(LayoutObject):
         font = self.font(node, zoom)
         for word in node.text.split():
             w = font.measureText(word)
-            self.add_inline_child(node, zoom, w, TextLayout, word)
+            self.add_inline_child(node, zoom, w, TextLayout, self.frame, word)
 
     def input(self, node, zoom):
         w = device_px(INPUT_WIDTH_PX, zoom)

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -283,11 +283,12 @@ class LayoutObject:
         pass
 ```
 
-``` {.python}
+``` {.python replace=tab/frame}
 class EmbedLayout(LayoutObject):
-    def __init__(self, node, parent=None, previous=None):
+    def __init__(self, node, tab, parent, previous):
         super().__init__()
         self.node = node
+        self.tab = tab
         node.layout_object = self
         self.children = []
         self.parent = parent
@@ -321,10 +322,10 @@ class EmbedLayout(LayoutObject):
 
 Now `InputLayout` looks like this:
 
-``` {.python}
+``` {.python replace=tab/frame}
 class InputLayout(EmbedLayout):
-    def __init__(self, node, parent, previous):
-        super().__init__(node, parent, previous)
+    def __init__(self, node, parent, previous, tab):
+        super().__init__(node, tab, parent, previous)
 
     def layout(self, zoom):
         super().layout(zoom)
@@ -333,13 +334,54 @@ class InputLayout(EmbedLayout):
         self.height = linespace(self.font)
 ```
 
-And `ImageLayout` is almost the same. The two key differences
-are the need to actually load the image off the network, and then use
-the size of the image to size the `ImageLayout`. Let's start with loading.
-After loading, the image is stored on the `node`. But this adds some complexity
-in the `image` function we need to add on `InlineLayout`, because first it needs
-to load the image and only then set its `parent` and `previous` fields. That'll
-be via a new `init` method call.
+And `ImageLayout` is almost the same. In `InputLayout`, the new `image`
+method is actually almost a carbon copy of `input` and `text`. So now we have
+three methods that are almost identical for each atomic piece of inline content.
+The two things in common are computing the font:
+
+``` {.python}
+class InlineLayout(LayoutObject):
+    def get_font(self, node, zoom):
+        weight = node.style["font-weight"]
+        style = node.style["font-style"]
+        font_size = device_px(float(node.style["font-size"][:-2]), zoom)
+        return get_font(font_size, weight, font_size)
+```
+
+And adding an inline child layout object. In this case we need to parameterize
+it with the name of the child class to instantiate, and an `extra_param` that
+varies depending on the child type.
+
+``` {.python}
+class InlineLayout(LayoutObject):
+    def add_inline_child(self, node, font, w, child_class, extra_param):
+        if self.cursor_x + w > self.x + self.width:
+            self.new_line()
+        line = self.children[-1]
+        child = child_class(node, line, self.previous_word, extra_param)
+        line.children.append(child)
+        self.previous_word = child
+        self.cursor_x += w + font.measureText(" ")
+```
+
+We can redefine  `text` and `input` in a satisfying way now:
+
+
+``` {.python}
+class InlineLayout(LayoutObject):
+    def text(self, node, zoom):
+        font = self.get_font(node, zoom)
+        for word in node.text.split():
+            w = font.measureText(word)
+            self.add_inline_child(node, font, w, TextLayout, word)
+
+    def input(self, node, zoom):
+        font = self.get_font(node, zoom)
+        w = device_px(INPUT_WIDTH_PX, zoom)
+        self.add_inline_child(node, font, w, InputLayout, self.frame) 
+```
+
+Finally, now here is `image`:
 
 ``` {.python}
 class InlineLayout(LayoutObject):
@@ -349,55 +391,21 @@ class InlineLayout(LayoutObject):
                 self.image(node, zoom)
     
     def image(self, node, zoom):
-        img = ImageLayout(node, self.frame)
-        w = device_px(node.image.width(), zoom)
-        if self.cursor_x + w > self.x + self.width:
-            self.new_line()
-        line = self.children[-1]
-        img.init(line, self.previous_word)
-        line.children.append(img)
-        self.previous_word = img
-        weight = node.style["font-weight"]
-        style = node.style["font-style"]
-        size = device_px(float(node.style["font-size"][:-2]), zoom)
-        font = get_font(size, weight, size)
-        self.cursor_x += w + font.measureText(" ")
+        font = self.get_font(node, zoom)
+        if "width" in node.attributes:
+            w = device_px(int(node.attributes["width"]), zoom)
+        else:
+            w = device_px(node.image.width(), zoom)
+        self.add_inline_child(node, font, w, ImageLayout, self.frame)
 ```
-
-And here is `ImageLayout`. Note how we're loading the image, but not
-yet decoding it, because we don't know the painted size until layout is done.
-
-``` {.python}
-class ImageLayout(EmbedLayout):
-    def __init__(self, node, frame):
-        super().__init__(node)
-        if not hasattr(self.node, "image"):
-            self.load(frame)
-
-    def load(self, frame):
-        assert "src" in self.node.attributes
-        link = self.node.attributes["src"]
-        try:
-            data, image = download_image(link, frame)
-        except Exception as e:
-            print("Image error:", e)
-            data, image = None, None
-        self.node.encoded_data = data
-        self.node.image = image
-
-    def init(self, parent, previous):
-        self.parent = parent
-        self.previous = previous
-    # ...
-```
-
-Note that we save both the encoded data and the image, because of the
-`MakeWithoutCopy` optimizaion we used in `download_image`
 
 Then there is layout, which shares all the code except sizing:
 
 ``` {.python expected=False}
 class ImageLayout(EmbedLayout):
+    def __init__(self, node, parent, previous, tab):
+        super().__init__(node, tab)
+
     def layout(self, zoom):
         super().layout(zoom)
         self.width = device_px(self.node.image.width(), zoom)
@@ -916,10 +924,9 @@ IFRAME_DEFAULT_WIDTH_PX = 300
 IFRAME_DEFAULT_HEIGHT_PX = 150
 ```
 
-Iframe layout in `InlineLayout` is a lot like images. The only difference
-is the width calculation, so I've omitted the rest with "..."
-instead. I've added 2 to the width and height in these calculations to provide
-room for the painted border to come.
+Iframe layout in `InlineLayout` is a lot like images. I've added 2 to the width
+and height in these calculations to provide room for the painted border to
+come.
 
 ``` {.python}
 class InlineLayout(LayoutObject):
@@ -930,11 +937,12 @@ class InlineLayout(LayoutObject):
                 self.iframe(node, zoom)
     # ...
     def iframe(self, node, zoom):
+        font = self.get_font(node, zoom)
         if "width" in self.node.attributes:
             w = device_px(int(self.node.attributes["width"]), zoom)
         else:
             w = IFRAME_DEFAULT_WIDTH_PX + 2
-        # ...
+        self.add_inline_child(node, font, w, IframeLayout, self.frame)
 ```
 
 And the `IframeLayout` layout code is also similar, and also inherits from
@@ -944,7 +952,7 @@ aspect ratio, because iframes don't have an intrinsic size.)
 ``` {.python}
 class IframeLayout(EmbedLayout):
     def __init__(self, node, parent, previous, parent_frame):
-        super().__init__(node, parent, previous)
+        super().__init__(node, parent_frame, parent, previous)
 
     def layout(self, zoom):
         # ...

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -349,14 +349,13 @@ class BlockLayout(LayoutObject):
         return get_font(font_size, weight, font_size)
 
     def recurse(self, node, zoom):
-        font = self.font(node, zoom)
         if isinstance(node, Text):
-            self.text(node, zoom, font)
+            self.text(node, zoom)
         else:
             if node.tag == "br":
                 self.new_line()
             elif node.tag == "input" or node.tag == "button":
-                self.input(node, zoom, font)
+                self.input(node, zoom)
             else:
                 for child in node.children:
                     self.recurse(child, zoom)
@@ -368,7 +367,8 @@ varies depending on the child type.
 
 ``` {.python}
 class BlockLayout(LayoutObject):
-    def add_inline_child(self, node, font, w, child_class, extra_param):
+    def add_inline_child(self, node, zoom, w, child_class, extra_param):
+        font = self.font(node, zoom)
         if self.cursor_x + w > self.x + self.width:
             self.new_line()
         line = self.children[-1]
@@ -383,14 +383,15 @@ We can redefine  `text` and `input` in a satisfying way now:
 
 ``` {.python}
 class BlockLayout(LayoutObject):
-    def text(self, node, zoom, font):
+    def text(self, node, zoom):
+        font = self.font(node, zoom)
         for word in node.text.split():
             w = font.measureText(word)
-            self.add_inline_child(node, font, w, TextLayout, word)
+            self.add_inline_child(node, zoom, w, TextLayout, word)
 
-    def input(self, node, zoom, font):
+    def input(self, node, zoom):
         w = device_px(INPUT_WIDTH_PX, zoom)
-        self.add_inline_child(node, font, w, InputLayout, self.frame) 
+        self.add_inline_child(node, zoom, w, InputLayout, self.frame) 
 ```
 
 Finally, now here is `image`:
@@ -400,14 +401,14 @@ class BlockLayout(LayoutObject):
     def recurse(self, node, zoom):
             # ...
             elif node.tag == "img":
-                self.image(node, zoom, font)
+                self.image(node, zoom)
     
-    def image(self, node, zoom, font):
+    def image(self, node, zoom):
         if "width" in node.attributes:
             w = device_px(int(node.attributes["width"]), zoom)
         else:
             w = device_px(node.image.width(), zoom)
-        self.add_inline_child(node, font, w, ImageLayout, self.frame)
+        self.add_inline_child(node, zoom, w, ImageLayout, self.frame)
 ```
 
 Then there is layout, which shares all the code except sizing:
@@ -511,7 +512,7 @@ easy, and we need to multiply by zoom to get device pixels:
 ``` {.python}
 class BlockLayout(LayoutObject):
     # ...
-    def image(self, node, zoom, font):
+    def image(self, node, zoom):
         if "width" in node.attributes:
             w = device_px(int(node.attributes["width"]), zoom)
         else:
@@ -945,14 +946,14 @@ class BlockLayout(LayoutObject):
     def recurse(self, node, zoom):
         # ...
             elif node.tag == "iframe":
-                self.iframe(node, zoom, font)
+                self.iframe(node, zoom)
     # ...
-    def iframe(self, node, zoom, font):
+    def iframe(self, node, zoom):
         if "width" in self.node.attributes:
             w = device_px(int(self.node.attributes["width"]), zoom)
         else:
             w = IFRAME_DEFAULT_WIDTH_PX + 2
-        self.add_inline_child(node, font, w, IframeLayout, self.frame)
+        self.add_inline_child(node, zoom, w, IframeLayout, self.frame)
 ```
 
 And the `IframeLayout` layout code is also similar, and also inherits from

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -367,7 +367,7 @@ it with the name of the child class to instantiate, and an `extra_param` that
 varies depending on the child type.
 
 ``` {.python}
-class InlineLayout(LayoutObject):
+class BlockLayout(LayoutObject):
     def add_inline_child(self, node, font, w, child_class, extra_param):
         if self.cursor_x + w > self.x + self.width:
             self.new_line()
@@ -382,7 +382,7 @@ We can redefine  `text` and `input` in a satisfying way now:
 
 
 ``` {.python}
-class InlineLayout(LayoutObject):
+class BlockLayout(LayoutObject):
     def text(self, node, zoom, font):
         for word in node.text.split():
             w = font.measureText(word)
@@ -396,7 +396,7 @@ class InlineLayout(LayoutObject):
 Finally, now here is `image`:
 
 ``` {.python}
-class InlineLayout(LayoutObject):
+class BlockLayout(LayoutObject):
     def recurse(self, node, zoom):
             # ...
             elif node.tag == "img":

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -347,18 +347,6 @@ class BlockLayout(LayoutObject):
         style = node.style["font-style"]
         font_size = device_px(float(node.style["font-size"][:-2]), zoom)
         return get_font(font_size, weight, font_size)
-
-    def recurse(self, node, zoom):
-        if isinstance(node, Text):
-            self.text(node, zoom)
-        else:
-            if node.tag == "br":
-                self.new_line()
-            elif node.tag == "input" or node.tag == "button":
-                self.input(node, zoom)
-            else:
-                for child in node.children:
-                    self.recurse(child, zoom)
 ```
 
 And adding an inline child layout object. In this case we need to parameterize

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -334,7 +334,6 @@ class InputLayout(EmbedLayout):
         self.height = linespace(self.font)
 ```
 
-<<<<<<< HEAD
 And `ImageLayout` is almost the same. In `InputLayout`, the new `image`
 method is actually almost a carbon copy of `input` and `text`. So now we have
 three methods that are almost identical for each atomic piece of inline content.
@@ -342,25 +341,13 @@ The two things in common are computing the font  (and passing it to the various
 functions):
 
 ``` {.python}
-class InlineLayout(LayoutObject):
+class BlockLayout(LayoutObject):
     def font(self, node, zoom):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         font_size = device_px(float(node.style["font-size"][:-2]), zoom)
         return get_font(font_size, weight, font_size)
 
-=======
-And `ImageLayout` is almost the same. The two key differences
-are the need to actually load the image off the network, and then use
-the size of the image to size the `ImageLayout`. Let's start with loading.
-After loading, the image is stored on the `node`. But this adds some complexity
-in the `image` function we need to add on `BlockLayout`, because first it needs
-to load the image and only then set its `parent` and `previous` fields. That'll
-be via a new `init` method call.
-
-``` {.python}
-class BlockLayout(LayoutObject):
->>>>>>> df1374481dc53e59d44f41bc93611e66b89737eb
     def recurse(self, node, zoom):
         font = self.font(node, zoom)
         if isinstance(node, Text):
@@ -948,16 +935,9 @@ IFRAME_DEFAULT_WIDTH_PX = 300
 IFRAME_DEFAULT_HEIGHT_PX = 150
 ```
 
-<<<<<<< HEAD
-Iframe layout in `InlineLayout` is a lot like images. I've added 2 to the width
+Iframe layout in `BlockLayout` is a lot like images. I've added 2 to the width
 and height in these calculations to provide room for the painted border to
 come.
-=======
-Iframe layout in `BlockLayout` is a lot like images. The only difference
-is the width calculation, so I've omitted the rest with "..."
-instead. I've added 2 to the width and height in these calculations to provide
-room for the painted border to come.
->>>>>>> df1374481dc53e59d44f41bc93611e66b89737eb
 
 ``` {.python}
 class BlockLayout(LayoutObject):

--- a/book/forms.md
+++ b/book/forms.md
@@ -207,7 +207,10 @@ are self-closing, they never have children.
     the exercises below.
 
 Finally, this new `input` method is similar to the `text` method,
-creating a new layout object and adding it to the current line:
+creating a new layout object and adding it to the current line:^[It's so
+similar in fact that they only differ in the `w` variable definition.
+I'll resist the temptation to refactor this code until we get to
+[Chapter 15](embeds.md).]
 
 ``` {.python}
 class BlockLayout:

--- a/book/forms.md
+++ b/book/forms.md
@@ -206,10 +206,10 @@ are self-closing, they never have children.
 [^but-exercise]: Though you'll need to do this differently for one of
     the exercises below.
 
-Finally, this new `input` method is similar to the `text` method,
-creating a new layout object and adding it to the current line:^[It's so
-similar in fact that they only differ in the `w` variable definition.
-I'll resist the temptation to refactor this code until we get to
+Finally, this new `input` method is similar to the `text` method, creating a new
+layout object and adding it to the current line:^[It's so similar in fact that
+they only differ in the `w` variable definition, and the need to loop over
+words. I'll resist the temptation to refactor this code until we get to
 [Chapter 15](embeds.md).]
 
 ``` {.python}

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1188,7 +1188,7 @@ class Tab:
         self.load(url, body)
 
     def keypress(self, char):
-        if self.focus:
+        if self.focus and self.focus.tag == "input":
             if not "value" in self.focus.attributes:
                 self.activate_element(self.focus)
             if self.js.dispatch_event("keydown", self.focus): return

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1189,6 +1189,8 @@ class Tab:
 
     def keypress(self, char):
         if self.focus:
+            if not "value" in self.focus.attributes:
+                self.activate_element(self.focus)
             if self.js.dispatch_event("keydown", self.focus): return
             self.focus.attributes["value"] += char
             self.set_needs_render()

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -393,7 +393,7 @@ class InlineLayout(LayoutObject):
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def get_font(self, node, zoom):
+    def font(self, node, zoom):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         font_size = device_px(float(node.style["font-size"][:-2]), zoom)
@@ -409,18 +409,18 @@ class InlineLayout(LayoutObject):
         self.cursor_x += w + font.measureText(" ")
 
     def text(self, node, zoom):
-        font = self.get_font(node, zoom)
+        font = self.font(node, zoom)
         for word in node.text.split():
             w = font.measureText(word)
             self.add_inline_child(node, font, w, TextLayout, word)
 
     def input(self, node, zoom):
-        font = self.get_font(node, zoom)
+        font = self.font(node, zoom)
         w = device_px(INPUT_WIDTH_PX, zoom)
         self.add_inline_child(node, font, w, InputLayout, self.frame) 
 
     def image(self, node, zoom):
-        font = self.get_font(node, zoom)
+        font = self.font(node, zoom)
         if "width" in node.attributes:
             w = device_px(int(node.attributes["width"]), zoom)
         else:
@@ -428,7 +428,7 @@ class InlineLayout(LayoutObject):
         self.add_inline_child(node, font, w, ImageLayout, self.frame)
 
     def iframe(self, node, zoom):
-        font = self.get_font(node, zoom)
+        font = self.font(node, zoom)
         if "width" in self.node.attributes:
             w = device_px(int(self.node.attributes["width"]), zoom)
         else:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -253,12 +253,15 @@ class BlockLayout(LayoutObject):
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def add_inline_child(self, node, zoom, w, child_class, extra_param):
+    def add_inline_child(self, node, zoom, w, child_class, frame, word=None):
         font = self.font(node, zoom)
         if self.cursor_x + w > self.x + self.width:
             self.new_line()
         line = self.children[-1]
-        child = child_class(node, line, self.previous_word, extra_param)
+        if word:
+            child = child_class(node, line, self.previous_word, word)
+        else:
+            child = child_class(node, line, self.previous_word, frame)
         line.children.append(child)
         self.previous_word = child
         self.cursor_x += w + font.measureText(" ")
@@ -267,7 +270,7 @@ class BlockLayout(LayoutObject):
         font = self.font(node, zoom)
         for word in node.text.split():
             w = font.measureText(word)
-            self.add_inline_child(node, zoom, w, TextLayout, word)
+            self.add_inline_child(node, zoom, w, TextLayout, self.frame, word)
 
     def input(self, node, zoom):
         font = self.font(node, zoom)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -231,18 +231,17 @@ class BlockLayout(LayoutObject):
         return get_font(font_size, weight, font_size)
 
     def recurse(self, node, zoom):
-        font = self.font(node, zoom)
         if isinstance(node, Text):
-            self.text(node, zoom, font)
+            self.text(node, zoom)
         else:
             if node.tag == "br":
                 self.new_line()
             elif node.tag == "input" or node.tag == "button":
-                self.input(node, zoom, font)
+                self.input(node, zoom)
             elif node.tag == "img":
-                self.image(node, zoom, font)
+                self.image(node, zoom)
             elif node.tag == "iframe":
-                self.iframe(node, zoom, font)
+                self.iframe(node, zoom)
             else:
                 for child in node.children:
                     self.recurse(child, zoom)
@@ -254,7 +253,8 @@ class BlockLayout(LayoutObject):
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def add_inline_child(self, node, font, w, child_class, extra_param):
+    def add_inline_child(self, node, zoom, w, child_class, extra_param):
+        font = self.font(node, zoom)
         if self.cursor_x + w > self.x + self.width:
             self.new_line()
         line = self.children[-1]
@@ -263,31 +263,30 @@ class BlockLayout(LayoutObject):
         self.previous_word = child
         self.cursor_x += w + font.measureText(" ")
 
-    def text(self, node, zoom, font):
+    def text(self, node, zoom):
+        font = self.font(node, zoom)
         for word in node.text.split():
             w = font.measureText(word)
-            self.add_inline_child(node, font, w, TextLayout, word)
+            self.add_inline_child(node, zoom, w, TextLayout, word)
 
-    def input(self, node, zoom, font):
+    def input(self, node, zoom):
         font = self.font(node, zoom)
         w = device_px(INPUT_WIDTH_PX, zoom)
-        self.add_inline_child(node, font, w, InputLayout, self.frame) 
+        self.add_inline_child(node, zoom, w, InputLayout, self.frame) 
 
-    def image(self, node, zoom, font):
-        font = self.font(node, zoom)
+    def image(self, node, zoom):
         if "width" in node.attributes:
             w = device_px(int(node.attributes["width"]), zoom)
         else:
             w = device_px(node.image.width(), zoom)
-        self.add_inline_child(node, font, w, ImageLayout, self.frame)
+        self.add_inline_child(node, zoom, w, ImageLayout, self.frame)
 
-    def iframe(self, node, zoom, font):
-        font = self.font(node, zoom)
+    def iframe(self, node, zoom):
         if "width" in self.node.attributes:
             w = device_px(int(self.node.attributes["width"]), zoom)
         else:
             w = IFRAME_DEFAULT_WIDTH_PX + 2
-        self.add_inline_child(node, font, w, IframeLayout, self.frame)
+        self.add_inline_child(node, zoom, w, IframeLayout, self.frame)
 
     def paint(self, display_list):
         cmds = []


### PR DESCRIPTION
...and emphasize to the reader how much they have in common.

I made the minimum edits to the chapter to make linting pass and remove/update obviously out of date commentary. 

I also moved image loading to `load`, because it was necessary to complete the refactoring.

And I found and fixed a bug where keypress after focus tabbing didn't activate an input element, and so
text entry didn't work. (unlike focusing it via click ). This bug is present in chapter 14 also, and I fixed it in both chapters.