### PR TITLE
Use `@wbetools.patch` on early chapters

### DIFF
--- a/book/layout.md
+++ b/book/layout.md
@@ -258,8 +258,6 @@ class BlockLayout:
                 self.children.append(next)
                 previous = next
         else:
-            self.display_list = []
-
             self.cursor_x = 0
             self.cursor_y = 0
             self.weight = "normal"

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -140,13 +140,14 @@ class ResolvePatches(ast.NodeTransformer):
                 for patch in patches:
                     for repl_name, repl_stmt in iter_methods(patch):
                         body2[repl_name] = repl_stmt
-                return ast.ClassDef(cmd.name, cmd.bases, cmd.keywords, list(body2.values()), [])
+                return ast.ClassDef(patch.name, cmd.bases, cmd.keywords, list(body2.values()), [])
             else:
                 return cmd
         else:
             assert len(cmd.decorator_list) == 1
             assert is_patch_decorator(cmd.decorator_list[0])
-            assert cmd.decorator_list[0].args[0].id == cmd.name
+            # Actually violated in Chapter 5 where we rename Layout to BlockLayout
+            #assert cmd.decorator_list[0].args[0].id == cmd.name
             self.patches.setdefault(cmd.name, []).append(cmd)
             return None
 

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -146,9 +146,8 @@ class ResolvePatches(ast.NodeTransformer):
         else:
             assert len(cmd.decorator_list) == 1
             assert is_patch_decorator(cmd.decorator_list[0])
-            # Actually violated in Chapter 5 where we rename Layout to BlockLayout
-            #assert cmd.decorator_list[0].args[0].id == cmd.name
-            self.patches.setdefault(cmd.name, []).append(cmd)
+            # Not just cmd.name because in Chapter 5 we rename Layout to BlockLayout
+            self.patches.setdefault(cmd.decorator_list[0].args[0].id, []).append(cmd)
             return None
 
     def double_visit(self, tree):

--- a/src/lab10.hints
+++ b/src/lab10.hints
@@ -1,7 +1,4 @@
 [{"code": "'href' in node.attributes", "type": "dict"},
- {"code": "'action' in elt.attributes", "type": "dict"},
- {"code": "'href' in elt.attributes", "type": "dict"},
- {"code": "'name' in node.attributes", "type": "dict"},
  {"code": "self.host in COOKIE_JAR", "type": "dict"},
  {"code": "'=' in param_pair", "type": "str"},
  {"code": "'set-cookie' in headers", "type": "dict"},
@@ -12,10 +9,5 @@
  {"code": "url.origin() in self.allowed_origins", "type": "dict"},
  {"code": "print", "js": "console.log"},
  {"code": "'src' in node.attributes", "type": "dict"},
- {"code": "elt not in self.node_to_handle", "js": "!this.node_to_handle.has(elt)"},
- {"code": "self.node_to_handle = {}", "js": "    this.node_to_handle = new Map();"},
- {"code": "self.node_to_handle.get(elt, -1)", "js": "this.node_to_handle.get(elt) ?? -1"},
- {"code": "self.node_to_handle[elt]", "js": "this.node_to_handle.get(elt)"},
- {"code": "len(self.node_to_handle)", "js": "this.node_to_handle.size"},
- {"code": "self.node_to_handle[elt] = handle", "js": "      this.node_to_handle.set(elt, handle);"}
+ {"code": "self.node_to_handle = {}", "js": "    this.node_to_handle = new Map();"}
 ]

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -18,8 +18,9 @@ from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
-from lab8 import URL, DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
-from lab9 import EVENT_DISPATCH_CODE, JSContext, Tab, Browser
+from lab8 import URL, Browser
+from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
+from lab9 import EVENT_DISPATCH_CODE, JSContext, Tab
 import wbetools
 
 @wbetools.patch(URL)

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -19,7 +19,7 @@ from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
 from lab8 import URL, DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
-from lab9 import EVENT_DISPATCH_CODE
+from lab9 import EVENT_DISPATCH_CODE, JSContext, Tab, Browser
 import wbetools
 
 @wbetools.patch(URL)
@@ -90,6 +90,7 @@ class URL:
         
 COOKIE_JAR = {}
 
+@wbetools.patch(JSContext)
 class JSContext:
     def __init__(self, tab):
         self.tab = tab
@@ -109,44 +110,6 @@ class JSContext:
         self.node_to_handle = {}
         self.handle_to_node = {}
 
-    def run(self, code):
-        self.interp.evaljs(code)
-
-    def dispatch_event(self, type, elt):
-        handle = self.node_to_handle.get(elt, -1)
-        do_default = self.interp.evaljs(
-            EVENT_DISPATCH_CODE, type=type, handle=handle)
-        return not do_default
-
-    def get_handle(self, elt):
-        if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle)
-            self.node_to_handle[elt] = handle
-            self.handle_to_node[handle] = elt
-        else:
-            handle = self.node_to_handle[elt]
-        return handle
-
-    def querySelectorAll(self, selector_text):
-        selector = CSSParser(selector_text).selector()
-        nodes = [node for node
-                 in tree_to_list(self.tab.nodes, [])
-                 if selector.matches(node)]
-        return [self.get_handle(node) for node in nodes]
-
-    def getAttribute(self, handle, attr):
-        elt = self.handle_to_node[handle]
-        return elt.attributes.get(attr, None)
-
-    def innerHTML_set(self, handle, s):
-        doc = HTMLParser("<html><body>" + s + "</body></html>").parse()
-        new_nodes = doc.children[0].children
-        elt = self.handle_to_node[handle]
-        elt.children = new_nodes
-        for child in elt.children:
-            child.parent = elt
-        self.tab.render()
-
     def XMLHttpRequest_send(self, method, url, body):
         full_url = self.tab.url.resolve(url)
         if not self.tab.allowed_request(full_url):
