### PR TITLE
Add newlines after content:example

### DIFF
--- a/www/book.css
+++ b/www/book.css
@@ -136,7 +136,7 @@ figure img { width: 100%; }
 .installation { border: 2px solid blue; }
 .installation:before { content: "Installation"; color: blue; }
 .example { border: 2px solid gray; }
-.example:before { content: "Example"; color: gray; }
+.example:before { content: "Example\A\A"; color: gray; }
 .further { border: 2px solid green; padding-top: 0; }
 .further > :first-child:before { content: "Go further: "; font-weight: bold; color: green; }
 .widget { width: 100%; border: 2px solid navy; }


### PR DESCRIPTION
The "Example" class is always applied to a `pre` element in the book, so we need to supply our own newlines.