### PR TITLE
Revert "Rewrite the `compare` tool to use JSON for data"

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -898,7 +898,7 @@ the last the focusable node (or if there weren't any focusable nodes
 to begin with), we'll un-focus the page and move focus to the address
 bar:
 
-``` {.python replace=%20%3d%20focusable_nodes[idx]/_element(focusable_nodes[idx]),%20%3d%20None/_element(None)}
+``` {.python replace=%20=%20focusable_nodes[idx]/_element(focusable_nodes[idx]),%20=%20None/_element(None)}
 class Tab:
     def advance_tab(self):
         if idx < len(focusable_nodes):
@@ -1139,7 +1139,7 @@ class DrawOutline(DisplayItem):
 
 Now we can paint a 1 pixel black outline around an element like this:
 
-``` {.python sub=node.is_focused with=has_outline(node) sub=%22black%22 with=color sub=1 with=thickness}
+``` {.python replace=node.is_focused/has_outline(node),"black"/color,1/thickness}
 def paint_outline(node, cmds, rect, zoom):
     if node.is_focused:
         cmds.append(DrawOutline(rect, "black", 1))

--- a/book/animations.md
+++ b/book/animations.md
@@ -407,7 +407,7 @@ similar code in every display command, so let's give them all a new
 that's overridden for specific display commands. For example, we can make sure
 that every display command has a `children` field:
 
-``` {.python replace=children%3d[]/rect%2c%20children%3d[]%2c%20node%3dNone}
+``` {.python replace=children=[]/rect%2c%20children=[]%2c%20node=None}
 class DisplayItem:
     def __init__(self, children=[]):
         self.children = children
@@ -430,7 +430,7 @@ class DrawRect(DisplayItem):
 Commands that already had a `children` field need to pass it to the
 `__init__` call:
 
-``` {.python replace=children%3dchildren/rect%2c%20children%3dchildren}
+``` {.python replace=children=children/rect%2c%20children=children}
 class ClipRRect(DisplayItem):
     def __init__(self, rect, radius, children, should_clip=True):
         super().__init__(children=children)

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -102,7 +102,7 @@ words in the whole inline element.
 Inside the `text` method, this key line adds a word to the current
 line of text:
 
-``` {.python file=lab6 indent=12}
+``` {.python.lab6 indent=12}
 self.line.append((self.cursor_x, word, font, color))
 ```
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -488,7 +488,7 @@ the `alt` attribute is for. It works like this:
 
 Implementing this in `AccessibilityNode` is very easy:
 
-``` {.python replace=node)/node%2C%20parent%20%3d%20None)}
+``` {.python replace=node)/node%2C%20parent%20=%20None)}
 class AccessibilityNode:
     def __init__(self, node):
         else:
@@ -1082,7 +1082,7 @@ Finally, let's also add iframes to the accessibility tree. Like the
 display list, the accessibility tree is global across all frames.
 We can have iframes create `iframe` nodes:
 
-``` {.python replace=node)/node%2C%20parent%20%3d%20None)}
+``` {.python replace=node)/node%2C%20parent%20=%20None)}
 class AccessibilityNode:
     def __init__(self, node):
         else:

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -775,7 +775,7 @@ animation maximally smooth. It works like this:
 
 [raf]: https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
 
-``` {.javascript .example}
+``` {.javascript.example}
 function callback() { /* Modify DOM */ }
 requestAnimationFrame(callback);
 ```

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -129,7 +129,7 @@ simple web page with a `script` tag:
 
 Then write a super simple script to `test.js`, maybe this:
 
-``` {.javascript .example}
+``` {.javascript.example}
 var x = 2
 x + x
 ```
@@ -220,7 +220,7 @@ class JSContext:
 We can call an exported function from JavaScript using Dukpy's
 `call_python` function. For example:
 
-``` {.javascript .example}
+``` {.javascript.example}
 call_python("log", "Hi from JS")
 ```
 
@@ -234,7 +234,7 @@ Since we ultimately want JavaScript to call a `console.log` function,
 not a `call_python` function, we need to define a `console` object
 and then give it a `log` property. We can do that *in JavaScript*:
 
-``` {.javascript .example}
+``` {.javascript.example}
 console = { log: function(x) { call_python("log", x); } }
 ```
 
@@ -294,7 +294,7 @@ Crashes in JavaScript code are frustrating to debug. You can cause a
 crash by writing bad code, or by explicitly raising an exception, like
 so:
 
-``` {.javascript .example}
+``` {.javascript.example}
 throw Error("bad");
 ```
 