@@ -156,15 +119,8 @@ class JSContext:
             raise Exception("Cross-origin XHR request not allowed")
         return out
 
+@wbetools.patch(Tab)
 class Tab:
-    def __init__(self):
-        self.history = []
-        self.focus = None
-        self.url = None
-
-        with open("browser8.css") as f:
-            self.default_style_sheet = CSSParser(f.read()).parse()
-
     def allowed_request(self, url):
         return self.allowed_origins == None or \
             url.origin() in self.allowed_origins
@@ -218,195 +174,6 @@ class Tab:
                 continue
             self.rules.extend(CSSParser(body).parse())
         self.render()
-
-    def render(self):
-        style(self.nodes, sorted(self.rules, key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
-        self.document.layout()
-        self.display_list = []
-        self.document.paint(self.display_list)
-
-        if self.focus:
-            obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus and \
-                        isinstance(obj, InputLayout)][0]
-            text = self.focus.attributes.get("value", "")
-            x = obj.x + obj.font.measure(text)
-            y = obj.y - self.scroll
-            self.display_list.append(
-                DrawLine(x, y, x, y + obj.height, "black", 1))
-
-
-    def draw(self, canvas):
-        for cmd in self.display_list:
-            if cmd.top > self.scroll + HEIGHT - CHROME_PX: continue
-            if cmd.bottom < self.scroll: continue
-            cmd.execute(self.scroll - CHROME_PX, canvas)
-
-    def scrolldown(self):
-        max_y = self.document.height - (HEIGHT - CHROME_PX)
-        self.scroll = min(self.scroll + SCROLL_STEP, max_y)
-
-    def click(self, x, y):
-        self.focus = None
-        y += self.scroll
-        objs = [obj for obj in tree_to_list(self.document, [])
-                if obj.x <= x < obj.x + obj.width
-                and obj.y <= y < obj.y + obj.height]
-        if not objs: return
-        elt = objs[-1].node
-        if elt and self.js.dispatch_event("click", elt): return
-        while elt:
-            if isinstance(elt, Text):
-                pass
-            elif elt.tag == "a" and "href" in elt.attributes:
-                url = self.url.resolve(elt.attributes["href"])
-                return self.load(url)
-            elif elt.tag == "input":
-                elt.attributes["value"] = ""
-                self.focus = elt
-                return
-            elif elt.tag == "button":
-                while elt:
-                    if elt.tag == "form" and "action" in elt.attributes:
-                        return self.submit_form(elt)
-                    elt = elt.parent
-            elt = elt.parent
-
-    def submit_form(self, elt):
-        if self.js.dispatch_event("submit", elt): return
-        inputs = [node for node in tree_to_list(elt, [])
-                  if isinstance(node, Element)
-                  and node.tag == "input"
-                  and "name" in node.attributes]
-
-        body = ""
-        for input in inputs:
-            name = input.attributes["name"]
-            value = input.attributes.get("value", "")
-            name = urllib.parse.quote(name)
-            value = urllib.parse.quote(value)
-            body += "&" + name + "=" + value
-        body = body [1:]
-
-        url = self.url.resolve(elt.attributes["action"])
-        self.load(url, body)
-
-    def keypress(self, char):
-        if self.focus:
-            if self.js.dispatch_event("keydown", self.focus): return
-            self.focus.attributes["value"] += char
-            self.render()
-
-    def go_back(self):
-        if len(self.history) > 1:
-            self.history.pop()
-            back = self.history.pop()
-            self.load(back)
-
-class Browser:
-    def __init__(self):
-        self.window = tkinter.Tk()
-        self.canvas = tkinter.Canvas(
-            self.window,
-            width=WIDTH,
-            height=HEIGHT,
-            bg="white",
-        )
-        self.canvas.pack()
-
-        self.window.bind("<Down>", self.handle_down)
-        self.window.bind("<Button-1>", self.handle_click)
-        self.window.bind("<Key>", self.handle_key)
-        self.window.bind("<Return>", self.handle_enter)
-
-        self.tabs = []
-        self.active_tab = None
-        self.focus = None
-        self.address_bar = ""
-
-    def handle_down(self, e):
-        self.tabs[self.active_tab].scrolldown()
-        self.draw()
-
-    def handle_click(self, e):
-        if e.y < CHROME_PX:
-            self.focus = None
-            if 40 <= e.x < 40 + 80 * len(self.tabs) and 0 <= e.y < 40:
-                self.active_tab = int((e.x - 40) / 80)
-            elif 10 <= e.x < 30 and 10 <= e.y < 30:
-                self.load("https://browser.engineering/")
-            elif 10 <= e.x < 35 and 50 <= e.y < 90:
-                self.tabs[self.active_tab].go_back()
-            elif 50 <= e.x < WIDTH - 10 and 50 <= e.y < 90:
-                self.focus = "address bar"
-                self.address_bar = ""
-        else:
-            self.focus = "content"
-            self.tabs[self.active_tab].click(e.x, e.y - CHROME_PX)
-        self.draw()
-
-    def handle_key(self, e):
-        if len(e.char) == 0: return
-        if not (0x20 <= ord(e.char) < 0x7f): return
-        if self.focus == "address bar":
-            self.address_bar += e.char
-            self.draw()
-        elif self.focus == "content":
-            self.tabs[self.active_tab].keypress(e.char)
-            self.draw()
-
-    def handle_enter(self, e):
-        if self.focus == "address bar":
-            self.tabs[self.active_tab].load(self.address_bar)
-            self.focus = None
-            self.draw()
-
-    def load(self, url):
-        new_tab = Tab()
-        new_tab.load(url)
-        self.active_tab = len(self.tabs)
-        self.tabs.append(new_tab)
-        self.draw()
-
-    def paint_chrome(self):
-        cmds = []
-        cmds.append(DrawRect(0, 0, WIDTH, CHROME_PX, "white"))
-        cmds.append(DrawLine(0, CHROME_PX - 1, WIDTH, CHROME_PX - 1, "black", 1))
-
-        tabfont = get_font(20, "normal", "roman")
-        for i, tab in enumerate(self.tabs):
-            name = "Tab {}".format(i)
-            x1, x2 = 40 + 80 * i, 120 + 80 * i
-            cmds.append(DrawLine(x1, 0, x1, 40, "black", 1))
-            cmds.append(DrawLine(x2, 0, x2, 40, "black", 1))
-            cmds.append(DrawText(x1 + 10, 10, name, tabfont, "black"))
-            if i == self.active_tab:
-                cmds.append(DrawLine(0, 40, x1, 40, "black", 1))
-                cmds.append(DrawLine(x2, 40, WIDTH, 40, "black", 1))
-
-        buttonfont = get_font(30, "normal", "roman")
-        cmds.append(DrawOutline(10, 10, 30, 30, "black", 1))
-        cmds.append(DrawText(11, 0, "+", buttonfont, "black"))
-
-        cmds.append(DrawOutline(40, 50, WIDTH - 10, 90, "black", 1))
-        if self.focus == "address bar":
-            cmds.append(DrawText(55, 55, self.address_bar, buttonfont, "black"))
-            w = buttonfont.measure(self.address_bar)
-            cmds.append(DrawLine(55 + w, 55, 55 + w, 85, "black", 1))
-        else:
-            url = str(self.tabs[self.active_tab].url)
-            cmds.append(DrawText(55, 55, url, buttonfont, "black"))
-
-        cmds.append(DrawOutline(10, 50, 35, 90, "black", 1))
-        cmds.append(DrawText(15, 50, "<", buttonfont, "black"))
-        return cmds
-
-    def draw(self):
-        self.canvas.delete("all")
-        self.tabs[self.active_tab].draw(self.canvas)
-        for cmd in self.paint_chrome():
-            cmd.execute(0, self.canvas)
 
 if __name__ == "__main__":
     import sys

--- a/src/lab11.hints
+++ b/src/lab11.hints
@@ -1,11 +1,3 @@
 [{"code": "key not in FONTS", "type": "dict"},
- {"code": "url.origin() in self.allowed_origins", "type": "dict"},
- {"code": "'src' in node.attributes", "type": "dict"},
- {"code": "'href' in node.attributes", "type": "dict"},
- {"code": "'action' in elt.attributes", "type": "dict"},
- {"code": "'href' in elt.attributes", "type": "dict"},
- {"code": "'name' in node.attributes", "type": "dict"},
- {"code": "'content-security-policy' in headers", "type": "dict"},
- {"code": "('TextLayout(x={}, y={}, width={}, height={}, ' + 'node={}, word={})').format(self.x, self.y, self.width, self.height, self.node, self.word)", "js": "('')"},
  {"code": "b'Browser'", "js": "'Browser'"}
  ]

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -14,14 +14,14 @@ import ssl
 import urllib.parse
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
-from lab6 import tree_to_list
-from lab7 import CHROME_PX
-from lab8 import INPUT_WIDTH_PX, layout_mode
+from lab6 import DrawText, tree_to_list
+from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
+from lab8 import BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode, Browser
 from lab9 import EVENT_DISPATCH_CODE
-from lab10 import COOKIE_JAR, URL, JSContext
+from lab10 import COOKIE_JAR, URL, JSContext, Tab
 import wbetools
 
 FONTS = {}
@@ -96,6 +96,7 @@ class SaveLayer:
         if self.should_save:
             canvas.restore()
 
+@wbetools.patch(DrawRect)
 class DrawRect:
     def __init__(self, x1, y1, x2, y2, color):
         self.rect = skia.Rect.MakeLTRB(x1, y1, x2, y2)
@@ -110,10 +111,7 @@ class DrawRect:
         paint.setColor(parse_color(self.color))
         canvas.drawRect(self.rect, paint)
 
-    def __repr__(self):
-        return "DrawRect(top={} left={} bottom={} right={} color={})".format(
-            self.left, self.top, self.right, self.bottom, self.color)
-
+@wbetools.patch(DrawText)
 class DrawText:
     def __init__(self, x1, y1, text, font, color):
         self.left = x1
@@ -132,9 +130,7 @@ class DrawText:
         canvas.drawString(self.text, float(self.left), baseline,
             self.font, paint)
 
-    def __repr__(self):
-        return "DrawText(text={})".format(self.text)
-
+@wbetools.patch(DrawOutline)
 class DrawOutline:
     def __init__(self, x1, y1, x2, y2, color, thickness):
         self.rect = skia.Rect.MakeLTRB(x1, y1, x2, y2)
@@ -152,12 +148,7 @@ class DrawOutline:
         paint.setColor(parse_color(self.color))
         canvas.drawRect(self.rect, paint)
 
-    @wbetools.js_hide
-    def __repr__(self):
-        return "DrawOutline({}, {}, {}, {}, color={}, thickness={})".format(
-            self.rect.left(), self.rect.top(), self.rect.right(), self.rect.bottom(),
-            self.color, self.thickness)
-
+@wbetools.patch(DrawLine)
 class DrawLine:
     def __init__(self, x1, y1, x2, y2, color, thickness):
         self.rect = skia.Rect.MakeLTRB(x1, y1, x2, y2)
@@ -205,62 +196,8 @@ class ClipRRect:
         if self.should_clip:
             canvas.restore()
 
+@wbetools.patch(BlockLayout)
 class BlockLayout:
-    def __init__(self, node, parent, previous):
-        self.node = node
-        self.parent = parent
-        self.previous = previous
-        self.children = []
-        self.x = None
-        self.y = None
-        self.width = None
-        self.height = None
-
-    def layout(self):
-        self.width = self.parent.width
-        self.x = self.parent.x
-
-        if self.previous:
-            self.y = self.previous.y + self.previous.height
-        else:
-            self.y = self.parent.y
-
-        mode = layout_mode(self.node)
-        if mode == "block":
-            previous = None
-            for child in self.node.children:
-                next = BlockLayout(child, self, previous)
-                self.children.append(next)
-                previous = next
-        else:
-            self.new_line()
-            self.recurse(self.node)
-
-        for child in self.children:
-            child.layout()
-
-        self.height = sum([child.height for child in self.children])
-
-    def recurse(self, node):
-        if isinstance(node, Text):
-            for word in node.text.split():
-                self.word(node, word)
-        else:
-            if node.tag == "br":
-                self.new_line()
-            elif node.tag == "input" or node.tag == "button":
-                self.input(node)
-            else:
-                for child in node.children:
-                    self.recurse(child)
-
-    def new_line(self):
-        self.previous_word = None
-        self.cursor_x = 0
-        last_line = self.children[-1] if self.children else None
-        new_line = LineLayout(self.node, self, last_line)
-        self.children.append(new_line)
-
     def word(self, node, word):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
@@ -315,44 +252,8 @@ class BlockLayout:
             cmds = paint_visual_effects(self.node, cmds, rect)
         display_list.extend(cmds)
 
-    def __repr__(self):
-        return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
-            layout_mode(self.node), self.x, self.y, self.width, self.height, self.node)
-
-class DocumentLayout:
-    def __init__(self, node):
-        self.node = node
-        self.parent = None
-        self.previous = None
-        self.children = []
-
-    def layout(self):
-        child = BlockLayout(self.node, self, None)
-        self.children.append(child)
-
-        self.width = WIDTH - 2*HSTEP
-        self.x = HSTEP
-        self.y = VSTEP
-        child.layout()
-        self.height = child.height + 2*VSTEP
-
-    def paint(self, display_list):
-        self.children[0].paint(display_list)
-
-    def __repr__(self):
-        return "DocumentLayout()"
-
+@wbetools.patch(LineLayout)
 class LineLayout:
