### PR TITLE
Prefetch web fonts

### DIFF
--- a/infra/template.html
+++ b/infra/template.html
@@ -2,6 +2,11 @@
 <html lang="en-US" xml:lang="en-US">
 <head>
   <meta charset="utf-8" />
+  <link rel="prefetch" href="https://fonts.gstatic.com/s/lora/v32/0QI6MX1D_JOuGQbT0gvTJPa787weuxJBkq0.woff2" as="font" type="font/woff2">
+  <link rel="prefetch" href="https://fonts.gstatic.com/s/vollkorn/v22/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGeHmmc.woff2" as="font" type="font/woff2">
+  <link rel="prefetch" href="https://fonts.gstatic.com/s/vollkorn/v22/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJGWlmeObQ.woff2" as="font" type="font/woff2">
+  <link rel="prefetch" href="https://fonts.gstatic.com/s/lora/v32/0QI8MX1D_JOuMw_hLdO6T2wV9KnW-MoFoq92nA.woff2" as="font" type="font/woff2">
+  <link rel="prefetch" href="https://fonts.gstatic.com/s/spectral/v5/rnCr-xNNww_2s0amA9M5knjsS_ul.woff2" as="font" type="font/woff2">
   <meta name="color-scheme" content="dark light">
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=yes" />


### PR DESCRIPTION
This should make them load a bit faster.

(I'm also working on a Chrome feature that blocks rendering until such fonts have loaded, and want to see if it works
on our site.)

I found the URLs by looking at the Network in tab in Chrome devtools when loading the site.