### PR TITLE
A few more editorial fixes to chapter 15, and a bugfix

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1145,8 +1145,10 @@ def paint_outline(node, cmds, rect, zoom):
         cmds.append(DrawOutline(rect, "black", 1))
 ```
 
-Call it in `InputLayout` to make sure text entries and buttons get
-outlines:
+Call it in `InputLayout` to make sure text entries and buttons get outlines.
+Also note that, because we now need access to `zoom` in all of the paint
+functions, you'll need to add that paramter to all of them
+(`DocumentLayout`, `BlockLayout`, etc).
 
 ``` {.python}
 class InputLayout:

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -513,7 +513,7 @@ modalities.
 Videos are similar to images, but demand more bandwidth, time, and
 memory; they also have complications like [Digital Rights Management
 (DRM)][drm]. The `<video>` tag addresses some of that, with built-in
-support for advanced video [*codecs*][codec]^[In video, it's called a
+support for advanced video [*codecs*][codec],^[In video, it's called a
 "codec", but in images it's called a "format"--go figure.] DRM, and
 hardware acceleration. It also provides media controls like a
 play/pause button and volume controls.

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1060,7 +1060,9 @@ images until chapter 15 perhaps?]
 [^content-box]: This book doesn't go into the details of the [CSS box
 model][box-model], but the `width` and `height` attributes of an
 iframe refer to the *content box*, and adding the border width yields
-the *border box*.
+the *border box*. Note also that the clip we're appling is an overflow
+clip, which is not quite the same as an iframe clip, and the differences have
+to do with the box model as well.
 
 [box-model]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -527,13 +527,15 @@ Modifying Image Sizes
 =====================
 
 So far, an image's size on the screen is its size in pixels, possibly
-zoomed. But in fact it's generally valuable for authors to control the
-size of embedded content. There are a number of ways to do this,^[For
-example, the `width` and `height` CSS properties (not to be confused
-with the `width` and `height` attributes!), which were an exercise in
+zoomed.^[Note that zoom already may cause an image to render at a size
+different than its regular size, even before introducing the features in this
+section.] But in fact it's generally valuable for
+authors to control the size of embedded content. There are a number of ways to
+do this,^[For example, the `width` and `height` CSS properties (not to be
+confused with the `width` and `height` attributes!), which were an exercise in
 Chapter 13.] but one way is the special `width` and `height`
-attributes.^[Images have these mostly for historical reasons, because
-these attributes were invented before CSS existed.]
+attributes.^[Images have these mostly for historical reasons, because these
+attributes were invented before CSS existed.]
 
 If _both_ those attributes are present, things are pretty easy: we
 just read from them when laying out the element, both in `image`:

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1064,7 +1064,8 @@ model][box-model], but the `width` and `height` attributes of an
 iframe refer to the *content box*, and adding the border width yields
 the *border box*. Note also that the clip we're appling is an overflow
 clip, which is not quite the same as an iframe clip, and the differences have
-to do with the box model as well.
+to do with the box model as well. As a result, what we've implemented is
+somewhat incorrect with respect to all of those factors.
 
 [box-model]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -935,7 +935,8 @@ IFRAME_WIDTH_PX = 300
 IFRAME_HEIGHT_PX = 150
 ```
 
-The extra 2 pixels provide room for a border later on.
+The extra 2 pixels (corrected for zoom, of course) provide room for a border
+later on.
 
 Now, note that this code is run in the *parent* frame. We need to get
 this width and height over to the *child* frame, so it can know its
@@ -1479,13 +1480,15 @@ class Frame:
         # ...
 ```
 
-So we've got multiple pages' scripts using one JavaScript context. Now we've got
-to keep them separate somehow. The key is going to be the `window` global, of
-type `Window`. In the browser, this refers to the[global object]
-[global-object], and instead of writing a global variable like `a`, you can
-always write `window.a` instead.[^shadow-realms] To keep our implementation
-simple, in our browser, scripts will always need to reference variable and
-functions via `window`. We'll need to do the same in our runtime:
+So we've got multiple pages' scripts using one JavaScript context. But now we've
+got to keep their variables in their own namespaces somehow. The key is going
+to be the `window` global, of type `Window`. In the browser, this refers to the
+[global object][global-object], and instead of writing a global variable like
+`a`, you can always write `window.a` instead.[^shadow-realms] To keep our
+implementation simple, in our browser, scripts will always need to reference
+variable and functions via `window`.^[This also means that all global variables
+in a script need to do the same, even if they are not browser APIs.] We'll need
+to do the same in our runtime:
 
 [^shadow-realms]: There are [various proposals][shadowrealm] to expose
 multiple global namespaces as a JavaScript API. It would definitely be

