### PR TITLE
Remove zombie "Script returned" prints in chapters 10+

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1605,7 +1605,7 @@ class JSContext:
     def run(self, script, code, window_id):
         try:
             code = self.wrap(code, window_id)
-            print("Script returned: ", self.interp.evaljs(code))
+            self.interp.evaljs(code)
         except dukpy.JSRuntimeError as e:
             print("Script", script, "crashed", e)
 ```

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -114,7 +114,7 @@ running scripts:
 class Tab:
     def run_script(self, url, body):
         try:
-            print("Script returned: ", self.js.run(body))
+            self.js.run(body)
         except dukpy.JSRuntimeError as e:
             print("Script", url, "crashed", e)
 

--- a/src/lab10-tests.md
+++ b/src/lab10-tests.md
@@ -214,9 +214,6 @@ check that all of these requests were made:
 
     >>> browser = lab10.Browser()
     >>> browser.load(url)
-    Script returned:  None
-    Script returned:  None
-    Script returned:  None
     >>> [test.socket.made_request(url + "css"),
     ...  test.socket.made_request(url + "js")]
     [True, True]
@@ -236,8 +233,6 @@ Now let's reload the page, but with CSP enabled for `test.test` and
     ... body.encode("utf8"))
     >>> browser = lab10.Browser()
     >>> browser.load(url)
-    Script returned:  None
-    Script returned:  None
     Blocked script http://other.test/js due to CSP
     Blocked style http://other.test/css due to CSP
 

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -211,7 +211,7 @@ class Tab:
                 continue
             header, body = request(script_url, url)
             try:
-                print("Script returned: ", self.js.run(body))
+                self.js.run(body)
             except dukpy.JSRuntimeError as e:
                 print("Script", script, "crashed", e)
 

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -549,7 +549,7 @@ class Tab:
                 continue
             header, body = request(script_url, url)
             try:
-                print("Script returned: ", self.js.run(body))
+                self.js.run(body)
             except dukpy.JSRuntimeError as e:
                 print("Script", script, "crashed", e)
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -84,7 +84,7 @@ class JSContext:
 
     def run(self, script, code):
         try:
-            print("Script returned: ", self.interp.evaljs(code))
+            self.interp.evaljs(code)
         except dukpy.JSRuntimeError as e:
             print("Script", script, "crashed", e)
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -732,7 +732,7 @@ class JSContext:
 
     def run(self, script, code):
         try:
-            print("Script returned: ", self.interp.evaljs(code))
+            self.interp.evaljs(code)
         except dukpy.JSRuntimeError as e:
             print("Script", script, "crashed", e)
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -822,7 +822,7 @@ class JSContext:
 
     def run(self, script, code):
         try:
-            print("Script returned: ", self.interp.evaljs(code))
+            self.interp.evaljs(code)
         except dukpy.JSRuntimeError as e:
             print("Script", script, "crashed", e)
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -813,7 +813,7 @@ class JSContext:
     def run(self, script, code, window_id):
         try:
             code = self.wrap(code, window_id)
-            print("Script returned: ", self.interp.evaljs(code))
+            self.interp.evaljs(code)
         except dukpy.JSRuntimeError as e:
             print("Script", script, "crashed", e)
 

--- a/src/lab16-tests.md
+++ b/src/lab16-tests.md
@@ -126,7 +126,6 @@ Next, we can execute some JavaScript to change the page:
     ... window.document.querySelectorAll("div")[1].innerHTML = 'Short body';
     ... """
     >>> frame.js.run("<test>", script, frame.window_id)
-    Script returned:  Short body
     >>> frame.render()
     >>> lab16.print_tree(frame.document) # doctest: +ELLIPSIS
      DocumentLayout()


### PR DESCRIPTION
In Chapter 9, we first make every script print its return value (because at first we don't have `console.log`) but then remove that (because it's annoying and useless). But we kept it in later chapters, probably an editing mishap. This removes it from all chapters and thereby fixes #831.