### PR TITLE
Don't check trivial dirty bits

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -957,11 +957,10 @@ class Frame:
 And we can set those when the parent frame is laid out:[^no-set-needs]
 
 [^no-set-needs]: You might be surprised that I'm not calling
-    `set_needs_render` on the child frame here. Our toy browser is so
-    limited that it's safe not to: the `width` and `height` attributes
-    can't change, and when the `zoom` changes we invalidate all of the
-    frames. But if our browser had, for example, the `setAttribute`
-    method, then we'd need to force that child frame to render.
+    `set_needs_render` on the child frame here. That's a shortcut: the
+    `width` and `height` attributes can only change through
+    `setAttribute`, while `zoom` can only change in `zoom_by` and
+    `reset_zoom`. All of those handlers already invalidate all frames.
 
 ``` {.python}
 class IframeLayout(EmbedLayout):

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -954,7 +954,14 @@ class Frame:
         self.frame_height = 0
 ```
 
-And we can set those when the parent frame is laid out:
+And we can set those when the parent frame is laid out:[^no-set-needs]
+
+[^no-set-needs]: You might be surprised that I'm not calling
+    `set_needs_render` on the child frame here. Our toy browser is so
+    limited that it's safe not to: the `width` and `height` attributes
+    can't change, and when the `zoom` changes we invalidate all of the
+    frames. But if our browser had, for example, the `setAttribute`
+    method, then we'd need to force that child frame to render.
 
 ``` {.python}
 class IframeLayout(EmbedLayout):

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1979,15 +1979,21 @@ as you include all of the protected fields for each layout type. In
 `DocumentLayout`, you do need to be a little careful, since it
 receives the frame width and zoom level as an argument. You need to
 make sure to `mark` those fields if they changed. The `width` changes
-when the `frame_width` changes, here:
+when the `frame_width` changes, here:[^or-protect-them]
+
+[^or-protect-them]: We need to mark the root layout object's `width`
+    because the `frame_width` is passed into `DocumentLayout`'s
+    `layout` method as the `width` parameter. We could have protected
+    the `frame_width` field instead, and then this `mark` would happen
+    automatically; I'm skipping that for expediency, but it would have
+    been a bit safer.
 
 ``` {.python}
 class IframeLayout(EmbedLayout):
     def layout(self):
         if self.node.frame:
             # ...
-            self.node.frame.document.height.mark()
-            self.node.frame.set_needs_render()
+            self.node.frame.document.width.mark()
 ```
 
 The `zoom` level changes in `Tab`:

--- a/book/layout.md
+++ b/book/layout.md
@@ -717,7 +717,7 @@ The browser's `draw` method now just uses `top` and `bottom` to
 decide which commands to `execute`:
 
 ``` {.python}
-clas Browser:
+class Browser:
     def draw(self):
         self.canvas.delete("all")
         for cmd in self.display_list:

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -770,8 +770,6 @@ class IframeLayout(EmbedLayout):
             self.node.frame.frame_height = self.height - device_px(2, self.zoom.get())
             self.node.frame.frame_width = self.width.get() - device_px(2, self.zoom.get())
             self.node.frame.document.width.mark()
-            self.node.frame.document.height.mark()
-            self.node.frame.set_needs_render()
         self.layout_after()
 
     def paint(self, display_list):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -234,15 +234,19 @@ class DocumentLayout:
         self.descendants = ProtectedField(node, "descendants")
 
     def layout_needed(self):
-        return any([self.width.dirty, self.height.dirty,
-                    self.zoom.dirty, self.x.dirty, self.y.dirty,
-                    self.descendants.dirty])
+        if self.zoom.dirty: return True
+        if self.width.dirty: return True
+        if self.height.dirty: return True
+        if self.x.dirty: return True
+        if self.y.dirty: return True
+        if self.descendants.dirty: return True
+        return False
 
     def layout(self, width, zoom):
         self.zoom.set(zoom)
         self.width.set(width - 2 * device_px(HSTEP, zoom))
-
         if not self.layout_needed(): return
+
         if not self.children:
             child = BlockLayout(self.node, self, None, self.frame)
         else:
@@ -295,10 +299,14 @@ class BlockLayout:
         self.parent.descendants.control(self.descendants)
 
     def layout_needed(self):
-        return any([self.zoom.dirty, self.width.dirty, self.height.dirty,
-                    self.x.dirty, self.y.dirty,
-                    self.children.dirty, self.descendants.dirty])
-        
+        if self.zoom.dirty: return True
+        if self.width.dirty: return True
+        if self.height.dirty: return True
+        if self.x.dirty: return True
+        if self.y.dirty: return True
+        if self.children.dirty: return True
+        if self.descendants.dirty: return True
+        return False
 
     def layout(self):
         if not self.layout_needed(): return
@@ -460,10 +468,15 @@ class LineLayout:
         self.parent.descendants.control(self.descendants)
 
     def layout_needed(self):
-        return any([self.zoom.dirty, self.width.dirty, self.height.dirty,
-                    self.x.dirty, self.y.dirty,
-                    self.ascent.dirty, self.descent.dirty,
-                    self.descendants.dirty])
+        if self.zoom.dirty: return True
+        if self.width.dirty: return True
+        if self.height.dirty: return True
+        if self.x.dirty: return True
+        if self.y.dirty: return True
+        if self.ascent.dirty: return True
+        if self.descent.dirty: return True
+        if self.descendants.dirty: return True
+        return False
 
     def layout(self):
         if not self.layout_needed(): return
@@ -547,10 +560,16 @@ class TextLayout:
         self.parent.descendants.control(self.descendants)
 
     def layout_needed(self):
-        return any([self.zoom.dirty, self.width.dirty, self.height.dirty,
-                    self.x.dirty, self.y.dirty,
-                    self.ascent.dirty, self.descent.dirty,
-                    self.font.dirty, self.descendants.dirty])
+        if self.zoom.dirty: return True
+        if self.width.dirty: return True
+        if self.height.dirty: return True
+        if self.x.dirty: return True
+        if self.y.dirty: return True
+        if self.ascent.dirty: return True
+        if self.descent.dirty: return True
+        if self.font.dirty: return True
+        if self.descendants.dirty: return True
+        return False
 
     def layout(self):
         if not self.layout_needed(): return
@@ -617,10 +636,16 @@ class EmbedLayout:
         self.parent.descendants.control(self.descendants)
 
     def layout_needed(self):
-        return any([self.zoom.dirty, self.width.dirty, self.height.dirty,
-                    self.x.dirty, self.y.dirty,
-                    self.ascent.dirty, self.descent.dirty,
-                    self.font.dirty, self.descendants.dirty])
+        if self.zoom.dirty: return True
+        if self.width.dirty: return True
+        if self.height.dirty: return True
+        if self.x.dirty: return True
+        if self.y.dirty: return True
+        if self.ascent.dirty: return True
+        if self.descent.dirty: return True
+        if self.font.dirty: return True
+        if self.descendants.dirty: return True
+        return False
 
     def layout_before(self):
         self.zoom.copy(self.parent.zoom)


### PR DESCRIPTION
This PR changes Chapter 16 to only check dirty bits for:

- Rebuilding the layout tree
- Skipping `layout` entirely
- Recomputing `style`

The text changes corresponding to this are probably not the best I could do—I plan to leave that for another PR that does a full read of the chapter.