### PR TITLE
Change how our browser computes style values

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -223,7 +223,7 @@ but before doing layout.
 This `style` function will also fill in the `style` field by parsing
 the element's `style` attribute:
     
-``` {.python replace=(node)/(node%2C%20rules),%3d%20value/%3d%20computed_value}
+``` {.python replace=(node)/(node%2C%20rules)}
 def style(node):
     # ...
     if isinstance(node, Element) and "style" in node.attributes:
@@ -490,7 +490,7 @@ the page, this will require looping over all elements *and* all rules.
 When a rule applies, its property/values pairs are copied to the
 element's style information:
 
-``` {.python replace=%3d%20value/%3d%20computed_value}
+``` {.python}
 def style(node, rules):
     # ...
     for selector, body in rules:
@@ -792,19 +792,16 @@ implementing those other properties in this book.
 [css-computed]: https://www.w3.org/TR/CSS2/cascade.html#value-stages
 
 ``` {.python}
-def compute_style(node, property, value):
-    if property == "font-size":
-        if value.endswith("px"):
-            return value
-        elif value.endswith("%"):
-            # ...
-        else:
-            return None
-    else:
-        return value
+def style(node, rules):
+    # ...
+    if node.style["font-size"].endswith("%"):
+        # ...
+
+    for child in node.children:
+        style(child, rules)
 ```
 
-Percentage sizes also have to handle a tricky edge case: percentage
+Resolving percentage sizes has just one tricky edge case: percentage
 sizes for the root `html` element. In that case the percentage is
 relative to the default font size:[^why-parse]
 
@@ -812,39 +809,22 @@ relative to the default font size:[^why-parse]
     our `style` field stores strings; in a real browser the computed
     style is stored parsed so this doesn't have to happen.
 
-``` {.python indent=12}
-if node.parent:
-    parent_font_size = node.parent.style["font-size"]
-else:
-    parent_font_size = INHERITED_PROPERTIES["font-size"]
-node_pct = float(value[:-1]) / 100
-parent_px = float(parent_font_size[:-2])
-return str(node_pct * parent_px) + "px"
-```
-
-Now `style` can call `computed_style` any time it reads a property
-value out of a style sheet:
-
 ``` {.python}
 def style(node, rules):
-    # ...
-    for selector, body in rules:
-        if not selector.matches(node): continue
-        for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
-    # ...
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 ```
 
