### PR TITLE
Reuse the window object across resizes

### DIFF
--- a/www/widgets/lab11-browser.html
+++ b/www/widgets/lab11-browser.html
@@ -33,12 +33,11 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
     rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
     let widget = new Widget(document.querySelector("#controls"));
-    let w;
     widget.run(async function() {
         constants.WIDTH = window.innerWidth;
         let url = "https://localhost:8000/";
         let b = await (new Browser()).init();
-        w = init_window(b);
+        init_window(b);
         await b.load(url);
     });
     widget.next();

--- a/www/widgets/lab12-browser.html
+++ b/www/widgets/lab12-browser.html
@@ -32,15 +32,17 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
     rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
     let widget = new Widget(document.querySelector("#controls"));
-    let w;
+    let interval;
     widget.run(async function() {
+        if (interval)
+          clearInterval(interval)
         constants.WIDTH = window.innerWidth;
         let url = "https://localhost:8000/";
         let b = await (new Browser()).init();
-        w = init_window(b);
+        init_window(b);
         await b.load(url);
         await b.render();
-        setInterval(async function() {
+        interval = setInterval(async function() {
           await b.render();
           await b.raster_and_draw();
           await b.schedule_animation_frame();

--- a/www/widgets/lab13-browser.html
+++ b/www/widgets/lab13-browser.html
@@ -32,15 +32,17 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
     rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
     let widget = new Widget(document.querySelector("#controls"));
-    let w;
+    let interval;
     widget.run(async function() {
+        if (interval)
+          clearInterval(interval);
         constants.WIDTH = window.innerWidth;
         let url = "https://localhost:8000";
         let b = await (new Browser()).init();
-        w = init_window(b);
+        init_window(b);
         await b.load(url);
         await b.render();
-        setInterval(async function() {
+        interval = setInterval(async function() {
           await b.render();
           await b.composite_raster_and_draw();
           await b.schedule_animation_frame();

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -168,7 +168,6 @@ class ssl {
 class tkinter { 
     static Tk = function(...args) {
         if (rt_constants.WINDOW) {
-            console.log('reused')
             return rt_constants.WINDOW;
         }
 


### PR DESCRIPTION
Previously, every embedded browser resize (resulting from resizing the outer browser window, via the `resize` event), would create a new `Browser` object *and `tkinter.Tk` object. After resize, the old window and browser would remain active and compete for the screen.

Now we keep around one `tkinter.Tk` object across resizes and rebind events to it. Old `Browser` objects are unref'd and therefore ready for garbage collection. `clearInterval` is also called when needed.