### PR TITLE
Fix single-threaded mode

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -79,7 +79,7 @@ consider [many different factors][chrome-scheduling].
 
 [chrome-scheduling]: https://blog.chromium.org/2015/04/scheduling-tasks-intelligently-for_30.html
 
-``` {.python}
+``` {.python expected=False}
 class TaskRunner:
     def run(self):
         if len(self.tasks) > 0:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -513,6 +513,7 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         tab = self.tabs[self.active_tab]
+        tab.task_runner.run_tasks()
         tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):
@@ -775,7 +776,6 @@ if __name__ == "__main__":
                 browser.handle_key(event.text.text.decode('utf8'))
         active_tab = browser.tabs[browser.active_tab]
         if not wbetools.USE_BROWSER_THREAD:
-            active_tab.task_runner.run_tasks()
             if active_tab.task_runner.needs_quit:
                 break
             if browser.needs_animation_frame:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1391,6 +1391,7 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         tab = self.tabs[self.active_tab]
+        tab.task_runner.run_tasks()
         tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -50,6 +50,7 @@ An outline causes a `DrawOutline` with the given width and color:
 
     >>> browser = lab14.Browser()
     >>> browser.load(outline_url)
+    >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1351,6 +1351,7 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         tab = self.tabs[self.active_tab]
+        tab.task_runner.run_tasks()
         tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -37,6 +37,7 @@ Let's verify that we can request the image:
     ... b'<img src="http://test.test/img.png">')
     >>> browser = lab15.Browser()
     >>> browser.load(url)
+    >>> browser.render()
     >>> frame = browser.tabs[0].root_frame
     >>> headers, body = lab15.request(image_url, frame)
     >>> type(body)
@@ -71,6 +72,7 @@ Now let's test setting a different width and height:
 
     >>> browser = lab15.Browser()
     >>> browser.load(size_url)
+    >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
@@ -88,6 +90,7 @@ Let's load the original image in an iframe.
 
     >>> browser = lab15.Browser()
     >>> browser.load(iframe_url)
+    >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
@@ -106,6 +109,7 @@ And the sized one:
 
     >>> browser = lab15.Browser()
     >>> browser.load(iframe_size_url)
+    >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
@@ -126,6 +130,7 @@ Iframes can be sized too:
 
     >>> browser = lab15.Browser()
     >>> browser.load(sized_iframe_url)
+    >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
@@ -171,6 +176,7 @@ Clicking the sub-frame focuses it:
 
     >>> browser = lab15.Browser()
     >>> browser.load(sized_iframe_url)
+    >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> e = Event(50, 600)
@@ -188,6 +194,7 @@ And now scrolling affects just the child frame:
     >>> browser.tabs[0].root_frame.nodes.children[0].children[47].frame.scroll
     0
     >>> browser.handle_down()
+    >>> browser.render()
     >>> browser.scroll > 0
     False
     >>> browser.tabs[0].root_frame.nodes.children[0].children[47].frame.scroll
@@ -205,6 +212,7 @@ Let's verify that it still works.
 
     >>> browser = lab15.Browser()
     >>> browser.load(focus_url)
+    >>> browser.render()
     >>> browser.toggle_accessibility()
 
 Rendering will read out the accessibility instructions:
@@ -221,6 +229,7 @@ It also works for iframes:
 
     >>> browser = lab15.Browser()
     >>> browser.load(iframe_url)
+    >>> browser.render()
     >>> browser.toggle_accessibility()
 
 Rendering will read out the accessibility instructions:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1720,6 +1720,7 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         tab = self.tabs[self.active_tab]
+        tab.task_runner.run_tasks()
         tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):


### PR DESCRIPTION
The code was deadlocking because load would take a browser lock and then (in single-threaded mode)
run a task that tried to commit back to the browser, attempting to get the lock again.

Rather than attempt to mess with the code and change chapter examples, I changed the single-threaded
task scheduler to queue up tasks and expect them to be run via call to a new method `run_tasks`.