-    def __init__(self, node, parent, previous):
-        self.node = node
-        self.parent = parent
-        self.previous = previous
-        self.children = []
-        self.x = None
-        self.y = None
-        self.width = None
-        self.height = None
-
     def layout(self):
         self.width = self.parent.width
         self.x = self.parent.x
@@ -378,27 +279,8 @@ class LineLayout:
                            for word in self.children])
         self.height = 1.25 * (max_ascent + max_descent)
 
-    def paint(self, display_list):
-        for child in self.children:
-            child.paint(display_list)
-
-    def __repr__(self):
-        return "LineLayout(x={}, y={}, width={}, height={}, node={})".format(
-            self.x, self.y, self.width, self.height, self.node)
-
+@wbetools.patch(TextLayout)
 class TextLayout:
-    def __init__(self, node, word, parent, previous):
-        self.node = node
-        self.word = word
-        self.children = []
-        self.parent = parent
-        self.previous = previous
-        self.x = None
-        self.y = None
-        self.width = None
-        self.height = None
-        self.font = None
-
     def layout(self):
         weight = self.node.style["font-weight"]
         style = self.node.style["font-style"]
@@ -416,28 +298,8 @@ class TextLayout:
 
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
-        color = self.node.style["color"]
-        display_list.append(
-            DrawText(self.x, self.y, self.word, self.font, color))
-    
-    def __repr__(self):
-        return ("TextLayout(x={}, y={}, width={}, height={}, " +
-            "node={}, word={})").format(
-            self.x, self.y, self.width, self.height, self.node, self.word)
-
+@wbetools.patch(InputLayout)
 class InputLayout:
