### PR TITLE
Granular style invalidation

### DIFF
--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -857,7 +857,7 @@ The same kind of dependency needs to be added to `image` and `iframe`.
 In `text`, however, we need to be a little more careful. This method
 computes the `w` parameter using a font returned by `font`:
 
-``` {.python replace=node.style/style}
+``` {.python replace=node.style/self.children%2c%20node.style}
 class BlockLayout:
     def text(self, node):
         zoom = self.children.read(self.zoom)
@@ -889,7 +889,7 @@ This style field is computed in the `style` method, which builds the
 map of style properties through multiple phases. Let's build that new
 dictionary in a local variable, and `set` it once complete:
 
-``` {.python}
+``` {.python expected=False}
 def style(node, rules, frame):
     old_style = node.style.value
     new_style = {}
@@ -900,7 +900,7 @@ def style(node, rules, frame):
 Inside `style`, a couple of lines read from the parent node's style.
 We need to mark dependencies in these cases:
 
-``` {.python}
+``` {.python expected=False}
 def style(node, rules, frame):
     for property, default_value in INHERITED_PROPERTIES.items():
         if node.parent:
@@ -927,7 +927,7 @@ class JSContext:
 Finally, in `text` (and also in `add_inline_child`) we can depend on
 the `style` field:
 
-``` {.python}
+``` {.python dropline=read(node.style) replace=style/self.children%2c%20node.style}
 class BlockLayout:
     def text(self, node):
         zoom = self.children.read(self.zoom)
@@ -1291,7 +1291,7 @@ Note the new `ascent` and `descent` fields.
 We'll need to compute these fields in `layout`. All of the
 font-related ones are fairly straightforward:
 