--- a/src/browser14.css
+++ b/src/browser14.css
@@ -16,14 +16,14 @@ button {
     background-color: orange;
 }
 
-input:focus { outline: 2px solid black; }
+input:focus { outline: 1px solid black; }
 
-button:focus { outline: 2px solid black; }
+button:focus { outline: 1px solid black; }
 
-div:focus { outline: 2px solid black; }
+div:focus { outline: 1px solid black; }
 
 a:focus {
-    outline: 2px solid black;
+    outline: 1px solid black;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -31,8 +31,8 @@ a:focus {
   input { background-color: blue; }
   button { background-color: orangered; }
 
-  input:focus { outline: 2px solid white; }
-  button:focus { outline: 2px solid white; }
-  div:focus { outline: 2px solid white; }
-  a:focus { outline: 2px solid white; }
+  input:focus { outline: 1px solid white; }
+  button:focus { outline: 1px solid white; }
+  div:focus { outline: 1px solid white; }
+  a:focus { outline: 1px solid white; }
 }

--- a/src/browser15.css
+++ b/src/browser15.css
@@ -16,14 +16,14 @@ button {
     background-color: orange;
 }
 
-input:focus { outline: 2px solid black; }
+input:focus { outline: 1px solid black; }
 
-button:focus { outline: 2px solid black; }
+button:focus { outline: 1px solid black; }
 
-div:focus { outline: 2px solid black; }
+div:focus { outline: 1px solid black; }
 
 a:focus {
-    outline: 2px solid black;
+    outline: 1px solid black;
 }
 
 input:-internal-accessibility-hover {
@@ -39,7 +39,7 @@ a:-internal-accessibility-hover {
 }
 
 iframe {
-    outline: 2px solid black;
+    outline: 1px solid black;
     overflow: clip;
 }
 
@@ -49,12 +49,12 @@ a { color: lightblue; }
 input { background-color: blue; }
 button { background-color: orangered; }
 
-input:focus { outline: 2px solid white; }
+input:focus { outline: 1px solid white; }
 
-button:focus { outline: 2px solid white; }
+button:focus { outline: 1px solid white; }
 
-div:focus { outline: 2px solid white; }
+div:focus { outline: 1px solid white; }
 
-a:focus { outline: 2px solid white; }
+a:focus { outline: 1px solid white; }
 
 }

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -186,7 +186,7 @@ def draw_rect(
         paint.setColor(parse_color(fill_color))
     else:
         paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(1);
+        paint.setStrokeWidth(width)
         paint.setColor(parse_color(border_color))
     rect = skia.Rect.MakeLTRB(l, t, r, b)
     canvas.drawRect(rect, paint)

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -23,12 +23,17 @@ Outlines
 
 The outline css property can be parsed:
 
-    >>> lab14.parse_outline("12px solid red")
+    >>> lab14.parse_outline("12px solid red", 1)
     (12, 'red')
+
+If zoom is set, it is incorporated:
+
+    >>> lab14.parse_outline("12px solid red", 2)
+    (24, 'red')
 
 Values other than "solid" for the secnod word are ignored:
 
-    >>> lab14.parse_outline("12px dashed red")
+    >>> lab14.parse_outline("12px dashed red", 1)
 
 An outline causes a `DrawOutline` with the given width and color:
 
@@ -81,7 +86,7 @@ The 2px wide black display list command is the focus ring for the `input`:
      DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawLine top=21.0 left=13.0 bottom=37.0 right=13.0
-     DrawOutline(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=black thickness=2)
+     DrawOutline(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=black thickness=1)
      DrawText(text=Link)
 
 And now it's for the `a`:
@@ -92,7 +97,7 @@ And now it's for the `a`:
      DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
-     DrawOutline(top=21.0 left=229.0 bottom=37.0 right=293.0 border_color=black thickness=2)
+     DrawOutline(top=21.0 left=229.0 bottom=37.0 right=293.0 border_color=black thickness=1)
 
 Tabindex changes the order:
 
@@ -113,7 +118,7 @@ This time the `a` element is focused first:
      DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawText(text=Link)
-     DrawOutline(top=21.0 left=229.0 bottom=37.0 right=293.0 border_color=black thickness=2)
+     DrawOutline(top=21.0 left=229.0 bottom=37.0 right=293.0 border_color=black thickness=1)
 
 And then the `input`:
 
@@ -123,7 +128,7 @@ And then the `input`:
      DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)
      DrawText(text=)
      DrawLine top=21.0 left=13.0 bottom=37.0 right=13.0
-     DrawOutline(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=black thickness=2)
+     DrawOutline(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=black thickness=1)
      DrawText(text=Link)
 
 Regular elements aren't focusable, but if the `tabindex` attribute is set, they
@@ -219,10 +224,10 @@ The rules parsed by the browser style sheet should also indicate dark mode:
     TagSelector(tag=a, priority=1) {'color': 'lightblue'}
     TagSelector(tag=input, priority=1) {'background-color': 'blue'}
     TagSelector(tag=button, priority=1) {'background-color': 'orangered'}
-    PseudoclassSelector(focus, TagSelector(tag=input, priority=1)) {'outline': '2px solid white'}
-    PseudoclassSelector(focus, TagSelector(tag=button, priority=1)) {'outline': '2px solid white'}
-    PseudoclassSelector(focus, TagSelector(tag=div, priority=1)) {'outline': '2px solid white'}
-    PseudoclassSelector(focus, TagSelector(tag=a, priority=1)) {'outline': '2px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=input, priority=1)) {'outline': '1px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=button, priority=1)) {'outline': '1px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=div, priority=1)) {'outline': '1px solid white'}
+    PseudoclassSelector(focus, TagSelector(tag=a, priority=1)) {'outline': '1px solid white'}
 
 Focus
 =====
@@ -240,5 +245,5 @@ It also nd also causes a painted outline:
      DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=blue)
      DrawText(text=)
      DrawLine top=21.0 left=13.0 bottom=37.0 right=13.0