-    def __init__(self, node, parent, previous):
-        self.node = node
-        self.children = []
-        self.parent = parent
-        self.previous = previous
-        self.x = None
-        self.y = None
-        self.width = None
-        self.height = None
-        self.font = None
-
     def layout(self):
         weight = self.node.style["font-weight"]
         style = self.node.style["font-style"]
@@ -483,14 +345,6 @@ class InputLayout:
         cmds = paint_visual_effects(self.node, cmds, rect)
         display_list.extend(cmds)
 
-    def __repr__(self):
-        if self.node.tag == "input":
-            extra = "type=input"
-        else:
-            extra = "type=button text={}".format(self.node.children[0].text)
-        return "InputLayout(x={}, y={}, width={}, height={} {})".format(
-            self.x, self.y, self.width, self.height, extra)
-
 def paint_visual_effects(node, cmds, rect):
     opacity = float(node.style.get("opacity", "1.0"))
 
@@ -514,71 +368,8 @@ def paint_visual_effects(node, cmds, rect):
         ], should_save=needs_blend_isolation),
     ]
 
+@wbetools.patch(Tab)
 class Tab:
-    def __init__(self):
-        self.history = []
-        self.focus = None
-        self.url = None
-        self.scroll = 0
-
-        with open("browser8.css") as f:
-            self.default_style_sheet = CSSParser(f.read()).parse()
-
-    def allowed_request(self, url):
-        return self.allowed_origins == None or \
-            url.origin() in self.allowed_origins
-
-    def load(self, url, body=None):
-        headers, body = url.request(self.url, body)
-        self.scroll = 0
-        self.url = url
-        self.history.append(url)
-
-        self.allowed_origins = None
-        if "content-security-policy" in headers:
-           csp = headers["content-security-policy"].split()
-           if len(csp) > 0 and csp[0] == "default-src":
-               self.allowed_origins = csp[1:]
-
-        self.nodes = HTMLParser(body).parse()
-
-        self.js = JSContext(self)
-        scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
-                   if isinstance(node, Element)
-                   and node.tag == "script"
-                   and "src" in node.attributes]
-        for script in scripts:
-            script_url = url.resolve(script)
-            if not self.allowed_request(script_url):
-                print("Blocked script", script, "due to CSP")
-                continue
-            header, body = script_url.request(url)
-            try:
-                self.js.run(body)
-            except dukpy.JSRuntimeError as e:
-                print("Script", script, "crashed", e)
-
-        self.rules = self.default_style_sheet.copy()
-        links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
-                 if isinstance(node, Element)
-                 and node.tag == "link"
-                 and "href" in node.attributes
-                 and node.attributes.get("rel") == "stylesheet"]
-        for link in links:
-            style_url = url.resolve(link)
-            if not self.allowed_request(style_url):
-                print("Blocked style", link, "due to CSP")
-                continue
-            try:
-                header, body = style_url.request(url)
-            except:
-                continue
-            self.rules.extend(CSSParser(body).parse())
-
-        self.render()
-
     def render(self):
         style(self.nodes, sorted(self.rules, key=cascade_priority))
         self.document = DocumentLayout(self.nodes)
