### PR TITLE
Fix bugs due to adding `main_func`

### DIFF
--- a/src/lab15.py
+++ b/src/lab15.py
@@ -44,7 +44,7 @@ from lab14 import parse_color, draw_rect, DrawRRect, \
     is_focused, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
     is_focusable, get_tabindex, announce_text, speak_text, \
-    CSSParser, DrawOutline, main_func
+    CSSParser, DrawOutline, main_func, Browser
 
 def request(url, top_level_url, payload=None):
     scheme, url = url.split("://", 1)
@@ -302,7 +302,7 @@ class BlockLayout:
                 radius = device_px(
                     float(self.node.style.get(
                         "border-radius", "0px")[:-2]),
-                    self.oom)
+                    self.zoom)
                 cmds.append(DrawRRect(rect, radius, bgcolor))
  
         for child in self.children:
@@ -1622,6 +1622,7 @@ def draw_line(canvas, x1, y1, x2, y2, color):
     paint.setStrokeWidth(1)
     canvas.drawPath(path, paint)
 
+@wbetools.patch(Browser)
 class Browser:
     def __init__(self):
         if wbetools.USE_GPU:


### PR DESCRIPTION
The main bug is that in Chapter 15, the `Browser` isn't marked with `@wbetools.patch`. This means that lab 15 calls `lab14.main_func`, which then creates a `lab14.Browser`, which because we didn't patch it is actually different from `lab15.Browser`. Once this bug is fixed, a typo is revealed which I also had to fix.