### PR TITLE
Fix several bugs in chapter 13-15

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1856,7 +1856,7 @@ standardized transform syntax.
 
 ``` {.python}
 def parse_transform(transform_str):
-    if transform_str.find('translate') < 0:
+    if transform_str.find('translate(') < 0:
         return None
     left_paren = transform_str.find('(')
     right_paren = transform_str.find(')')

--- a/src/lab13-tests.md
+++ b/src/lab13-tests.md
@@ -93,6 +93,7 @@ The `parse_transform` function parses the value of the `transform` CSS property.
 Unsupported values are ignored.
 
     >>> lab13.parse_transform("rotate(45deg)")
+    >>> lab13.parse_transform("translateY(10px)")
 
 Animations work:
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -285,7 +285,7 @@ class DrawCompositedLayer(DisplayItem):
 
 
 def parse_transform(transform_str):
-    if transform_str.find('translate') < 0:
+    if transform_str.find('translate(') < 0:
         return None
     left_paren = transform_str.find('(')
     right_paren = transform_str.find(')')
@@ -1008,6 +1008,8 @@ class CompositedLayer:
                     self.skia_context, skia.Budgeted.kNo,
                     skia.ImageInfo.MakeN32Premul(
                         irect.width(), irect.height()))
+                if self.surface is None:
+                    self.surface = skia.Surface(irect.width(), irect.height())
                 assert self.surface is not None
             else:
                 self.surface = skia.Surface(irect.width(), irect.height())

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1596,6 +1596,10 @@ class Browser:
 
     def set_active_tab(self, index):
         self.active_tab = index
+        active_tab = self.tabs[self.active_tab]
+        task = Task(active_tab.set_needs_paint)
+        active_tab.task_runner.schedule_task(task)
+
         self.clear_data()
         self.needs_animation_frame = True
 

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -243,3 +243,14 @@ Rendering will read out the accessibility instructions:
     
     >>> document.children[0].children[0].attributes
     {'src': 'my-url', 'alt': 'This is alt text'}
+
+Here are some brief tests for the attribute parser. First, that it allows
+spaces:
+
+    >>> lab15.AttributeParser('tag a="a b c" b=def').parse()
+    ('tag', {'a': 'a b c', 'b': 'def'})
+
+Next, that it allows the equals sign within quoted text:
+
+    >>> lab15.AttributeParser('tag a="a=b c"').parse()
+    ('tag', {'a': 'a=b c'})

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1959,7 +1959,6 @@ class Browser:
 
     def set_active_tab(self, index):
         self.active_tab = index
-        print(index)
         active_tab = self.tabs[self.active_tab]
         task = Task(active_tab.set_needs_paint)
         active_tab.task_runner.schedule_task(task)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1969,9 +1969,6 @@ class Browser:
         active_tab.task_runner.schedule_task(task)
         self.clear_data()
 
-    def add_tab(self):
-        self.load("https://browser.engineering/")
-
     def cycle_tabs(self):
         new_active_tab = (self.active_tab + 1) % len(self.tabs)
         self.set_active_tab(new_active_tab)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -625,10 +625,13 @@ class AttributeParser:
                 in_quote = not in_quote
                 quoted = True
                 self.i += 1
-            elif in_quote and cur.isspace():
+            elif in_quote and (cur.isspace() or cur == "="):
                 self.i += 1
             else:
                 break
+        if self.i == start:
+            print("tag: " + self.s)
+            print("current: " + self.s[self.i:])
         assert self.i > start
         if quoted:
             return self.s[start+1:self.i-1]
@@ -1956,6 +1959,11 @@ class Browser:
 
     def set_active_tab(self, index):
         self.active_tab = index
+        print(index)
+        active_tab = self.tabs[self.active_tab]
+        task = Task(active_tab.set_needs_paint)
+        active_tab.task_runner.schedule_task(task)
+
         self.clear_data()
         self.needs_animation_frame = True
 
@@ -2024,7 +2032,7 @@ class Browser:
             if 40 <= e.x < 40 + 80 * len(self.tabs) and 0 <= e.y < 40:
                 self.set_active_tab(int((e.x - 40) / 80))
             elif 10 <= e.x < 30 and 10 <= e.y < 30:
-                self.add_tab()
+                self.load_internal("https://browser.engineering/")
             elif 10 <= e.x < 35 and 50 <= e.y < 90:
                 self.go_back()
             elif 50 <= e.x < WIDTH - 10 and 50 <= e.y < 90:
@@ -2086,9 +2094,14 @@ class Browser:
         active_tab.task_runner.schedule_task(task)
 
     def load(self, url):
+        self.lock.acquire(blocking=True)
+        self.load_internal(url)
+        self.lock.release()
+
+    def load_internal(self, url):
         new_tab = Tab(self)
-        self.set_active_tab(len(self.tabs))
         self.tabs.append(new_tab)
+        self.set_active_tab(len(self.tabs) - 1)
         self.schedule_load(url)
 
     def raster_tab(self):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -629,9 +629,6 @@ class AttributeParser:
                 self.i += 1
             else:
                 break
-        if self.i == start:
-            print("tag: " + self.s)
-            print("current: " + self.s[self.i:])
         assert self.i > start
         if quoted:
             return self.s[start+1:self.i-1]


### PR DESCRIPTION
* When changing tabs, chapters 14 and 15 failed to set paint dirty, and so the display list was never updated

* The chapter 15 code was missing a bugfix related to tab updates that was already in chapter 14

* consume the `=` character when in a quoted attribute

* GPU surfaces that are too big fail to allocate (fix: if that happens, fall back to a software surface)

* Only parse the `translate(x, y)` form of transform (and skip translateY or translateX in particular).

Bugs 3 and 4 happened when loading browser.engineering with chapter 15 code, because now we load the iframes.