@@ -600,67 +391,7 @@ class Tab:
         for cmd in self.display_list:
             cmd.execute(canvas)
 
-    def scrolldown(self):
-        max_y = self.document.height - (HEIGHT - CHROME_PX)
-        self.scroll = min(self.scroll + SCROLL_STEP, max_y)
-
-    def click(self, x, y):
-        self.focus = None
-        y += self.scroll
-        objs = [obj for obj in tree_to_list(self.document, [])
-                if obj.x <= x < obj.x + obj.width
-                and obj.y <= y < obj.y + obj.height]
-        if not objs: return
-        elt = objs[-1].node
-        if elt and self.js.dispatch_event("click", elt): return
-        while elt:
-            if isinstance(elt, Text):
-                pass
-            elif elt.tag == "a" and "href" in elt.attributes:
-                url = self.url.resolve(elt.attributes["href"])
-                return self.load(url)
-            elif elt.tag == "input":
-                elt.attributes["value"] = ""
-                self.focus = elt
-                return
-            elif elt.tag == "button":
-                while elt:
-                    if elt.tag == "form" and "action" in elt.attributes:
-                        return self.submit_form(elt)
-                    elt = elt.parent
-            elt = elt.parent
-
-    def submit_form(self, elt):
-        if self.js.dispatch_event("submit", elt): return
-        inputs = [node for node in tree_to_list(elt, [])
-                  if isinstance(node, Element)
-                  and node.tag == "input"
-                  and "name" in node.attributes]
-
-        body = ""
-        for input in inputs:
-            name = input.attributes["name"]
-            value = input.attributes.get("value", "")
-            name = urllib.parse.quote(name)
-            value = urllib.parse.quote(value)
-            body += "&" + name + "=" + value
-        body = body [1:]
-
-        url = self.url.resolve(elt.attributes["action"])
-        self.load(url, body)
-
-    def keypress(self, char):
-        if self.focus:
-            if self.js.dispatch_event("keydown", self.focus): return
-            self.focus.attributes["value"] += char
-        self.document.paint(self.display_list) # TODO: is this necessary?
-
-    def go_back(self):
-        if len(self.history) > 1:
-            self.history.pop()
-            back = self.history.pop()
-            self.load(back)
-
+@wbetools.patch(Browser)
 class Browser:
     def __init__(self):
         self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
@@ -689,10 +420,6 @@ class Browser:
             self.GREEN_MASK = 0x0000ff00
             self.BLUE_MASK = 0x00ff0000
             self.ALPHA_MASK = 0xff000000
-
-    def handle_down(self):
-        self.tabs[self.active_tab].scrolldown()
-        self.draw()
 
     def handle_click(self, e):
         if e.y < CHROME_PX:
@@ -754,6 +481,7 @@ class Browser:
         canvas.clear(skia.ColorWHITE)
         active_tab.raster(canvas)
 
+    # We need to keep this because it calls get_font
     def paint_chrome(self):
         cmds = []
         cmds.append(DrawRect(0, 0, WIDTH, CHROME_PX, "white"))

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -10,7 +10,7 @@ import ssl
 import tkinter
 import tkinter.font
 from lab1 import URL
-from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP, Browser
 
 class Text:
     def __init__(self, text):
@@ -123,6 +123,7 @@ class Layout:
         self.cursor_y = baseline + 1.25 * max_descent
         wbetools.record("final_y", self.cursor_y);
 
+@wbetools.patch(Browser)
 class Browser:
     def __init__(self):
         self.window = tkinter.Tk()
@@ -149,10 +150,6 @@ class Browser:
             if y > self.scroll + HEIGHT: continue
             if y + font.metrics("linespace") < self.scroll: continue
             self.canvas.create_text(x, y - self.scroll, text=word, font=font, anchor="nw")
-
-    def scrolldown(self, e):
-        self.scroll += SCROLL_STEP
-        self.draw()
 
 if __name__ == "__main__":
     import sys

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -47,7 +47,6 @@ class BlockLayout:
         self.y = None
         self.width = None
         self.height = None