-     DrawOutline(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=white thickness=2)
+     DrawOutline(top=21.0 left=13.0 bottom=37.0 right=213.0 border_color=white thickness=1)
      DrawText(text=Link)

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -92,10 +92,10 @@ Let's load the original image in an iframe.
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
      SaveLayer(alpha=1.0)
-       ClipRRect(RRect(13, 18, 315, 170, 1))
+       ClipRRect(RRect(14, 19, 314, 169, 1))
          Transform(translate(14.0, 19.0))
            DrawImage(rect=Rect(13, 29, 18, 34))
-         DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=2)
+     DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=1.0)
 
 And the sized one:
 
@@ -110,10 +110,10 @@ And the sized one:
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
      SaveLayer(alpha=1.0)
-       ClipRRect(RRect(13, 18, 315, 170, 1))
+       ClipRRect(RRect(14, 19, 314, 169, 1))
          Transform(translate(14.0, 19.0))
            DrawImage(rect=Rect(13, 18, 23, 38))
-         DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=2)
+     DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=1.0)
 
 Iframes can be sized too:
 
@@ -154,10 +154,10 @@ Iframes can be sized too:
      DrawText(text=.)
      DrawText(text=.)
      SaveLayer(alpha=1.0)
-       ClipRRect(RRect(45, 478, 95, 508, 1))
+       ClipRRect(RRect(46, 479, 96, 509, 1))
          Transform(translate(46.0, 479.0))
            DrawImage(rect=Rect(13, 29, 18, 34))
-         DrawOutline(top=478.0 left=45.0 bottom=508.0 right=95.0 border_color=black thickness=2)
+     DrawOutline(top=478.0 left=45.0 bottom=510.0 right=97.0 border_color=black thickness=1.0)
 
 Now let's test scrolling of the root frame:
 