-Note that because the `style` function recurses at the end of the
-function, the node's parent already has a `font-size` value stored
-when `compute_style` is called.
-
-The loop that handles `style` attributes should likewise call
-`computed_style`. Remember that `style` attributes overwrite CSS
-rules; that means the loop above, which handles rules, should come
-*before* the loop that handles the style attribute.
+Note that this happens after all of the different sources of style
+values are handled (so we are working with the final `font-size`
+value) but before we recurse (so children can assume *our* `font-size`
+has been resolved to a pixel value).
 
 ::: {.further}
 Styling a page can be slow, so real browsers apply tricks like [bloom

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -15,7 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -16,7 +16,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -20,7 +20,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -21,7 +21,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, cascade_priority
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode
@@ -920,14 +920,19 @@ def style(node, rules, tab):
     for selector, body in rules:
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 
     if old_style:
         transitions = diff_styles(old_style, node.style)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -28,7 +28,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, compute_style
+from lab6 import INHERITED_PROPERTIES
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode
@@ -342,14 +342,19 @@ def style(node, rules, tab):
             if (media == "dark") != tab.dark_mode: continue
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 
     if old_style:
         transitions = diff_styles(old_style, node.style)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -21,9 +21,7 @@ import wbetools
 from lab4 import print_tree
 from lab13 import Text, Element
 from lab6 import resolve_url
-from lab6 import tree_to_list
-from lab6 import INHERITED_PROPERTIES
-from lab6 import compute_style
+from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab8 import layout_mode
 from lab10 import COOKIE_JAR, url_origin
 from lab11 import draw_text, get_font, linespace, \
@@ -948,14 +946,19 @@ def style(node, rules, frame):
             if (media == "dark") != frame.tab.dark_mode: continue
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 
     if old_style:
         transitions = diff_styles(old_style, node.style)

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -126,33 +126,37 @@ with a scannerless parser like used here:
 Testing compute_style
 =====================
 
+Let's make a simple HTML tree:
+
     >>> html = lab6.Element("html", {}, None)
     >>> body = lab6.Element("body", {}, html)
     >>> div = lab6.Element("div", {}, body)
+    >>> html.children.append(body)
+    >>> body.children.append(div)
+    
+Let's give all of them a percentage font size:
 
-Other than `font-size`, this just returns the value:
+    >>> html.attributes["style"] = "font-size:150%"
+    >>> body.attributes["style"] = "font-size:150%"
+    >>> div.attributes["style"] = "font-size:150%"
+    >>> lab6.style(html, [])
 
-    >>> lab6.compute_style(body, "property", "value")
-    'value'
+The font size of the `<div>` is computed relatively:
 
-Values for `font-size` ending in "px" return the value:
+    >>> lab6.INHERITED_PROPERTIES["font-size"]
+    '16px'
+    >>> 16 * 1.5 * 1.5 * 1.5
+    54.0
+    >>> div.style["font-size"]
+    '54.0px'
+    
+If we change the `<body>` to be absolute, then the `<div>` is relative
+to that:
 
-    >>> lab6.compute_style(body, "font-size", "12px")
-    '12px'
-
-Percentage values are computed against the parent
-
-    >>> html.style = {"font-size": "30px"}
-    >>> lab6.compute_style(body, "font-size", "100%")
-    '30.0px'
-    >>> lab6.compute_style(body, "font-size", "80%")
-    '24.0px'
-
-    >>> body.style = {"font-size": "10px"}
-    >>> lab6.compute_style(div, "font-size", "100%")
-    '10.0px'
-    >>> lab6.compute_style(div, "font-size", "80%")
-    '8.0px'
+    >>> body.attributes["style"] = "font-size:10px"
+    >>> lab6.style(html, [])
+    >>> div.style["font-size"]
+    '15.0px'
 
 Testing style
 =============

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -161,23 +161,6 @@ INHERITED_PROPERTIES = {
     "color": "black",
 }
 
-def compute_style(node, property, value):
-    if property == "font-size":
-        if value.endswith("px"):
-            return value
-        elif value.endswith("%"):
-            if node.parent:
-                parent_font_size = node.parent.style["font-size"]
-            else:
-                parent_font_size = INHERITED_PROPERTIES["font-size"]
-            node_pct = float(value[:-1]) / 100
-            parent_px = float(parent_font_size[:-2])
-            return str(node_pct * parent_px) + "px"
-        else:
-            return None
-    else:
-        return value
-
 def style(node, rules):
     node.style = {}
     for property, default_value in INHERITED_PROPERTIES.items():
@@ -188,14 +171,19 @@ def style(node, rules):
     for selector, body in rules:
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
     for child in node.children:
         style(child, rules)
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -15,7 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 
 class LineLayout:

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -14,7 +14,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -15,7 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import request, layout_mode


### PR DESCRIPTION
This PR redoes a bit of Chapter 6 that 1) I was never happy with; 2) students never got; and 3) gets in the way of Chapter 16. The issue is computed styles.

"Computed styles" are a CSS concept that divides the style pass into first computing "specified styles" and then computing "computed styles". Computed styles differ from specified styles because they have resolved a variety of relative values and have clamped properties like paddings to positive values.

In our browser, the only computed value was font-size, which can be specified as a percentage value and which is resolved relative to the parent font size. (Note that _most_ percentage sizes are resolved during layout, but font size is resolved during computed styles because it is the basis of the `em` unit and friends.)

Our browser implemented this via a `compute_style` function which was called on all values before storing them in the style dictionary. This is different from real browsers—instead of being a separate pass, it is fused into prior passes. This also had other problems:

- First, the function was confusing and I saw in class that students didn't understand why you would do something in `compute_style` instead of in `style` itself. (This was hard to answer because this abstraction boundary was fake, not something in a real browser.)
- Second, it had a weird API. Apparently it could output `None` to mean not to store the value at all, but this was only implemented in one of the two cases where it was used. Due to the API boundary itself being unclear, it wasn't clear when you would use this.
- Third, it gets in the way of Chapter 16. In Chapter 16, we want to track dependencies between fields, which means using `ProtectedField`s instead of ordinary values. The `compute_style` API hindered that because it accessed style fields and returned style values. Updating it seemed hard because the API itself made no sense.

This PR goes back into Chapter 6 and redoes `compute_style`. Instead of computing style values whenever we set `node.style`, we just do a "post-pass" at the end of the `style` method to update each computed style value. This is more like a real browser, it drops the API entirely, and is easy for Chapter 16 to deal with.