-``` {.python}
+``` {.python dropline=self.font.read(self.node.style) replace=font(style/font(self.font%2c%20self.node.style}
 class TextLayout:
     def layout(self):
         # ...
@@ -1630,7 +1630,7 @@ Let's fix these. First, let's tackle `style`. The reason `style` is
 being recomputed repeatedly is just that we don't skip `style`
 recomputation if it isn't dirty. Let's do that:
 
-``` {.python}
+``` {.python replace=node.style.dirty/needs_style}
 def style(node, rules, frame):
     if node.style.dirty:
         # ...

--- a/book/styles.md
+++ b/book/styles.md
@@ -223,7 +223,7 @@ but before doing layout.
 This `style` function will also fill in the `style` field by parsing
 the element's `style` attribute:
     
-``` {.python replace=(node)/(node%2C%20rules),%3d%20value/%3d%20computed_value}
+``` {.python replace=(node)/(node%2C%20rules)}
 def style(node):
     # ...
     if isinstance(node, Element) and "style" in node.attributes:
@@ -490,7 +490,7 @@ the page, this will require looping over all elements *and* all rules.
 When a rule applies, its property/values pairs are copied to the
 element's style information:
 
-``` {.python replace=%3d%20value/%3d%20computed_value}
+``` {.python}
 def style(node, rules):
     # ...
     for selector, body in rules:
@@ -792,19 +792,16 @@ implementing those other properties in this book.
 [css-computed]: https://www.w3.org/TR/CSS2/cascade.html#value-stages
 
 ``` {.python}
-def compute_style(node, property, value):
-    if property == "font-size":
-        if value.endswith("px"):
-            return value
-        elif value.endswith("%"):
-            # ...
-        else:
-            return None
-    else:
-        return value
+def style(node, rules):
+    # ...
+    if node.style["font-size"].endswith("%"):
+        # ...
+
+    for child in node.children:
+        style(child, rules)
 ```
 
-Percentage sizes also have to handle a tricky edge case: percentage
+Resolving percentage sizes has just one tricky edge case: percentage
 sizes for the root `html` element. In that case the percentage is
 relative to the default font size:[^why-parse]
 
@@ -812,39 +809,22 @@ relative to the default font size:[^why-parse]
     our `style` field stores strings; in a real browser the computed
     style is stored parsed so this doesn't have to happen.
 
-``` {.python indent=12}
-if node.parent:
-    parent_font_size = node.parent.style["font-size"]
-else:
-    parent_font_size = INHERITED_PROPERTIES["font-size"]
-node_pct = float(value[:-1]) / 100
-parent_px = float(parent_font_size[:-2])
-return str(node_pct * parent_px) + "px"
-```
-
-Now `style` can call `computed_style` any time it reads a property
-value out of a style sheet:
-
 ``` {.python}
 def style(node, rules):
-    # ...
-    for selector, body in rules:
-        if not selector.matches(node): continue
-        for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
-    # ...
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 ```
 
-Note that because the `style` function recurses at the end of the
-function, the node's parent already has a `font-size` value stored
-when `compute_style` is called.
-
-The loop that handles `style` attributes should likewise call
-`computed_style`. Remember that `style` attributes overwrite CSS
-rules; that means the loop above, which handles rules, should come
-*before* the loop that handles the style attribute.
+Note that this happens after all of the different sources of style
+values are handled (so we are working with the final `font-size`
+value) but before we recurse (so children can assume *our* `font-size`
+has been resolved to a pixel value).
 
 ::: {.further}
 Styling a page can be slow, so real browsers apply tricks like [bloom

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -15,7 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -16,7 +16,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -20,7 +20,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -21,7 +21,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, cascade_priority
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode
@@ -920,14 +920,19 @@ def style(node, rules, tab):
     for selector, body in rules:
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 
     if old_style:
         transitions = diff_styles(old_style, node.style)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -28,7 +28,7 @@ from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
 from lab6 import TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, compute_style
+from lab6 import INHERITED_PROPERTIES
 from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode
@@ -342,14 +342,19 @@ def style(node, rules, tab):
             if (media == "dark") != tab.dark_mode: continue
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 
     if old_style:
         transitions = diff_styles(old_style, node.style)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -21,9 +21,7 @@ import wbetools
 from lab4 import print_tree
 from lab13 import Text, Element
 from lab6 import resolve_url
-from lab6 import tree_to_list
-from lab6 import INHERITED_PROPERTIES
-from lab6 import compute_style
+from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab8 import layout_mode
 from lab10 import COOKIE_JAR, url_origin
 from lab11 import draw_text, get_font, linespace, \
@@ -948,14 +946,19 @@ def style(node, rules, frame):
             if (media == "dark") != frame.tab.dark_mode: continue
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
 
     if old_style:
         transitions = diff_styles(old_style, node.style)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -90,17 +90,10 @@ def font(who, css_style, zoom):
 def has_outline(node):
     return parse_outline(node.style['outline'].get(), 1)
 
-def unprotect(v):
-    if isinstance(v, float):
-        return v
-    else:
-        return v.get()
-
 @wbetools.patch(absolute_bounds_for_obj)
 def absolute_bounds_for_obj(obj):
     rect = skia.Rect.MakeXYWH(
-        unprotect(obj.x), unprotect(obj.y),
-        unprotect(obj.width), unprotect(obj.height))
+        obj.x.get(), obj.y.get(), obj.width.get(), obj.height.get())
     cur = obj.node
     while cur:
         rect = map_translation(rect, parse_transform(cur.style['transform'].get()))

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -174,18 +174,12 @@ class ProtectedField:
         return "ProtectedField({}, {})".format(self.node, self.name)
     
 CSS_PROPERTIES = {
-    "font-size": "inherit",
-    "font-weight": "inherit",
-    "font-style": "inherit",
-    "color": "inherit",
-    "opacity": "1.0",
-    "transition": "",
-    "transform": "none",
-    "mix-blend-mode": "normal",
-    "border-radius": "0px",
-    "overflow": "visible",
-    "outline": "none",
-    "background-color": "transparent",
+    "font-size": "inherit", "font-weight": "inherit",
+    "font-style": "inherit", "color": "inherit",
+    "opacity": "1.0", "transition": "",
+    "transform": "none", "mix-blend-mode": "normal",
+    "border-radius": "0px", "overflow": "visible",
+    "outline": "none", "background-color": "transparent",
     "image-rendering": "auto",
 }
 
@@ -769,7 +763,10 @@ class IframeLayout(EmbedLayout):
 def style(node, rules, frame):
     needs_style = any([field.dirty for field in node.style.values()])
     if needs_style:
-        old_style = dict([(property, field.value) for property, field in node.style.items()])
+        old_style = dict([
+            (property, field.value)
+            for property, field in node.style.items()
+        ])
         new_style = CSS_PROPERTIES.copy()
         for property, default_value in INHERITED_PROPERTIES.items():
             if node.parent:

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -71,12 +71,24 @@ def tree_to_list(tree, l):
 @wbetools.patch(paint_outline)
 def paint_outline(node, cmds, rect, zoom):
     if has_outline(node):
-        thickness, color = parse_outline(node.style.get().get('outline'), zoom)
+        thickness, color = parse_outline(node.style['outline'].get(), zoom)
         cmds.append(DrawOutline(rect, color, thickness))
+
+@wbetools.patch(font)
+def font(who, css_style, zoom):
+    weight = who.read(css_style['font-weight'])
+    style = who.read(css_style['font-style'])
+    try:
+        size = float(who.read(css_style['font-size'])[:-2])
+    except ValueError:
+        size = 16
+    font_size = device_px(size, zoom)
+    return get_font(font_size, weight, style)
+
 
 @wbetools.patch(has_outline)
 def has_outline(node):
-    return parse_outline(node.style.get().get('outline'), 1)
+    return parse_outline(node.style['outline'].get(), 1)
 
 def unprotect(v):
     if isinstance(v, float):
@@ -91,21 +103,21 @@ def absolute_bounds_for_obj(obj):
         unprotect(obj.width), unprotect(obj.height))
     cur = obj.node
     while cur:
-        rect = map_translation(rect, parse_transform(cur.style.get().get('transform', '')))
+        rect = map_translation(rect, parse_transform(cur.style['transform'].get()))
         cur = cur.parent
     return rect
 
 @wbetools.patch(paint_visual_effects)
 def paint_visual_effects(node, cmds, rect):
-    opacity = float(node.style.get().get('opacity', '1.0'))
-    blend_mode = parse_blend_mode(node.style.get().get('mix-blend-mode'))
-    translation = parse_transform(node.style.get().get('transform', ''))
-    border_radius = float(node.style.get().get('border-radius', '0px')[:-2])
-    if node.style.get().get('overflow', 'visible') == 'clip':
+    opacity = float(node.style["opacity"].get())
+    blend_mode = parse_blend_mode(node.style["mix-blend-mode"].get())
+    translation = parse_transform(node.style["transform"].get())
+    border_radius = float(node.style["border-radius"].get()[:-2])
+    if node.style["overflow"].get() == 'clip':
         clip_radius = border_radius
     else:
         clip_radius = 0
-    needs_clip = node.style.get().get('overflow', 'visible') == 'clip'
+    needs_clip = node.style['overflow'].get() == 'clip'
     needs_blend_isolation = blend_mode != skia.BlendMode.kSrcOver or needs_clip or opacity != 1.0
     save_layer = SaveLayer(skia.Paint(BlendMode=blend_mode, Alphaf=opacity), node, [ClipRRect(rect, clip_radius, cmds, should_clip=needs_clip)], should_save=needs_blend_isolation)
     transform = Transform(translation, rect, node, [save_layer])
@@ -167,6 +179,22 @@ class ProtectedField:
 
     def __repr__(self):
         return "ProtectedField({}, {})".format(self.node, self.name)
+    
+CSS_PROPERTIES = {
+    "font-size": "inherit",
+    "font-weight": "inherit",
+    "font-style": "inherit",
+    "color": "inherit",
+    "opacity": "1.0",
+    "transition": "",
+    "transform": "none",
+    "mix-blend-mode": "normal",
+    "border-radius": "0px",
+    "overflow": "visible",
+    "outline": "none",
+    "background-color": "transparent",
+    "image-rendering": "auto",
+}
 
 @wbetools.patch(Element)
 class Element:
@@ -176,7 +204,10 @@ class Element:
         self.children = []
         self.parent = parent
 
-        self.style = ProtectedField(self, "style")
+        self.style = dict([
+            (property, ProtectedField(self, property))
+            for property in CSS_PROPERTIES
+        ])
         self.animations = {}
 
         self.is_focused = False
@@ -189,7 +220,10 @@ class Text:
         self.children = []
         self.parent = parent
 
-        self.style = ProtectedField(self, "style")
+        self.style = dict([
+            (property, ProtectedField(self, property))
+            for property in CSS_PROPERTIES
+        ])
         self.animations = {}
 
         self.is_focused = False
@@ -341,8 +375,7 @@ class BlockLayout:
 
     def text(self, node):
         zoom = self.children.read(self.zoom)
-        style = self.children.read(node.style)
-        node_font = font(style, zoom)
+        node_font = font(self.children, node.style, zoom)
         for word in node.text.split():
             w = node_font.measureText(word)
             self.add_inline_child(node, w, TextLayout, self.frame, word)
@@ -365,9 +398,8 @@ class BlockLayout:
             child = child_class(node, line, self.previous_word, frame)
         line.children.append(child)
         self.previous_word = child
-        style = self.children.read(node.style)
         zoom = self.children.read(self.zoom)
-        self.cursor_x += w + font(style, zoom).measureText(' ')
+        self.cursor_x += w + font(self.children, node.style, zoom).measureText(' ')
 
     def paint(self, display_list):
         cmds = []
@@ -380,12 +412,10 @@ class BlockLayout:
             (self.node.tag == "input" or self.node.tag == "button")
 
         if not is_atomic:
-            bgcolor = self.node.style.get().get(
-                "background-color", "transparent")
+            bgcolor = self.node.style["background-color"].get()
             if bgcolor != "transparent":
                 radius = device_px(
-                    float(self.node.style.get().get(
-                        "border-radius", "0px")[:-2]),
+                    float(self.node.style["border-radius"].get()[:-2]),
                     self.zoom.get())
                 cmds.append(DrawRRect(rect, radius, bgcolor))
  
@@ -529,8 +559,7 @@ class TextLayout:
 
         if self.font.dirty:
             zoom = self.font.read(self.zoom)
-            style = self.font.read(self.node.style)
-            self.font.set(font(style, zoom))
+            self.font.set(font(self.font, self.node.style, zoom))
 
         if self.width.dirty:
             f = self.width.read(self.font)
@@ -559,7 +588,7 @@ class TextLayout:
 
     def paint(self, display_list):
         leading = self.height.get() / 1.25 * .25 / 2
-        color = self.node.style.get()['color']
+        color = self.node.style['color'].get()
         display_list.append(DrawText(self.x.get(), self.y.get() + leading, self.word, self.font.get(), color))
 
 @wbetools.patch(EmbedLayout)
@@ -597,9 +626,8 @@ class EmbedLayout:
             self.zoom.copy(self.parent.zoom)
 
         if self.font.dirty:
-            style = self.font.read(self.node.style)
             zoom = self.font.read(self.zoom)
-            self.font.set(font(style, zoom))
+            self.font.set(font(self.font, self.node.style, zoom))
 
         if self.x.dirty:
             if self.previous:
@@ -637,11 +665,10 @@ class InputLayout(EmbedLayout):
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
 
-        bgcolor = self.node.style.get().get("background-color",
-                                 "transparent")
+        bgcolor = self.node.style["background-color"].get()
         if bgcolor != "transparent":
             radius = device_px(
-                float(self.node.style.get().get("border-radius", "0px")[:-2]),
+                float(self.node.style["border-radius"].get()[:-2]),
                 self.zoom.get())
             cmds.append(DrawRRect(rect, radius, bgcolor))
 
@@ -655,7 +682,7 @@ class InputLayout(EmbedLayout):
                 print("Ignoring HTML contents inside button")
                 text = ""
 
-        color = self.node.style.get()["color"]
+        color = self.node.style["color"].get()
         cmds.append(DrawText(self.x.get(), self.y.get(),
                              text, self.font.get(), color))
 
@@ -699,7 +726,7 @@ class ImageLayout(EmbedLayout):
     def paint(self, display_list):
         cmds = []
         rect = skia.Rect.MakeLTRB(self.x.get(), self.y.get() + self.height.get() - self.img_height, self.x.get() + self.width.get(), self.y.get() + self.height)
-        quality = self.node.style.get().get('image-rendering', 'auto')
+        quality = self.node.style["image-rendering"].get()
         cmds.append(DrawImage(self.node.image, rect, quality))
         display_list.extend(cmds)
 
@@ -732,9 +759,9 @@ class IframeLayout(EmbedLayout):
     def paint(self, display_list):
         frame_cmds = []
         rect = skia.Rect.MakeLTRB(self.x.get(), self.y.get(), self.x.get() + self.width.get(), self.y.get() + self.height.get())
-        bgcolor = self.node.style.get().get('background-color', 'transparent')
+        bgcolor = self.node.style["background-color"].get()
         if bgcolor != 'transparent':
-            radius = device_px(float(self.node.style.get().get('border-radius', '0px')[:-2]), self.zoom.get())
+            radius = device_px(float(self.node.style["border-radius"].get()[:-2]), self.zoom.get())
             frame_cmds.append(DrawRRect(rect, radius, bgcolor))
         if self.node.frame:
             self.node.frame.paint(frame_cmds)
@@ -747,13 +774,15 @@ class IframeLayout(EmbedLayout):
         display_list.extend(cmds)
 
 def style(node, rules, frame):
-    if node.style.dirty:
-        old_style = node.style.value
-        new_style = {}
+    needs_style = any([field.dirty for field in node.style.values()])
+    if needs_style:
+        old_style = dict([(property, field.value) for property, field in node.style.items()])
+        new_style = CSS_PROPERTIES.copy()
         for property, default_value in INHERITED_PROPERTIES.items():
             if node.parent:
-                parent_style = node.style.read(node.parent.style)
-                new_style[property] = parent_style[property]
+                parent_field = node.parent.style[property]
+                parent_value = node.style[property].read(parent_field)
+                new_style[property] = parent_value
             else:
                 new_style[property] = default_value
         for media, selector, body in rules:
@@ -768,8 +797,8 @@ def style(node, rules, frame):
                 new_style[property] = value
         if new_style["font-size"].endswith("%"):
             if node.parent:
-                parent_style = node.style.read(node.parent.style)
-                parent_font_size = parent_style["font-size"]
+                parent_field = node.parent.style["font-size"]
+                parent_font_size = node.style["font-size"].read(parent_field)
             else:
                 parent_font_size = INHERITED_PROPERTIES["font-size"]
             node_pct = float(new_style["font-size"][:-1]) / 100
@@ -784,7 +813,8 @@ def style(node, rules, frame):
                     animation = AnimationClass(old_value, new_value, num_frames)
                     node.animations[property] = animation
                     new_style[property] = animation.animate()
-        node.style.set(new_style)
+        for property, field in node.style.items():
+            field.set(new_style[property])
 
     for child in node.children:
         style(child, rules, frame)
@@ -995,7 +1025,7 @@ class Tab:
                     node.animations.items():
                     value = animation.animate()
                     if value:
-                        node.style[property_name] = value
+                        node.style[property_name].set(value)
                         if wbetools.USE_COMPOSITING and \
                             property_name == "opacity":
                             self.composited_updates.append(node)

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -126,33 +126,37 @@ with a scannerless parser like used here:
 Testing compute_style
 =====================
 
+Let's make a simple HTML tree:
+
     >>> html = lab6.Element("html", {}, None)
     >>> body = lab6.Element("body", {}, html)
     >>> div = lab6.Element("div", {}, body)
+    >>> html.children.append(body)
+    >>> body.children.append(div)
+    
+Let's give all of them a percentage font size:
 
-Other than `font-size`, this just returns the value:
+    >>> html.attributes["style"] = "font-size:150%"
+    >>> body.attributes["style"] = "font-size:150%"
+    >>> div.attributes["style"] = "font-size:150%"
+    >>> lab6.style(html, [])
 
-    >>> lab6.compute_style(body, "property", "value")
-    'value'
+The font size of the `<div>` is computed relatively:
 
-Values for `font-size` ending in "px" return the value:
+    >>> lab6.INHERITED_PROPERTIES["font-size"]
+    '16px'
+    >>> 16 * 1.5 * 1.5 * 1.5
+    54.0
+    >>> div.style["font-size"]
+    '54.0px'
+    
+If we change the `<body>` to be absolute, then the `<div>` is relative
+to that:
 
-    >>> lab6.compute_style(body, "font-size", "12px")
-    '12px'
-
-Percentage values are computed against the parent
-
-    >>> html.style = {"font-size": "30px"}
-    >>> lab6.compute_style(body, "font-size", "100%")
-    '30.0px'
-    >>> lab6.compute_style(body, "font-size", "80%")
-    '24.0px'
-
-    >>> body.style = {"font-size": "10px"}
-    >>> lab6.compute_style(div, "font-size", "100%")
-    '10.0px'
-    >>> lab6.compute_style(div, "font-size", "80%")
-    '8.0px'
+    >>> body.attributes["style"] = "font-size:10px"
+    >>> lab6.style(html, [])
+    >>> div.style["font-size"]
+    '15.0px'
 
 Testing style
 =============

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -161,23 +161,6 @@ INHERITED_PROPERTIES = {
     "color": "black",
 }
 
-def compute_style(node, property, value):
-    if property == "font-size":
-        if value.endswith("px"):
-            return value
-        elif value.endswith("%"):
-            if node.parent:
-                parent_font_size = node.parent.style["font-size"]
-            else:
-                parent_font_size = INHERITED_PROPERTIES["font-size"]
-            node_pct = float(value[:-1]) / 100
-            parent_px = float(parent_font_size[:-2])
-            return str(node_pct * parent_px) + "px"
-        else:
-            return None
-    else:
-        return value
-
 def style(node, rules):
     node.style = {}
     for property, default_value in INHERITED_PROPERTIES.items():
@@ -188,14 +171,19 @@ def style(node, rules):
     for selector, body in rules:
         if not selector.matches(node): continue
         for property, value in body.items():
-            computed_value = compute_style(node, property, value)
-            if not computed_value: continue
-            node.style[property] = computed_value
+            node.style[property] = value
     if isinstance(node, Element) and "style" in node.attributes:
         pairs = CSSParser(node.attributes["style"]).body()
         for property, value in pairs.items():
-            computed_value = compute_style(node, property, value)
-            node.style[property] = computed_value
+            node.style[property] = value
+    if node.style["font-size"].endswith("%"):
+        if node.parent:
+            parent_font_size = node.parent.style["font-size"]
+        else:
+            parent_font_size = INHERITED_PROPERTIES["font-size"]
+        node_pct = float(node.style["font-size"][:-1]) / 100
+        parent_px = float(parent_font_size[:-2])
+        node.style["font-size"] = str(node_pct * parent_px) + "px"
     for child in node.children:
         style(child, rules)
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -15,7 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 
 class LineLayout:

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -14,7 +14,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -15,7 +15,7 @@ from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
-from lab6 import INHERITED_PROPERTIES, style, cascade_priority, compute_style
+from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import request, layout_mode


### PR DESCRIPTION
This PR applies to Chapter 16 and changes the `style` field of nodes from a protected field containing a dictionary to a dictionary containing protected fields. This basically means that dependencies are tracked on the level of individual CSS properties, instead of invalidating an element as soon as any style changes. Among other benefits, this restores clean composited animations, because the properties being animated don't affect layout and thus no longer dirty any layout fields.