-
         self.display_list = []
 
     def layout(self):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -48,6 +48,8 @@ class BlockLayout:
         self.width = None
         self.height = None
 
+        self.display_list = []
+
     def layout(self):
         wbetools.record("layout_pre", self)
 
@@ -67,8 +69,6 @@ class BlockLayout:
                 self.children.append(next)
                 previous = next
         else:
-            self.display_list = []
-
             self.cursor_x = 0
             self.cursor_y = 0
             self.weight = "normal"

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -12,7 +12,7 @@ import tkinter.font
 from lab1 import URL
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
-from lab4 import Text, Element, print_tree, HTMLParser
+from lab4 import Text, Element, print_tree, HTMLParser, Layout, Browser
 
 BLOCK_ELEMENTS = [
     "html", "body", "article", "section", "nav", "aside",
@@ -36,6 +36,7 @@ def layout_mode(node):
     else:
         return "block"
 
+@wbetools.patch(Layout)
 class BlockLayout:
     def __init__(self, node, parent, previous):
         self.node = node
@@ -89,41 +90,6 @@ class BlockLayout:
 
         wbetools.record("layout_post", self)
 
-    def recurse(self, node):
-        if isinstance(node, Text):
-            for word in node.text.split():
-                self.word(word)
-        else:
-            self.open_tag(node.tag)
-            for child in node.children:
-                self.recurse(child)
-            self.close_tag(node.tag)
-
-    def open_tag(self, tag):
-        if tag == "i":
-            self.style = "italic"
-        elif tag == "b":
-            self.weight = "bold"
-        elif tag == "small":
-            self.size -= 2
-        elif tag == "big":
-            self.size += 4
-        elif tag == "br":
-            self.flush()
-
-    def close_tag(self, tag):
-        if tag == "i":
-            self.style = "roman"
-        elif tag == "b":
-            self.weight = "normal"
-        elif tag == "small":
-            self.size += 2
-        elif tag == "big":
-            self.size -= 4
-        elif tag == "p":
-            self.flush()
-            self.cursor_y += VSTEP
-        
     def word(self, word):
         font = get_font(self.size, self.weight, self.style)
         w = font.measure(word)
@@ -210,7 +176,6 @@ class DrawText:
         return "DrawText(top={} left={} bottom={} text={} font={})".format(
             self.top, self.left, self.bottom, self.text, self.font)
 
-
 class DrawRect:
     def __init__(self, x1, y1, x2, y2, color):
         self.top = y1
@@ -231,20 +196,8 @@ class DrawRect:
         return "DrawRect(top={} left={} bottom={} right={} color={})".format(
             self.top, self.left, self.bottom, self.right, self.color)
 
+@wbetools.patch(Browser)
 class Browser:
-    def __init__(self):
-        self.window = tkinter.Tk()
-        self.canvas = tkinter.Canvas(
-            self.window,
-            width=WIDTH,
-            height=HEIGHT
-        )
-        self.canvas.pack()
-
-        self.scroll = 0
-        self.window.bind("<Down>", self.scrolldown)
-        self.display_list = []
-
     def load(self, url):
         headers, body = url.request()
         self.nodes = HTMLParser(body).parse()

--- a/src/lab7-tests.md
+++ b/src/lab7-tests.md
@@ -50,17 +50,7 @@ Here is how the lines are represented in chapter 7:
                TextLayout(x=61, y=50.25, width=48, height=12, node='And this too', word=this)
                TextLayout(x=121, y=50.25, width=36, height=12, node='And this too', word=too)
 
-Whereas in chapter 6 there is no direct layout tree representation of text, but the inline
-has the same total height:
-
-    >>> import lab6
-    >>> browser2 = lab6.Browser()
-    >>> browser2.load(url)
-    >>> lab6.print_tree(browser2.document)
-     DocumentLayout()
-       BlockLayout[block](x=13, y=18, width=774, height=45.0)
-         BlockLayout[block](x=13, y=18, width=774, height=45.0)
-           BlockLayout[inline](x=13, y=18, width=774, height=45.0)
+Whereas in chapter 6 there is no direct layout tree representation of text.
 
 Testing Tab
 ===========

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -15,7 +15,7 @@ from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
-from lab6 import DrawText, URL, tree_to_list
+from lab6 import DrawText, URL, tree_to_list, BlockLayout, DocumentLayout
 import wbetools
 
 @wbetools.patch(URL)
@@ -114,17 +114,8 @@ class TextLayout:
             "node={}, word={})").format(
             self.x, self.y, self.width, self.height, self.node, self.word)
 
+@wbetools.patch(BlockLayout)
 class BlockLayout:
-    def __init__(self, node, parent, previous):
-        self.node = node
-        self.parent = parent
-        self.previous = previous
-        self.children = []
-        self.x = None
-        self.y = None
-        self.width = None
-        self.height = None
-
     def layout(self):
         wbetools.record("layout_pre", self)
 
@@ -171,13 +162,6 @@ class BlockLayout:
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def get_font(self, node):
-        weight = node.style["font-weight"]
-        style = node.style["font-style"]
-        if style == "normal": style = "roman"
-        size = int(float(node.style["font-size"][:-2]) * .75)
-        return get_font(size, weight, style)
-
     def word(self, node, word):
         font = self.get_font(node)
         w = font.measure(word)
@@ -203,31 +187,6 @@ class BlockLayout:
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(
             layout_mode(self.node), self.x, self.y, self.width, self.height)
