### PR TITLE
Pass on iframe security section

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1991,69 +1991,68 @@ like [Rust][rust] have message-passing as a core language feature.
 Iframe security
 ===============
 
-I've already discussed security in Chapter 10, but iframes cause new classes of
-serious security problems that are worth briefly covering here. However, there
-isn't anything new to implement in our browser for this section, so consider it
-optional reading.
+Iframes add a whole new layer of security challenges atop what we
+discussed in [Chapter 10](security.md). The power to embed one web
+page into another creates a commensurate security risk when the two
+pages don't trust each other---both in the case of embedding a trusted
+page into your own page, and the reverse, where an attacker embeds
+your page into their own, malicious one. In both cases, we want to
+protect your page from any security or privacy risks caused by the
+other frame.
 
-Iframes are very powerful, because they allow a web page to embed another one.
-But with that power comes a commensurate security risk in cases where the
-embedded web page is cross-origin to the main page. After all, it's literally a
-web page controlled by someone else that renders into the same tab as yours.
-And since it's unlikely that you really trust that other web page, you want to
-be protected from any security or privacy risks that page may represent.
-
-The fact that cross-origin iframes can't access their parents directly already
-provides a reasonable starting point. But it doesn't protect you if a
-browser bug allows JavaScript in an iframe to cause a
-[buffer overrun][buffer-overrun], which an attacker exploits to run
-arbitrary code. To protect against such a situation, browsers these days
-load web pages in a security [*sandbox*][sandbox], which prevents arbitrary
-code from such an attack from escaping the sandbox, thus (usually) protecting
-your OS, cookies, personal data and so on from being compromised.
-But we'd also like to separate the frames in a web page from each other,
-because there is also of plenty of user data embedded directly in each page.
+The starting point is that cross-origin iframes can't access each
+other directly. But what if a [buffer overrun][buffer-overrun] lets an
+iframe run arbitrary code on your computer, circumventing these
+restrictions? To protect against such a situation, browsers these days
+load web pages in a security [*sandbox*][sandbox], wherein the
+operating system prevents even arbitrary code from accessing files,
+personal data, or other processes, including other frames. This
+technique is called [*site isolation*][site-isolation].
 
 [buffer-overrun]: https://en.wikipedia.org/wiki/Buffer_overflow
 
-That's the reason many browsers these days place each iframe in its own CPU
-process sandbox; this technique is called
-[*site isolation*][site-isolation]. Implementing site isolation seems
-conceptually "straightforward", in the same sense that the browser thread we
-added in chapter 13 is "straightforward". In practice, there are so many
-browser APIs and subtleties that both features are extremely complex and subtle
-in their full glory. That's why it took many years for Chromium to ship the
-first implementation of site isolation.
+Implementing site isolation seems conceptually "straightforward", in
+the same sense that the browser thread we added in [Chapter
+13](scheduling.md) is "straightforward". In practice, the many browser
+APIs mean both are full of subtleties and end up being extremely
+complex. Chromium, for example, took many years to ship the first
+implementation of site isolation.
 
 [sandbox]: https://en.wikipedia.org/wiki/Sandbox_(computer_security)
 
 [site-isolation]: https://www.chromium.org/Home/chromium-security/site-isolation/
 
-The importance of site isolation has greatly increased in recent years, due to
-the discovery of certain CPU cache timing attacks called *spectre*
-and *meltdown*.^[There's even a
-[website devoted to them][spectre-meltdown]---check out the videos and links on
-the website to see it in action!] In short, these attacks allow an attacker to
-read arbitrary locations in memory (e.g., the user's data!)
-as long as you have access to a high-precision timer. They do so by exploiting
-the timing of various features in modern CPUs. Placing sensitive content
-in different CPU processes (which come with their own memory address spaces) is
-a good protection against these attacks, and that's just what site isolation
-does.
+Site isolation has become much more important recent years, due to the
+CPU cache timing attacks called [*spectre* and
+*meltdown*][spectre-meltdown]. In short, these attacks allow an
+attacker to read arbitrary locations in memory---including another
+frame's data, if the two frames are in the same process---by measuring
+the time certain operations take. Placing sensitive content in
+different CPU processes (which come with their own memory address
+spaces) is a good protection against these attacks, and that's just
+what site isolation does.
 
 [spectre-meltdown]: https://meltdownattack.com/
 
-But that's not the only protection needed. It's also important to 
-*remove high-precision timers*^[A *high precision timer* is anything that can
- measure duration of execution of code very accurately.] from the platform. So
- browsers did things like reducing the accuracy of APIs like `Date.now` or
- `setTimeout`. But there are some browser APIs that don't seem like timers yet
- still are, such as [SharedArrayBuffer].^[Check out
- [this explanation][sab-attack] if you want to learn more.] Since this API
- is still useful, and there is no good way to make it "less accurate", browsers
- now require [certain optional HTTP headers][sab-headers] to be present on the
- parent *and* child frames' HTTP responses in order to allow use of
- `SharedArrayBuffer`.
+That said, these kinds of *timing attacks* can be subtle, and there
+are doubtless more that haven't been discovered yet. To try to dull
+this threat, browsers currently prevent access to *high-precision
+timers* that can provide the accurate timing data typically required
+for timing attacks. For example, browsers reduce the accuracy of APIs
+like `Date.now` or `setTimeout`.
+
+Worse yet, there are browser APIs that don't seem like timers but can
+be used as such.[^sharedarraybuffer-attack] These API are useful, so
+browsers don't quite want to remove it, but there is also no way to
+make it "less accurate", since it's not primarily a clock anyway.
+Browsers now require [certain optional HTTP headers][sab-headers] to
+be present on the parent *and* child frames' HTTP responses in order
+to allow use of `SharedArrayBuffer`, though this is not a perfect
+solution.
+
+[^sharedarraybuffer-attack]: For example, the [SharedArrayBuffer] lets
+two JavaScript threads run concurrently and share memory, which can be
+used to [construct a clock][sab-attack].
 
 [SharedArrayBuffer]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1988,8 +1988,8 @@ like [Rust][rust] have message-passing as a core language feature.
 [rust]: https://en.wikipedia.org/wiki/Rust_(programming_language)
 
 
-Iframe security
-===============
+Isolation and timing
+====================
 
 Iframes add a whole new layer of security challenges atop what we
 discussed in [Chapter 10](security.md). The power to embed one web


### PR DESCRIPTION
Just language changes, moving things in and out of footnotes, and so on. The biggest change is probably renaming the section to "Isolation and timing", so that our section headings aren't all "Iframe XYZ".