### PR TITLE
Pass on communication section

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1863,7 +1863,7 @@ Window.prototype.dispatchEvent = function(evt) {
 ```
 
 That's everything on the receiver side; now let's do the sender side and implement
-The `postMessage` API itself. Note that `this._id` is the ID of the
+the `postMessage` API itself. Note that `this._id` is the ID of the
 receiver or target window:
 
 ``` {.javascript}

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1774,7 +1774,7 @@ code return a fresh `Window` object with a fake, negative id. This
 makes further accesses to that window's APIs to fail, making it
 impossible to modify that frame's state.^[Note however that in a real
 browser, this `Window` object is not fake, and some APIs can be called
-on it, most important its `parent` can also be retrieved. There is a
+on it, such as that its `parent` can also be retrieved. There is a
 related exercise at the end of the chapter.]
 
 So via `parent`, same-origin iframes can communicate. But what about

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1862,7 +1862,7 @@ Window.prototype.dispatchEvent = function(evt) {
 }
 ```
 
-That's everything on the receiver side; now let's do the sender side.
+That's everything on the receiver side; now let's do the sender side and implement
 The `postMessage` API itself. Note that `this._id` is the ID of the
 receiver or target window:
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -755,7 +755,7 @@ EVENT_DISPATCH_CODE = \
     ".dispatchEvent(new window.Event(dukpy.type))"
 
 POST_MESSAGE_DISPATCH_CODE = \
-    "window.dispatchEvent(new window.PostMessageEvent(dukpy.data))"
+    "window.dispatchEvent(new window.MessageEvent(dukpy.data))"
 
 class JSContext:
     def __init__(self, tab):
@@ -784,6 +784,7 @@ class JSContext:
         self.handle_to_node = {}
 
         self.interp.evaljs("function Window(id) { this._id = id };")
+        self.interp.evaljs("WINDOWS = {}")
 
     def add_window(self, frame):
         code = "var window_{} = new Window({});".format(
@@ -792,6 +793,9 @@ class JSContext:
 
         with open("runtime15.js") as f:
             self.interp.evaljs(self.wrap(f.read(), frame.window_id))
+
+        self.interp.evaljs("WINDOWS[{}] = window_{};".format(
+            frame.window_id, frame.window_id))
 
     def wrap(self, script, window_id):
         return "window = window_{}; {}".format(window_id, script)

--- a/src/runtime15.js
+++ b/src/runtime15.js
@@ -119,7 +119,7 @@ window.__runRAFHandlers = function() {
 
 window.WINDOW_LISTENERS = {}
 
-window.PostMessageEvent = function(data) {
+window.MessageEvent = function(data) {
     this.type = "message";
     this.data = data;
 }
@@ -152,16 +152,11 @@ Window.prototype.dispatchEvent = function(evt) {
 Object.defineProperty(Window.prototype, 'parent', {
   configurable: true,
   get: function() {
-    parent_id = call_python('parent', window._id);
+    var parent_id = call_python('parent', window._id);
     if (parent_id != undefined) {
-        try {
-            target_window = eval("window_" + parent_id);
-            // Same-origin
-            return target_window;
-        } catch (e) {
-            // Cross-origin
-            return new Window(-1)
-        }
+        var parent = WINDOWS[parent_id];
+        if (parent === undefined) parent = new Window(-1);
+        return parent;
     }
   }
 });


### PR DESCRIPTION
This PR does a pass on the `window.parent` / `window.postMessage` section. The changes are pretty minor, stuff like renaming `PostMessageEvent` to `MessageEvent` (that's what it's called in a real browser?) or adding a global window ID to Window map.

I have two questions—let's merge this and settle them in new PRs.

**Configurable**: Why did you make the `window.parent` property `configurable`? It's the first I've seen this property; I read the description but have no strong feelings whether or not it should be. It's one line of code, so not a big deal either way, but it would be good to explain it, and possibly other properties we define should also be configurable?

**postMessage**: Does postmessage to cross-origin frames actually work? I think looking at the current code, you'd get a bogus target window ID of `-1` and the message wouldn't go anywhere. I think I'm missing something, so please explain what I'm missing so we can make sure to explain it correctly.