-
-class DocumentLayout:
-    def __init__(self, node):
-        self.node = node
-        self.parent = None
-        self.previous = None
-        self.children = []
-
-    def layout(self):
-        wbetools.record("layout_pre", self)
-        child = BlockLayout(self.node, self, None)
-        self.children.append(child)
-
-        self.width = WIDTH - 2*HSTEP
-        self.x = HSTEP
-        self.y = VSTEP
-        child.layout()
-        self.height = child.height + 2*VSTEP
-        wbetools.record("layout_post", self)
-
-    def paint(self, display_list):
-        self.children[0].paint(display_list)
-
-    def __repr__(self):
-        return "DocumentLayout()"
 
 class DrawLine:
     def __init__(self, x1, y1, x2, y2, color, thickness):

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -4,6 +4,7 @@ up to and including Chapter 9 (Running Interactive Scripts),
 without exercises.
 """
 
+import wbetools
 import socket
 import ssl
 import tkinter
@@ -18,7 +19,7 @@ from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
-from lab8 import URL, layout_mode
+from lab8 import URL, layout_mode, Tab, Browser
 from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX
 
 EVENT_DISPATCH_CODE = \
@@ -79,15 +80,8 @@ class JSContext:
             child.parent = elt
         self.tab.render()
 
+@wbetools.patch(Tab)
 class Tab:
-    def __init__(self):
-        self.history = []
-        self.focus = None
-        self.url = None
-
-        with open("browser8.css") as f:
-            self.default_style_sheet = CSSParser(f.read()).parse()
-
     def load(self, url, body=None):
         self.scroll = 0
         self.url = url
@@ -122,33 +116,6 @@ class Tab:
                 continue
             self.rules.extend(CSSParser(body).parse())
         self.render()
-
-    def render(self):
-        style(self.nodes, sorted(self.rules, key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
-        self.document.layout()
-        self.display_list = []
-        self.document.paint(self.display_list)
-
-        if self.focus:
-            obj = [obj for obj in tree_to_list(self.document, [])
-                   if obj.node == self.focus and \
-                        isinstance(obj, InputLayout)][0]
-            text = self.focus.attributes.get("value", "")
-            x = obj.x + obj.font.measure(text)
-            y = obj.y - self.scroll
-            self.display_list.append(
-                DrawLine(x, y, x, y + obj.height, "black", 1))
-
-    def draw(self, canvas):
-        for cmd in self.display_list:
-            if cmd.top > self.scroll + HEIGHT - CHROME_PX: continue
-            if cmd.bottom < self.scroll: continue
-            cmd.execute(self.scroll - CHROME_PX, canvas)
-
-    def scrolldown(self):
-        max_y = self.document.height - (HEIGHT - CHROME_PX)
-        self.scroll = min(self.scroll + SCROLL_STEP, max_y)
 
     def click(self, x, y):
         self.focus = None
@@ -202,115 +169,6 @@ class Tab:
             if self.js.dispatch_event("keydown", self.focus): return
             self.focus.attributes["value"] += char
             self.render()
-
-    def go_back(self):
-        if len(self.history) > 1:
-            self.history.pop()
-            back = self.history.pop()
-            self.load(back)
-
-class Browser:
-    def __init__(self):
-        self.window = tkinter.Tk()
-        self.canvas = tkinter.Canvas(
-            self.window,
-            width=WIDTH,
-            height=HEIGHT,
-            bg="white",
-        )
-        self.canvas.pack()
-
-        self.window.bind("<Down>", self.handle_down)
-        self.window.bind("<Button-1>", self.handle_click)
-        self.window.bind("<Key>", self.handle_key)
-        self.window.bind("<Return>", self.handle_enter)
-
-        self.tabs = []
-        self.active_tab = None
-        self.focus = None
-        self.address_bar = ""
-
-    def handle_down(self, e):
-        self.tabs[self.active_tab].scrolldown()
-        self.draw()
-
-    def handle_click(self, e):
-        if e.y < CHROME_PX:
-            self.focus = None
-            if 40 <= e.x < 40 + 80 * len(self.tabs) and 0 <= e.y < 40:
-                self.active_tab = int((e.x - 40) / 80)
-            elif 10 <= e.x < 30 and 10 <= e.y < 30:
-                self.load("https://browser.engineering/")
-            elif 10 <= e.x < 35 and 50 <= e.y < 90:
-                self.tabs[self.active_tab].go_back()
-            elif 50 <= e.x < WIDTH - 10 and 50 <= e.y < 90:
-                self.focus = "address bar"
-                self.address_bar = ""
-        else:
-            self.focus = "content"
-            self.tabs[self.active_tab].click(e.x, e.y - CHROME_PX)
-        self.draw()
-
-    def handle_key(self, e):
-        if len(e.char) == 0: return
-        if not (0x20 <= ord(e.char) < 0x7f): return
-        if self.focus == "address bar":
-            self.address_bar += e.char
-        elif self.focus == "content":
-            self.tabs[self.active_tab].keypress(e.char)
-        self.draw()
-
-    def handle_enter(self, e):
-        if self.focus == "address bar":
-            self.tabs[self.active_tab].load(self.address_bar)
-            self.focus = None
-            self.draw()
-
-    def load(self, url):
-        new_tab = Tab()
-        new_tab.load(url)
-        self.active_tab = len(self.tabs)
-        self.tabs.append(new_tab)
-        self.draw()
-
-    def paint_chrome(self):
-        cmds = []
-        cmds.append(DrawRect(0, 0, WIDTH, CHROME_PX, "white"))
-        cmds.append(DrawLine(0, CHROME_PX - 1, WIDTH, CHROME_PX - 1, "black", 1))
-
-        tabfont = get_font(20, "normal", "roman")
-        for i, tab in enumerate(self.tabs):
-            name = "Tab {}".format(i)
-            x1, x2 = 40 + 80 * i, 120 + 80 * i
-            cmds.append(DrawLine(x1, 0, x1, 40, "black", 1))
-            cmds.append(DrawLine(x2, 0, x2, 40, "black", 1))
-            cmds.append(DrawText(x1 + 10, 10, name, tabfont, "black"))
-            if i == self.active_tab:
-                cmds.append(DrawLine(0, 40, x1, 40, "black", 1))
-                cmds.append(DrawLine(x2, 40, WIDTH, 40, "black", 1))
-
-        buttonfont = get_font(30, "normal", "roman")
-        cmds.append(DrawOutline(10, 10, 30, 30, "black", 1))
-        cmds.append(DrawText(11, 0, "+", buttonfont, "black"))
-
-        cmds.append(DrawOutline(40, 50, WIDTH - 10, 90, "black", 1))
-        if self.focus == "address bar":
-            cmds.append(DrawText(55, 55, self.address_bar, buttonfont, "black"))
-            w = buttonfont.measure(self.address_bar)
-            cmds.append(DrawLine(55 + w, 55, 55 + w, 85, "black", 1))
-        else:
-            url = str(self.tabs[self.active_tab].url)
-            cmds.append(DrawText(55, 55, url, buttonfont, "black"))
-
-        cmds.append(DrawOutline(10, 50, 35, 90, "black", 1))
-        cmds.append(DrawText(15, 50, "<", buttonfont, "black"))
-        return cmds
-
-    def draw(self):
-        self.canvas.delete("all")
-        self.tabs[self.active_tab].draw(self.canvas)
-        for cmd in self.paint_chrome():
-            cmd.execute(0, self.canvas)
 
 if __name__ == "__main__":
     import sys

--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -5,7 +5,6 @@ def record(type, *args):
 
 def patch(existing_cls):
     def decorator(new_cls):
-<<<<<<< HEAD
         if isinstance(new_cls, type): # Patching classes
             assert isinstance(existing_cls, type), f"Can't patch {existing_cls} with {new_cls}"
             for attr, obj in new_cls.__dict__.items():
@@ -51,34 +50,6 @@ def patch(existing_cls):
                             raise Exception(msg)
         else:
             raise ValueError(f"Cannot patch {existing_cls}")
-=======
-        for attr in dir(new_cls):
-            obj = getattr(new_cls, attr)
-            # Copies over all methods and all writable fields of functions
-            # Uses a cute hack to get the `function` class.
-            if isinstance(obj, type(decorator)) \
-               or attr in ["__code__", "__module__", "__defaults__", "__annotations"]:
-                try:
-                    setattr(existing_cls, attr, obj)
-                except Exception as e:
-                    print(f"Trying to patch field {attr} of {existing_cls}")
-                    raise e
-            elif attr == "__closure__":
-                assert obj is None, "Cannot patch using a closure"
-                assert getattr(existing_cls, attr) is None, "Cannot patch a closure"
-            elif attr == "__globals__":
-                continue
-                old_obj = getattr(existing_cls, attr)
-                for field in obj:
-                    if field not in old_obj:
-                        print(f"While patching {existing_cls}, __globals__.{field} not in old")
-                        continue
-                    if obj[field] != old_obj[field]:
-                        print(f"While patching {existing_cls}, __globals__.{field} differs")
-                for field in old_obj:
-                    if field not in obj:
-                        print(f"While patching {existing_cls}, __globals__.{field} not in new")
->>>>>>> b8f8b45 (Use wbetools.patch on lab8)
         return existing_cls
     return decorator
 

--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -5,6 +5,7 @@ def record(type, *args):
 
 def patch(existing_cls):
     def decorator(new_cls):
+<<<<<<< HEAD
         if isinstance(new_cls, type): # Patching classes
             assert isinstance(existing_cls, type), f"Can't patch {existing_cls} with {new_cls}"
             for attr, obj in new_cls.__dict__.items():
@@ -50,6 +51,34 @@ def patch(existing_cls):
                             raise Exception(msg)
         else:
             raise ValueError(f"Cannot patch {existing_cls}")
+=======
+        for attr in dir(new_cls):
+            obj = getattr(new_cls, attr)
+            # Copies over all methods and all writable fields of functions
+            # Uses a cute hack to get the `function` class.
+            if isinstance(obj, type(decorator)) \
+               or attr in ["__code__", "__module__", "__defaults__", "__annotations"]:
+                try:
+                    setattr(existing_cls, attr, obj)
+                except Exception as e:
+                    print(f"Trying to patch field {attr} of {existing_cls}")
+                    raise e
+            elif attr == "__closure__":
+                assert obj is None, "Cannot patch using a closure"
+                assert getattr(existing_cls, attr) is None, "Cannot patch a closure"
+            elif attr == "__globals__":
+                continue
+                old_obj = getattr(existing_cls, attr)
+                for field in obj:
+                    if field not in old_obj:
+                        print(f"While patching {existing_cls}, __globals__.{field} not in old")
+                        continue
+                    if obj[field] != old_obj[field]:
+                        print(f"While patching {existing_cls}, __globals__.{field} differs")
+                for field in old_obj:
+                    if field not in obj:
+                        print(f"While patching {existing_cls}, __globals__.{field} not in new")
+>>>>>>> b8f8b45 (Use wbetools.patch on lab8)
         return existing_cls
     return decorator
 


### PR DESCRIPTION
This PR deletes a bunch of duplicate code from earlier chapters using the `wbetools.patch` code. It has to delete one test which relies on running `lab6` and `lab7` in parallel to get two different layouts. It also pulls in an improved version of `wbetools.patch`, which was originally written for Chapter 16.