### PR TITLE
Work around playsound not being present

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ certifi==2022.12.7
 # And quieting an error message. Transitive dependencies of
 # PyObjC are not frozen because there are a lot and they may depend
 # on macOS version.
-playsound==1.3.0
+playsound==1.3.0; sys_platform == "darwin"
 pyobjc==8.5; sys_platform == "darwin"
 pyobjc-core==8.5; sys_platform == "darwin"

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -9,7 +9,11 @@ import dukpy
 import math
 import os
 import gtts
-import playsound
+try:
+    import playsound
+except:
+    playsound = None
+    
 import sdl2
 import skia
 import socket
@@ -630,7 +634,8 @@ def speak_text(text):
     print("SPEAK:", text)
     tts = gtts.gTTS(text)
     tts.save(SPEECH_FILE)
-    playsound.playsound(SPEECH_FILE)
+    if playsound:
+        playsound.playsound(SPEECH_FILE)
     os.remove(SPEECH_FILE)
     
 class PseudoclassSelector:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -9,7 +9,6 @@ import dukpy
 import gtts
 import math
 import os
-import playsound
 import sdl2
 import skia
 import socket


### PR DESCRIPTION
For some reason, github fails to load playsound (probably because of a security improvement that makes some non-python dependency  of it no longer load).