### PR TITLE
Require animation frame when scrolling in lab15

### DIFF
--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1940,6 +1940,7 @@ class Browser:
                 self.active_tab_height)
             self.scroll = scroll
             self.set_needs_draw()
+            self.needs_animation_frame = True
             self.lock.release()
             return
         active_tab = self.tabs[self.active_tab]


### PR DESCRIPTION
#808 didn't fix scrolling in `lab15.py`

I believe I tracked down why—we mis-fixed it in #808. @chrishtr please check that I'm right, but the change is needed for Chapter 16.