### PR TITLE
Downgrade sandbox to a log instead of alert; relax sandboxing rule

### DIFF
--- a/infra/server.py
+++ b/infra/server.py
@@ -5,7 +5,7 @@ from http import server
 # Based on code from https://stackoverflow.com/questions/12499171/
 class WBEServer(server.SimpleHTTPRequestHandler):
     def end_headers(self):
-        if self.path.startswith("widgets/"):
+        if self.path.find("widgets") >= 0:
             self.send_header("Cross-Origin-Opener-Policy", "same-origin");
             self.send_header("Cross-Origin-Embedder-Policy", "require-corp");
         self.send_header('Cache-Control', 'no-store, must-revalidate')

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -15,7 +15,7 @@ addEventListener("message", (e) => {
         try {
             val = eval?.(e.data.body);
         } catch (e) {
-            console.log('js error');
+            console.log('Script crashed');
         }
         if (val instanceof Function) val = null;
         $$POSTMESSAGE({"type": "return", "data": val});

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -11,7 +11,12 @@ addEventListener("message", (e) => {
     switch (e.data.type) {
     case "eval":
         dukpy = e.data.bindings;
-        let val = eval?.(e.data.body);
+        let val;
+        try {
+            val = eval?.(e.data.body);
+        } catch (e) {
+            console.log('js error');
+        }
         if (val instanceof Function) val = null;
         $$POSTMESSAGE({"type": "return", "data": val});
         break;

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -483,7 +483,7 @@ class Widget {
     
     on_error(e) {
         if (e instanceof ExpectedError) {
-            alert(e);
+            console.log(e);
         } else {
             throw e;
         }


### PR DESCRIPTION
* Downgrade sandbox to a log instead of alert
* Relax sandboxing rule (makes infra/server.py work locally for me)
* Don't crash on JS errors (otherwise browser.engineering wont load in lab10-browser.html)

The third change is needed because the JS is evaluated in a worker thread, and so browser code that is not in the
worker thread cannot catch its exceptions.