### PR TITLE
Schedule an animation frame after scroll updates on the browser thread

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1391,7 +1391,6 @@ class Browser:
     def set_needs_raster(self):
         self.needs_raster = True
         self.needs_draw = True
-        self.needs_animation_frame = True
 
     def set_needs_composite(self):
         self.needs_composite = True

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1496,10 +1496,15 @@ class Browser:
             self.active_tab_height)
         self.scroll = scroll
         self.set_needs_raster_and_draw()
+        self.needs_animation_frame = True
         self.lock.release()
 ```
 
-This code sets `needs_raster_and_draw` to apply the new scroll offset.
+This code sets `needs_raster_and_draw` to raster and draw with changed scroll
+offset, and sets `needs_animation_frame` to cause the main thread to receive
+the scroll offset asynchronously in the future. (Even with threaded scroll,
+it's important to synchronize the new value back to the main thread soon,
+since APIs like click handling depend on it.)
 
 The scroll offset also needs to change when the user switches tabs,
 but in this case we don't know the right scroll offset yet. We need

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -539,7 +539,6 @@ class Browser:
 
     def set_needs_raster_and_draw(self):
         self.needs_raster_and_draw = True
-        self.needs_animation_frame = True
 
     def raster_and_draw(self):
         self.lock.acquire(blocking=True)
@@ -581,6 +580,7 @@ class Browser:
             self.active_tab_height)
         self.scroll = scroll
         self.set_needs_raster_and_draw()
+        self.needs_animation_frame = True
         self.lock.release()
 
     def set_active_tab(self, index):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1421,7 +1421,6 @@ class Browser:
     def set_needs_raster(self):
         self.needs_raster = True
         self.needs_draw = True
-        self.needs_animation_frame = True
 
     def set_needs_composite(self):
         self.needs_composite = True
@@ -1538,6 +1537,7 @@ class Browser:
             self.active_tab_height)
         self.scroll = scroll
         self.set_needs_draw()
+        self.needs_animation_frame = True
         self.lock.release()
 
     def clear_data(self):
@@ -1602,6 +1602,7 @@ class Browser:
             self.url = self.address_bar
             self.focus = None
             self.set_needs_raster()
+            self.needs_animation_frame = True
         self.lock.release()
 
     def load(self, url):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1391,7 +1391,6 @@ class Browser:
     def set_needs_raster(self):
         self.needs_raster = True
         self.needs_draw = True
-        self.needs_animation_frame = True
 
     def set_needs_composite(self):
         self.needs_composite = True
@@ -1583,6 +1582,7 @@ class Browser:
             self.active_tab_height)
         self.scroll = scroll
         self.set_needs_draw()
+        self.needs_animation_frame = True
         self.lock.release()
 
     def handle_tab(self):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1753,7 +1753,6 @@ class Browser:
     def set_needs_raster(self):
         self.needs_raster = True
         self.needs_draw = True
-        self.needs_animation_frame = True
 
     def set_needs_composite(self):
         self.needs_composite = True
@@ -1947,6 +1946,7 @@ class Browser:
         active_tab = self.tabs[self.active_tab]
         task = Task(active_tab.scrolldown)
         active_tab.task_runner.schedule_task(task)
+        self.needs_animation_frame = True
         self.lock.release()        
 
     def handle_tab(self):


### PR DESCRIPTION
This is necessary to ensure browser-thread scrolls cause an update in the `Tab`. Real browsers also do this.

Fixes #803