@@ -396,7 +396,7 @@ class JSContext:
 In JavaScript, `querySelectorAll` is a method on the `document`
 object, which we need to define in the JavaScript runtime:
 
-``` {.javascript replace=return/var%20handles%20%3d}
+``` {.javascript replace=return/var%20handles%20=}
 document = { querySelectorAll: function(s) {
     return call_python("querySelectorAll", s);
 }}
@@ -713,7 +713,7 @@ on.
 
 When an event occurs, the browser calls `dispatchEvent` from Python:
 
-``` {.python replace=self.interp.evaljs/do_default%20%3d%20self.interp.evaljs}
+``` {.python replace=self.interp.evaljs/do_default%20=%20self.interp.evaljs}
 class JSContext:
     def dispatch_event(self, type, elt):
         handle = self.node_to_handle.get(elt, -1)
@@ -767,7 +767,7 @@ that change the page. The full DOM API provides a lot of such methods,
 but for simplicity I'm going to implement only `innerHTML`, which is
 used like this:
 
-``` {.javascript .example}
+``` {.javascript.example}
 node.innerHTML = "This is my <b>new</b> bit of content!";
 ```
 
@@ -886,7 +886,7 @@ def do_request(method, url, headers, body):
 We can then put our little input length checker into `comment.js`,
 with the `lengthCheck` function modified to use `innerHTML`:
 
-``` {.javascript file=comment replace=value.length%20%3e%20100/!allow_submit}
+``` {.javascript file=comment replace=value.length%20>%20100/!allow_submit}
 var label = document.querySelectorAll("label")[0];
 
 function lengthCheck() {
@@ -1220,7 +1220,7 @@ property is called `backgroundColor` in Javascript. Implement the
 return a string containing HTML source code. That source code should
 reflect the *current* attributes of the element; for example:
 
-``` {.javascript .example} 
+``` {.javascript.example} 
 element.innerHTML = '<span id=foo>Chris was here</span>';
 element.id = 'bar';
 // Prints "<span id=bar>Chris was here</span>":

--- a/book/security.md
+++ b/book/security.md
@@ -86,7 +86,7 @@ def handle_connection(conx):
 Of course, new visitors need to be told to remember their
 newly-generated token:
 
-``` {.python file=server replace=%7b%7d/%7b%7d;%20SameSite%3dLax}
+``` {.python file=server replace=%7b%7d/%7b%7d;%20SameSite=Lax}
 def handle_connection(conx):
     # ...
     if 'cookie' not in headers:
@@ -359,7 +359,7 @@ you open a second tab, you're logged in on that tab as well.
 When the browser visits a page, it needs to send the cookie for that
 site:
 
-``` {.python replace=(url/(url%2c%20top_level_url,cookie%20%3d/cookie%2c%20params%20%3d}
+``` {.python replace=(url/(url%2c%20top_level_url,cookie%20=/cookie%2c%20params%20=}
 def request(url, payload=None):
     # ...
     if host in COOKIE_JAR:
@@ -374,7 +374,7 @@ Symmetrically, the browser has to update the cookie jar when it sees a
 [^multiple-set-cookies]: A server can actually send multiple
     `Set-Cookie` headers to set multiple cookies in one request.
 
-``` {.python sub=(url with=(url,%20top_level_url sub=%3d%20kv with=%3d%20(kv%2c%20params) sub=kv with=cookie}
+``` {.python replace=(url/(url%2c%20top_level_url,=%20kv/=%20(kv%2c%20params),kv/cookie}
 def request(url, payload=None):
     # ...
     if "set-cookie" in headers:
@@ -458,7 +458,7 @@ I'll implement a minimal version here. Specifically, I'll support only
 
 [xhr-open]: https://xhr.spec.whatwg.org/#the-open()-method
 
-``` {.javascript .example}
+``` {.javascript.example}
 x = new XMLHttpRequest();
 x.open("GET", url, false);
 x.send();
@@ -557,7 +557,7 @@ could request the guest book page:
     ads on sketchy websites where users have low standards for
     security anyway.
 
-``` {.javascript .example}
+``` {.javascript.example}
 x = new XMLHttpRequest();
 x.open("GET", "http://localhost:8000/", false);
 x.send();

--- a/book/styles.md
+++ b/book/styles.md
@@ -223,7 +223,7 @@ but before doing layout.
 This `style` function will also fill in the `style` field by parsing
 the element's `style` attribute:
     
-``` {.python replace=(node)/(node%2C%20rules),%3d%20value/%3d%20computed_value}
+``` {.python replace=(node)/(node%2C%20rules),=%20value/=%20computed_value}
 def style(node):
     # ...
     if isinstance(node, Element) and "style" in node.attributes:
@@ -279,7 +279,7 @@ HTML elements a list of property/value pairs apply to:[^media-queries]
     Media queries are super-important for building sites that work
     across many devices, like reading this book on a phone.
 
-``` {.css .example}
+``` {.css.example}
 selector { property-1: value-1; property-2: value-2; }
 ```
 
@@ -490,7 +490,7 @@ the page, this will require looping over all elements *and* all rules.
 When a rule applies, its property/values pairs are copied to the
 element's style information:
 
-``` {.python replace=%3d%20value/%3d%20computed_value}
+``` {.python replace==%20value/=%20computed_value}
 def style(node, rules):
     # ...
     for selector, body in rules:

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -814,7 +814,7 @@ real browser: the `transform` property, `position`ed elements,
 negative margins, and so many more. But color mixing works the same
 way each time.
 
-``` {.html .example}
+``` {.html.example}
 <div style="background-color:orange">
     Parent
     <div style="background-color:white;border-radius:5px">Child</div>
@@ -1100,7 +1100,7 @@ the [`mix-blend-mode` property][mix-blend-mode-def], like this:
 
 [wiki-blend-mode]: https://en.wikipedia.org/wiki/Blend_modes
 
-``` {.html .example}
+``` {.html.example}
 <div style="background-color:orange">
     Parent
     <div style="background-color:blue;mix-blend-mode:difference">
@@ -1226,7 +1226,7 @@ parent. Our browser doesn't support these, but there is one edge case
 where `overflow: clip` is relevant: rounded corners. Consider this
 example:
 
-``` {.html .example}
+``` {.html.example}
 <div 
   style="border-radius:30px;background-color:lightblue;overflow:clip">
     This test text exists here to ensure that the "div" element is

--- a/config.json
+++ b/config.json
@@ -32,7 +32,6 @@
         },
         "chrome.md": {
             "lab": "lab7.py",
-            "lab6": "lab6.py",
             "tests": "lab7-tests.md"
         },
 

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -7,86 +7,77 @@ import sys
 import tempfile
 import urllib.parse
 
-class Span:
-    def __init__(self, s):
-        self.filename, pos = s.split("@", 1)
-        self.start_line = None
-        for piece in pos.split(";"):
-            start, end = piece.split("-")
-            if not self.start_line:
-                self.start_line, self.start_char = start.split(":")
-            self.end_line, self.end_char = end.split(":")
+def get_blocks(file):
+    status = None
+    accumulator = ""
+    for line in file:
+        if line.startswith("##</>"):
+            yield status, accumulator
+            status = None
+            accumulator = ""
+        elif line.startswith("##<"):
+            metadata = line[len("##<"):-len(">")]
+            try:
+                status = json.loads(metadata)
+            except json.decoder.JSONDecodeError:
+                print("Could not decode " + metadata)
+                status = {}
+            accumulator = ""
+        elif status is not None:
+            if line:
+                accumulator += line + "\n"
+                
+# Lua code to extract all code blocks from a Markdown file via Pandoc
+FILTER = r'''
+function CodeBlock(el)
+  io.write("##<{")
+  local written = nil
+  io.write("\"classes\": [")
+  for i, cls in pairs(el.classes) do
+      if written then io.write(", ") end
+      io.write("\"" .. cls .. "\"")
+      written = true
+  end
+  io.write("]")
+  for k, v in pairs(el.attributes) do
+      io.write(", \"" .. k .. "\": \"" .. v:gsub("\"", "\\\"") .. "\"")
+  end
+  io.write("}>\n")
+  io.write(el.text .. "\n")
+  io.write("##</>\n\n")
+  io.flush()
+  return el
+end
+'''
 
-    def __str__(self):
-        return f"{self.filename}:{self.start_line}"
+def indent(block, n=0):
+    n = int(n)
+    if n == 0: return block
+    indentation = " " * n
+    block = indentation + block.replace("\n", "\n" + indentation)
+    return block[:-n]
 
-class Block:
-    def __init__(self, block):
-        meta, self.content = block
-        assert meta[0] == ""
-        self.classes = meta[1]
+def replace(block, *cmds):
+    for find, replace in cmds:
+        find = urllib.parse.unquote(find)
+        replace = urllib.parse.unquote(replace)
+        block = block.replace(find, replace)
+    return block
 
-        self.errors = []
-        if any(c.startswith("{.") for c in meta[1]):
-            self.errors.append(f"Mis-parsed block metadata")
-
-        attrs = dict(meta[2])
-        self.loc = Span(attrs["data-pos"])
-        self.file = attrs.get("file")
-        self.expected = attrs.get("expected", "True") == "True"
-        self.indent(int(attrs.get("indent", "0")))
-        if "dropline" in attrs:
-            self.dropline(attrs["dropline"])
-
-        # There are several ways to specify text replacements
-        cmds = [(key, val) for key, val in meta[2] if key in ["replace", "sub", "with"]]
-        if cmds:
-            self.replace(cmds)
-
-        self.stop = "stop" in attrs
-
-    def indent(self, n):
-        indentation = " " * n
-        self.content = indentation + self.content.strip().replace("\n", "\n" + indentation) + "\n"
-
-    def dropline(self, pattern):
-        self.content = "\n".join([
-            line for line in self.content.split("\n")
-            if urllib.parse.unquote(pattern) not in line
-        ])
-
-    def replace(self, cmds):
-        replacements = []
-        sub = None
-        for key, value in cmds:
-            if key == "replace":
-                replacements.extend([item.split("/", 1) for item in value.split(",")])
-            elif key == "sub":
-                if sub: self.errors.append("'sub' key with no corresponding 'with'")
-                sub = value
-            elif key == "with":
-                replacements.append((sub, value))
-                sub = None
-        for find, replace in replacements:
-            find = urllib.parse.unquote(find)
-            replace = urllib.parse.unquote(replace)
-            self.content = self.content.replace(find, replace)
-
-BLOCK_CACHE = {}
+def dropline(block, pattern):
+    return "\n".join([
+        line for line in block.split("\n")
+        if pattern not in line
+    ])
 
 def tangle(file):
-    if file not in BLOCK_CACHE:
-        cmd = ["pandoc", "--from", "commonmark_x+sourcepos", "--to", "json", file]
-        out = subprocess.run(cmd, capture_output=True, check=True)
-        data = json.loads(out.stdout)
-        blocks = []
-        for block in data['blocks']:
-            if block['t'] == "CodeBlock":
-                val = Block(block['c'])
-                blocks.append(val)
-                if val.stop: break
-        BLOCK_CACHE[file] = blocks
-    return BLOCK_CACHE[file]
+    with open("/tmp/test", "wb") as f:
+        f.write(FILTER.encode("utf8"))
+        f.close()
+        cmd = ["pandoc", "--from", "markdown", "--to", "html", "--lua-filter", f.name, file]
+        out = subprocess.run(cmd, capture_output=True)
+    out.check_returncode()
+    return list(get_blocks(out.stdout.decode("utf8").split("\n")))
 
 def find_block(block, text):
     differ = difflib.Differ(charjunk=lambda c: c == " ", linejunk=str.isspace)
@@ -122,25 +113,23 @@ def compare_files(book, code, language, file):
     src = code.read()
     blocks = tangle(book.name)
     failure, count = 0, 0
-    for block in blocks:
-        content = block.content
-        if block.errors:
-            for error in block.errors:
-                print(f"{block.loc}:", error)
-                failure += 1
-            continue
-        if "example" in block.classes: continue
-        if language and language not in block.classes: continue
-        if block.file != file: continue
-        cng = find_block(block.content, src)
+    for name, block in blocks:
+        if "example" in name.get("classes"): continue
+        if language and language not in name.get("classes"): continue
+        if name.get("file") != file: continue
+        block = indent(block, name.get("indent", "0"))
+        block = replace(block, *[item.split("/", 1) for item in name.get("replace", "/").split(",")])
+        block = dropline(block, name["dropline"]) if "dropline" in name else block
+        cng = find_block(block, src)
+        expected = name.get("expected", "True") == "True"
         count += 1
-        if any(l2 for l2, l in cng) == block.expected:
+        if any(l2 for l2, l in cng) == expected:
             # If expected to pass (True) and there are lines,
             # or if expected to fail (False) and there are no lines,
             # it is a failure
             failure += 1
-            lines = block.content.count('\n')
-            print(f"{block.loc}: Failed to match {lines} lines")
+            print("Block <{}> ({} lines)".format(name, block.count("\n")))
+            if "hide" in name: continue
             for l2, l in cng:
                 if l2:
                     print(">", l, end="")
@@ -149,5 +138,6 @@ def compare_files(book, code, language, file):
                 else:
                     print(" ", l, end="")
             print()
+        if name.get("last"): break
     return failure, count
     


### PR DESCRIPTION
Reverts browserengineering/book#788

Breaks rendering the chapter with the latest pandoc, because duplicate `sub` and `with` attributes are not allowed.