@@ -191,7 +191,7 @@ And now scrolling affects just the child frame:
     >>> browser.scroll > 0
     False
     >>> browser.tabs[0].root_frame.nodes.children[0].children[47].frame.scroll
-    24.0
+    22.0
 
 Accessibility
 =============

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -41,7 +41,7 @@ from lab13 import diff_styles, \
     REFRESH_RATE_SEC, HSTEP, VSTEP, SETTIMEOUT_CODE, XHR_ONLOAD_CODE, \
     Transform, ANIMATED_PROPERTIES, SaveLayer
 
-from lab14 import parse_color, parse_outline, draw_rect, DrawRRect, \
+from lab14 import parse_color, draw_rect, DrawRRect, \
     is_focused, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
     is_focusable, get_tabindex, announce_text, speak_text, \
@@ -163,9 +163,9 @@ class DocumentLayout:
         child.layout(zoom)
         self.height = child.height + 2* device_px(VSTEP, zoom)
 
-    def paint(self, display_list, dark_mode, scroll):
+    def paint(self, display_list, dark_mode, scroll, zoom):
         cmds = []
-        self.children[0].paint(cmds)
+        self.children[0].paint(cmds, zoom)
         if scroll != None and scroll != 0:
             rect = skia.Rect.MakeLTRB(
                 self.x, self.y,
@@ -280,10 +280,10 @@ class BlockLayout:
         if "width" in self.node.attributes:
             w = device_px(int(self.node.attributes["width"]), zoom)
         else:
-            w = IFRAME_WIDTH_PX + 2
+            w = IFRAME_WIDTH_PX + device_px(2, zoom)
         self.add_inline_child(node, zoom, w, IframeLayout, self.frame)
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -297,15 +297,16 @@ class BlockLayout:
             bgcolor = self.node.style.get(
                 "background-color", "transparent")
             if bgcolor != "transparent":
-                radius = float(self.node.style.get(
-                    "border-radius", "0px")[:-2])
+                radius = device_px(
+                    float(self.node.style.get(
+                        "border-radius", "0px")[:-2]),
+                    zoom)
                 cmds.append(DrawRRect(rect, radius, bgcolor))
  
         for child in self.children:
-            child.paint(cmds)
+            child.paint(cmds, zoom)
 
         if not is_atomic:
-            paint_outline(self.node, cmds, rect)
             cmds = paint_visual_effects(self.node, cmds, rect)
         display_list.extend(cmds)
 
@@ -352,7 +353,7 @@ class InputLayout(EmbedLayout):
         self.width = device_px(INPUT_WIDTH_PX, zoom)
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -362,7 +363,9 @@ class InputLayout(EmbedLayout):
         bgcolor = self.node.style.get("background-color",
                                  "transparent")
         if bgcolor != "transparent":
-            radius = float(self.node.style.get("border-radius", "0px")[:-2])
+            radius = device_px(
+                float(self.node.style.get("border-radius", "0px")[:-2]),
+                zoom)
             cmds.append(DrawRRect(rect, radius, bgcolor))
 
         if self.node.tag == "input":
@@ -383,8 +386,8 @@ class InputLayout(EmbedLayout):
             cx = rect.left() + self.font.measureText(text)
             cmds.append(DrawLine(cx, rect.top(), cx, rect.bottom()))
 
-        paint_outline(self.node, cmds, rect)
         cmds = paint_visual_effects(self.node, cmds, rect)
+        paint_outline(self.node, cmds, rect, zoom)
         display_list.extend(cmds)
 
     def __repr__(self):
@@ -427,7 +430,7 @@ class LineLayout:
                            for child in self.children])
         self.height = max_ascent + max_descent
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         outline_rect = skia.Rect.MakeEmpty()
         outline_node = None
         for child in self.children:
@@ -435,10 +438,10 @@ class LineLayout:
             if isinstance(node, Text) and has_outline(node.parent):
                 outline_node = node.parent
                 outline_rect.join(child.rect())
-            child.paint(display_list)
+            child.paint(display_list, zoom)
 
         if outline_node:
-            paint_outline(outline_node, display_list, outline_rect)
+            paint_outline(outline_node, display_list, outline_rect, zoom)
 
     def role(self):
         return "none"
@@ -480,7 +483,7 @@ class TextLayout:
 
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         color = self.node.style["color"]
         display_list.append(
             DrawText(self.x, self.y, self.word, self.font, color))
@@ -532,7 +535,7 @@ class ImageLayout(EmbedLayout):
 
         self.height = max(self.img_height, linespace(self.font))
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         cmds = []
         rect = skia.Rect.MakeLTRB(
             self.x, self.y + self.height - self.img_height,
@@ -560,20 +563,20 @@ class IframeLayout(EmbedLayout):
         height_attr = self.node.attributes.get("height")
 
         if width_attr:
-            self.width = device_px(int(width_attr), zoom)
+            self.width = device_px(int(width_attr) + 2, zoom)
         else:
             self.width = device_px(IFRAME_WIDTH_PX + 2, zoom)
 
         if height_attr:
-            self.height = device_px(int(height_attr), zoom)
+            self.height = device_px(int(height_attr) + 2, zoom)
         else:
             self.height = device_px(IFRAME_HEIGHT_PX + 2, zoom)
 
         if self.node.frame:
-            self.node.frame.frame_height = self.height - 2
-            self.node.frame.frame_width = self.width - 2
+            self.node.frame.frame_height = self.height - device_px(2, zoom)
+            self.node.frame.frame_width = self.width - device_px(2, zoom)
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         frame_cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -582,17 +585,22 @@ class IframeLayout(EmbedLayout):
         bgcolor = self.node.style.get("background-color",
                                  "transparent")
         if bgcolor != "transparent":
-            radius = float(
-                self.node.style.get("border-radius", "0px")[:-2])
+            radius = device_px(
+                float(self.node.style.get("border-radius", "0px")[:-2]),
+                zoom)
             frame_cmds.append(DrawRRect(rect, radius, bgcolor))
 
         if self.node.frame:
-            self.node.frame.paint(frame_cmds)
+            self.node.frame.paint(frame_cmds, zoom)
 
-        offset = (self.x + 1, self.y + 1)
+        diff = device_px(1, zoom)
+        offset = (self.x + diff, self.y + diff)
         cmds = [Transform(offset, rect, self.node, frame_cmds)]
-        paint_outline(self.node, cmds, rect)
-        cmds = paint_visual_effects(self.node, cmds, rect)
+        inner_rect = skia.Rect.MakeLTRB(
+            self.x + diff, self.y + diff,
+            self.x + self.width - diff, self.y + self.height - diff)
+        cmds = paint_visual_effects(self.node, cmds, inner_rect)
+        paint_outline(self.node, cmds, rect, zoom)
         display_list.extend(cmds)
 
     def __repr__(self):
@@ -1262,9 +1270,10 @@ class Frame:
             self.scroll_changed_in_frame = True
         self.scroll = clamped_scroll
 
-    def paint(self, display_list):
+    def paint(self, display_list, zoom):
         self.document.paint(display_list, self.tab.dark_mode,
-            self.scroll if self != self.tab.root_frame else None)
+            self.scroll if self != self.tab.root_frame else None,
+            zoom)
 
     def advance_tab(self):
         focusable_nodes = [node
@@ -1538,7 +1547,7 @@ class Tab:
 
         if self.needs_paint:
             self.display_list = []
-            self.root_frame.paint(self.display_list)
+            self.root_frame.paint(self.display_list, self.zoom)
             self.needs_paint = False
 
         self.measure_render.stop()

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -161,7 +161,7 @@ class DocumentLayout:
         self.x = device_px(HSTEP, zoom)
         self.y = device_px(VSTEP, zoom)
         child.layout(zoom)
-        self.height = child.height + 2* device_px(VSTEP, zoom)
+        self.height = child.height + 2 * device_px(VSTEP, zoom)
 
     def paint(self, display_list, dark_mode, scroll, zoom):
         cmds = []


### PR DESCRIPTION
The bug was threefold regarding outlines:

* We weren't adjusting outlines for zoom
* Outlines were painted before clip (in some corner cases on the real web the new way is slightly wrong also I think, due to interaction with visual effects)
* We weren't respecting the `thickness` parameter

I also changed the default focus border and iframe border to 1px.