### PR TITLE
Remove the `descendants` ProtectedField

### DIFF
--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1820,7 +1820,11 @@ dependencies---though there are some differences.
 
 So let's add a new dirty flag, which I call `has_dirty_descendants`,
 to track whether anty descendants have a dirty
-`ProtectedField`.
+`ProtectedField`.[^ancestors]
+
+[^ancestors]: In some code bases, you will see these
+called *ancestor* dirty flags instead. It's the same thing, just
+following the flow of dirty bits instead of the flow of control.
 
 ``` {.python}
 class BlockLayout:

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1869,20 +1869,6 @@ Here's `BlockLayout`, for example:
 
 
 ``` {.python}
-class ProtectedField:
-    def set_ancestor_dirty_bits(self):
-        parent = self.parent
-        while parent:
-            parent.has_dirty_descendants = True
-            parent = parent.parent
-
-    def mark(self):
-        # ...
-        self.set_ancestor_dirty_bits()
-
-    def notify(self):
-        # ...
-
 class BlockLayout:
     def __init__(self, node, parent, previous, frame):
         # ...    
@@ -1895,9 +1881,6 @@ class BlockLayout:
 ```
 
 And then the bit needs to be cleared after `layout`:
-
-For each layout object type, pass the parameter for each `ProtectedField`.
-Here's `BlockLayout`, for example:
 
 ``` {.python}
 class BlockLayout:

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1938,8 +1938,9 @@ class BlockLayout:
 
 With these changes, the descendant dirty bits should now be set
 correctly, and the `layout_needed` approach above should work as long
-as you include all of the protected fields for each layout type. In
-`DocumentLayout`, you do need to be a little careful, since it
+as you include all of the protected fields for each layout type.
+
+In`DocumentLayout`, you do need to be a little careful, since it
 receives the frame width and zoom level as an argument. You need to
 make sure to `mark` those fields if they changed. The `width` changes
 when the `frame_width` changes, here:[^or-protect-them]

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1091,9 +1091,11 @@ class BlockLayout:
             # ...
         else:
             if self.children.dirty:
-                self.children.set([])
+                self.temp_children = []
                 self.new_line()
                 self.recurse(self.node)
+                self.children.set(self.temp_children)
+                self.temp_children = None
 ```
 
 Note that I reset `temp_children` once we're done with it, to make
@@ -1106,10 +1108,10 @@ class BlockLayout:
     def new_line(self):
         self.previous_word = None
         self.cursor_x = 0
-        last_line = self.children.get()[-1] \
-            if self.children.get() else None
+        last_line = self.temp_children[-1] \
+            if self.temp_children else None
         new_line = LineLayout(self.node, self, last_line)
-        self.children.get().append(new_line)
+        self.temp_children.append(new_line)
 ```
 
 You'll want to do something similar in `add_inline_child`:
@@ -1119,7 +1121,7 @@ class BlockLayout:
     def add_inline_child(self, node, w, child_class,
         frame, word=None):
         # ...
-        line = self.children.get()[-1]
+        line = self.temp_children[-1]
         # ...
 ```
 

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1832,10 +1832,6 @@ to track whether any descendants have a dirty
 [^ancestors]: In some code bases, you will see these
 called *ancestor* dirty flags instead. It's the same thing, just
 following the flow of dirty bits instead of the flow of control.
-=======
-[^ancestors] to track whether anty descendants have a dirty
-`ProtectedField`.
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
 
 ``` {.python}
 class BlockLayout:

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1075,7 +1075,6 @@ computation we are skipping here---line breaking and rebuilding the
 layout tree---is pretty expensive.
 
 We also need to fix up `add_inline_child`'s and `new_line`'s
-<<<<<<< HEAD
 references to `children`. There are a couple of possible fixes, but in
 the interests of expediency,[^perhaps-local] I'm going to use a
 second, unprotected field, `temp_children`:
@@ -1083,14 +1082,6 @@ second, unprotected field, `temp_children`:
 [^perhaps-local]: Perhaps the nicest design would thread a local
 `children` variable through all of the methods involved in line
 layout, similar to how we handle `paint`.
-=======
-references to `children`. I'll solve this by first setting
-`this.children` to an empty array, then filling it in. This is
-a bit of an expediency, because the `ProtectedValue` for `children`
-stores an array, and so we can read and write the contents of the
-array (in methods like `add_inline_child`) without causing the
-field to become dirty.
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
 
 ``` {.python}
 class BlockLayout:
@@ -1842,13 +1833,6 @@ class BlockLayout:
 
 Add this to every other kind of layout object, too.
 
-<<<<<<< HEAD
-This field doesn't store a value, but just a dirty flag. We want this flag
-dirty if any descendant has a dirty `children` or layout field.
-This can be achieved by walking up the layout tree, setting
-`has_dirty_descendants` to true on each ancestor.
-
-
 This will be easy to do with an additional (and optional) `parent` parameter to
 a `ProtectedField`. (It's optional because only `ProtectedField`s on layout
 objects need this feature.)
@@ -1857,26 +1841,10 @@ objects need this feature.)
 class ProtectedField:
     def __init__(self, node, name, parent=None):
         # ...
-=======
-This field doesn't store a value, just a dirty flag. We want this flag
-dirty if any descendant has a dirty `children` or layout field. When any
-of them are dirtied, we need to walk up the layout tree setting
-`has_dirty_descendants` to true on each ancestor.
-
-
-This will be easy to do with an addition (and optional) `parent` parameter to a
-`ProtectedField`. (It's optional because only `ProtectedField`s on layout
-objects need this feature.)
-
-``` {.python}
-class ProtectedField:
-    def __init__(self, node, name, parent=None):
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
         self.parent = parent
 ```
 
 Then, whenever `mark` or `notify` is called, we set the bits:
-<<<<<<< HEAD
 
 
 ``` {.python}
@@ -1898,7 +1866,6 @@ class ProtectedField:
 
 For each layout object type, pass the parameter for each `ProtectedField`.
 Here's `BlockLayout`, for example:
-=======
 
 
 ``` {.python}
@@ -1912,11 +1879,13 @@ class ProtectedField:
     def mark(self):
         # ...
         self.set_ancestor_dirty_bits()
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
 
     def notify(self):
         # ...
-<<<<<<< HEAD
+
+class BlockLayout:
+    def __init__(self, node, parent, previous, frame):
+        # ...    
         self.children = ProtectedField(node, "children", self.parent)
         self.zoom = ProtectedField(node, "zoom", self.parent)
         self.width = ProtectedField(node, "width", self.parent)
@@ -1926,35 +1895,20 @@ class ProtectedField:
 ```
 
 And then the bit needs to be cleared after `layout`:
-=======
-        self.set_ancestor_dirty_bits()
-```
 
 For each layout object type, pass the parameter for each `ProtectedField`.
 Here's `BlockLayout`, for example:
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
 
 ``` {.python}
 class BlockLayout:
     def layout(self):
         # ...
-<<<<<<< HEAD
         for child in self.children.get():
             child.layout()
 
         self.has_dirty_descendants = False    
 ```
 
-=======
-        self.children = ProtectedField(node, "children", self.parent)
-        self.zoom = ProtectedField(node, "zoom", self.parent)
-        self.width = ProtectedField(node, "width", self.parent)
-        self.height = ProtectedField(node, "height", self.parent)
-        self.x = ProtectedField(node, "x", self.parent)
-        self.y = ProtectedField(node, "y", self.parent)
-```
-
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
 Now that we have descendant dirty flags, let's use them to skip
 unneeded recursions. We'd like to use the `descendants` dirty flags to
 skip recursing in the `layout` method:

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -572,7 +572,7 @@ to avoid.
 We need a better approach. As a first step, let's try to combine a
 dirty flag and the field it protects into a single object:
 
-``` {.python replace=(self)/(self%2c%20node%2c%20name)}
+``` {.python replace=(self)/(self%2c%20node%2c%20name%2c%20parent%3dNone)}
 class ProtectedField:
     def __init__(self):
         self.value = None
@@ -787,7 +787,7 @@ fields that depend on it.
 To do that, we're going to need to keep around a `depended_on` set
 of fields that depend on this one:
 
-``` {.python replace=(self)/(self%2c%20node%2c%20name),depended_on/depended_lazy}
+``` {.python replace=(self)/(self%2c%20node%2c%20name%2c%20parent%3dNone),depended_on/depended_lazy}
 class ProtectedField:
     def __init__(self):
         # ...
@@ -1075,13 +1075,12 @@ computation we are skipping here---line breaking and rebuilding the
 layout tree---is pretty expensive.
 
 We also need to fix up `add_inline_child`'s and `new_line`'s
-references to `children`. There are couple of possible fixes, but in
-the interests of expediency,[^perhaps-local] I'm going to use a
-second, unprotected field, `temp_children`:
-
-[^perhaps-local]: Perhaps the nicest design would thread a local
-    `children` variable through all of the methods involved in line
-    layout, similar to how we handle `paint`.
+references to `children`. I'll solve this by first setting
+`this.children` to an empty array, then filling it in. This is
+a bit of an expediency, because the `ProtectedValue` for `children`
+stores an array, and so we can read and write the contents of the
+array (in methods like `add_inline_child`) without causing the
+field to become dirty.
 
 ``` {.python}
 class BlockLayout:
@@ -1091,11 +1090,9 @@ class BlockLayout:
             # ...
         else:
             if self.children.dirty:
-                self.temp_children = []
+                self.children.set([])
                 self.new_line()
                 self.recurse(self.node)
-                self.children.set(self.temp_children)
-                self.temp_children = None
 ```
 
 Note that I reset `temp_children` once we're done with it, to make
@@ -1108,10 +1105,10 @@ class BlockLayout:
     def new_line(self):
         self.previous_word = None
         self.cursor_x = 0
-        last_line = self.temp_children[-1] \
-            if self.temp_children else None
+        last_line = self.children.get()[-1] \
+            if self.children.get() else None
         new_line = LineLayout(self.node, self, last_line)
-        self.temp_children.append(new_line)
+        self.children.get().append(new_line)
 ```
 
 You'll want to do something similar in `add_inline_child`:
@@ -1121,7 +1118,7 @@ class BlockLayout:
     def add_inline_child(self, node, w, child_class,
         frame, word=None):
         # ...
-        line = self.temp_children[-1]
+        line = self.children.get()[-1]
         # ...
 ```
 
@@ -1677,7 +1674,7 @@ for debugging puposes:[^why-print-node]
 because layout objects' printable forms print layout field values,
 which might be dirty and unreadable.
 
-``` {.python}
+``` {.python replace=%2c%20name/%2c%20name%2c%20parent%3dNone}
 class ProtectedField:
     def __init__(self, node, name):
         self.node = node
@@ -1792,7 +1789,7 @@ Skipping traversals
 ===================
 
 All of the layout fields are now wrapped in invalidation logic,
-which means that when if any layout field needs to be recomputed, a
+which means that if any layout field needs to be recomputed, a
 dirty bit somewhere in the layout tree is set. But we're still
 *visiting* every layout object to actually recompute them. Instead, we
 should use the dirty bits to guide our traversal of the layout tree
@@ -1818,114 +1815,82 @@ on calling its parent's `layout` method, and so on. We can apply
 invalidation to control dependencies just like we do to data
 dependencies---though there are some differences.
 
-So let's add a new dirty flag, which I call `descendants`,[^ancestors]
-to track the control dependencies for a node's descendants:
-
-[^ancestors]: In some code bases, you will see these
-called *ancestor* dirty flags instead. It's the same thing, just
-following the flow of dirty bits instead of the flow of control.
+So let's add a new dirty flag, which I call `has_dirty_descendants`,
+to track whether anty descendants have a dirty
+`ProtectedField`.
 
 ``` {.python}
 class BlockLayout:
     def __init__(self, node, parent, previous, frame):
         # ...
-        self.descendants = ProtectedField(node, "descendants")
+        self.has_dirty_descendants = False
 ```
 
-We can add this to every other kind of layout object, too.
+Add this to every other kind of layout object, too.
 
-This field doesn't store a value, just a dirty flag, but it's
-convenient to use the `ProtectedField` machinery. We want this flag
+This field doesn't store a value, but just a dirty flag. We want this flag
 dirty if any descendant has a dirty `children` or layout field.
-Something like this is *close* to working:
+This can be achieved by walking up the layout tree, setting
+`has_dirty_descendants` to true on each ancestor.
 
-``` {.python expected=False}
-class BlockLayout:
-    def __init__(self, node, parent, previous, frame):
-        # ...
-        self.parent.descendants.read(self.zoom)
-        self.parent.descendants.read(self.width)
-        self.parent.descendants.read(self.height)
-        self.parent.descendants.read(self.x)
-        self.parent.descendants.read(self.y)
-```
 
-Note that it is the *parent's* `descendants` field that depends on
-this node's layout fields. That's because this element is one of its
-parent's (not its own) descendants.
+This will be easy to do with an additional (and optional) `parent` parameter to
+a `ProtectedField`. (It's optional because only `ProtectedField`s on layout
+objects need this feature.)
 
-However, this code doesn't quite work, for a couple of reasons.
-
-First of all, `read` asserts that the field being read is not dirty,
-and here the fields being read were just created and are therefore
-dirty. We need a variant of `read`, which I'll call `control` because
-it's for control dependencies:
-
-``` {.python replace=depended_on/depended_eager}
+``` {.python}
 class ProtectedField:
-    def control(self, source):
-        source.depended_on.add(self)
-        self.dirty = True
+    def __init__(self, node, name, parent=None):
+        # ...
+        self.parent = parent
 ```
 
-Note that the `control` method doesn't actually read the source field's
-value; that's why it's safe to use even when the source field is dirty.
-The `descendants` field can use it:
+Then, whenever `mark` or `notify` is called, we set the bits:
+
+
+``` {.python}
+class ProtectedField:
+    def set_ancestor_dirty_bits(self):
+        parent = self.parent
+        while parent:
+            parent.has_dirty_descendants = True
+            parent = parent.parent
+
+    def mark(self):
+        # ...
+        self.set_ancestor_dirty_bits()
+
+    def notify(self):
+        # ...
+        self.set_ancestor_dirty_bits()
+```
+
+For each layout object type, pass the parameter for each `ProtectedField`.
+Here's `BlockLayout`, for example:
 
 ``` {.python}
 class BlockLayout:
     def __init__(self, node, parent, previous, frame):
         # ...
-        self.parent.descendants.control(self.zoom)
-        self.parent.descendants.control(self.width)
-        self.parent.descendants.control(self.height)
-        self.parent.descendants.control(self.x)
-        self.parent.descendants.control(self.y)
+        self.children = ProtectedField(node, "children", self.parent)
+        self.zoom = ProtectedField(node, "zoom", self.parent)
+        self.width = ProtectedField(node, "width", self.parent)
+        self.height = ProtectedField(node, "height", self.parent)
+        self.x = ProtectedField(node, "x", self.parent)
+        self.y = ProtectedField(node, "y", self.parent)
 ```
 
-We also need `descendants` to control the `children` field:
+And then the bit needs to be cleared after `layout`:
 
 ``` {.python}
 class BlockLayout:
-    def __init__(self, node, parent, previous, frame):
-        # ...
-        self.parent.descendants.control(self.children)
-```
-
-Finally, we need `descendants` to include not just direct children but
-also distant descendants. We can do that with a bit of recursion:
-
-``` {.python}
-class BlockLayout:
-    def __init__(self, node, parent, previous, frame):
-        # ...
-        self.parent.descendants.control(self.descendants)
-```
-
-Finally, the `control` calls take care of setting the dirty bit, but
-we also need to reset it when the descendants are laid out. Since
-we're not actually using the value inside the protected field, I'll
-just `set` it to a dummy value:
-
-``` {.python}
-class BlockLayout:
-    def __init__(self, node, parent, previous, frame):
+    def layout(self):
         # ...
         for child in self.children.get():
             child.layout()
-        self.descendants.set(None)
-        # ...
+
+        self.has_dirty_descendants = False    
 ```
-
-Replicate this code in every layout object type. In `DocumentLayout`
-you won't need to `control` any fields, since `DocumentLayout` has no
-parent, and in the other layout objects also `control` the `font`,
-`ascent`, and `descent` fields that those layout objects have while
-not `control`ing the `children` field, which is unprotected.
-
-
-Eager and lazy dirty bits
-=========================
 
 Now that we have descendant dirty flags, let's use them to skip
 unneeded recursions. We'd like to use the `descendants` dirty flags to
@@ -1950,104 +1915,8 @@ class BlockLayout:
         if self.x.dirty: return True
         if self.y.dirty: return True
         if self.children.dirty: return True
-        if self.descendants.dirty: return True
+        if self.has_dirty_descendants: return True
         return False
-```
-
-However, this idea doesn't quite work. If you run it, your browser
-will crash when it skips recomputing a field that was dirty.
-
-This is a consequence of us implementing *lazy* marking. Recall how
-the `mark` method works:
-
-``` {.python}
-class ProtectedField:
-    def mark(self):
-        if self.dirty: return
-        self.dirty = True
-```
-
-When a protected field is marked, *its* dirty field is set, but any
-other fields that depend on it aren't set yet.
-
-Lazy marking works for data dependencies but not for control
-dependencies. That's because data dependencies are computed before the
-dirty flags is checked, meaning the dirty flags gets marked before it's
-checked. Lazy marking also allows us to skip no-op updates, so it's
-important for data dependencies to be fast.
-
-But for control dependencies we need eager marking. If the `width` of
-some layout object is marked, we need its parent's `descendants`
-field, which depends on `width`, needs to be marked right away,
-_before_ the `width` is recomputed. After all, that `descendants` field
-is used to determine _whether_ the `width` is recomputed!
-
-For eager marking, I'll give each protected field a second sets of
-fields to mark eagerly:
-
-``` {.python}
-class ProtectedField:
-    def __init__(self, node, name):
-        # ...
-        self.depended_lazy = set()
-        self.depended_eager = set()
-```
-
-The `read` method will be lazy, but `control` will be eager:
-
-``` {.python}
-class ProtectedField:
-    def read(self, field):
-        field.depended_lazy.add(self)
-        return field.get()
-
-    def control(self, source):
-        source.depended_eager.add(self)
-        self.dirty = True
-```
-
-In `notify`, we'll mark both lazy and eager dependencies:
-
-``` {.python}
-class ProtectedField:
-    def notify(self):
-        for field in self.depended_lazy:
-            field.mark()
-        for field in self.depended_eager:
-            field.mark()
-```
-
-However, in `mark`, we'll only recursively notify the eager fields:
-
-``` {.python}
-class ProtectedField:
-    def mark(self):
-        if self.dirty: return
-        self.dirty = True
-        for field in self.depended_eager:
-            field.mark()
-```
-
-There's one more subtlety here: multi-step dependencies. For example,
-imagine changing the `style` of a `<b>` tag from JavaScript. That
-might affect the `style` of a `Text` child of that tag, which might
-affect the `height` of its `TextLayout`. Because of this chain, we
-want the `style` change to mark a bunch of `descendants` flags. But,
-because none of the `descendants` flags directly `control` the `style`
-field, it doesn't have any eager dependants and no dirty flags are
-propagated to the `descendants` field.
-
-To solve this, we need to add one more rule: when one field reads
-another, any fields controlling the first need to also control the
-second:
-
-``` {.python}
-class ProtectedField:
-    def read(self, field):
-        field.depended_lazy.add(self)
-        for dependant in self.depended_eager:
-            dependant.control(field)
-        return field.get()
 ```
 
 With these changes, the descendant dirty bits should now be set

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -329,9 +329,11 @@ class BlockLayout:
                 self.children.set(children)
         else:
             if self.children.dirty:
-                self.children.set([])
+                self.temp_children = []
                 self.new_line()
                 self.recurse(self.node)
+                self.children.set(self.temp_children)
+                self.temp_children = None
 
         for child in self.children.get():
             child.layout()
@@ -377,17 +379,17 @@ class BlockLayout:
     def new_line(self):
         self.previous_word = None
         self.cursor_x = 0
-        last_line = self.children.get()[-1] \
-            if self.children.get() else None
+        last_line = self.temp_children[-1] \
+            if self.temp_children else None
         new_line = LineLayout(self.node, self, last_line)
-        self.children.get().append(new_line)
+        self.temp_children.append(new_line)
 
     def add_inline_child(self, node, w, child_class,
         frame, word=None):
         width = self.children.read(self.width)
         if self.cursor_x + w > width:
             self.new_line()
-        line = self.children.get()[-1]
+        line = self.temp_children[-1]
         if word:
             child = child_class(node, line, self.previous_word, word)
         else:

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -335,10 +335,7 @@ class BlockLayout:
 
         for child in self.children.get():
             child.layout()
-<<<<<<< HEAD
 
-=======
->>>>>>> 4da6b3a438a009ca9d534b77bdc0211513cbc710
         self.has_dirty_descendants = False
 
         children = self.height.read(self.children)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -330,9 +330,11 @@ class BlockLayout:
                 self.children.set(children)
         else:
             if self.children.dirty:
-                self.children.set([])
+                self.temp_children = []
                 self.new_line()
                 self.recurse(self.node)
+                self.children.set(self.temp_children)
+                self.temp_children = None
 
         for child in self.children.get():
             child.layout()
@@ -378,17 +380,17 @@ class BlockLayout:
     def new_line(self):
         self.previous_word = None
         self.cursor_x = 0
-        last_line = self.children.get()[-1] \
-            if self.children.get() else None
+        last_line = self.temp_children[-1] \
+            if self.temp_children else None
         new_line = LineLayout(self.node, self, last_line)
-        self.children.get().append(new_line)
+        self.temp_children.append(new_line)
 
     def add_inline_child(self, node, w, child_class,
         frame, word=None):
         width = self.children.read(self.width)
         if self.cursor_x + w > width:
             self.new_line()
-        line = self.children.get()[-1]
+        line = self.temp_children[-1]
         if word:
             child = child_class(node, line, self.previous_word, word)
         else:

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -119,26 +119,30 @@ def paint_visual_effects(node, cmds, rect):
     return [transform]
 
 class ProtectedField:
-    def __init__(self, node, name):
+    def __init__(self, node, name, parent=None):
         self.node = node
         self.name = name
+        self.parent = parent
 
         self.value = None
         self.dirty = True
         self.depended_lazy = set()
-        self.depended_eager = set()
+
+    def set_ancestor_dirty_bits(self):
+        parent = self.parent
+        while parent:
+            parent.has_dirty_descendants = True
+            parent = parent.parent
 
     def mark(self):
         if self.dirty: return
         self.dirty = True
-        for field in self.depended_eager:
-            field.mark()
+        self.set_ancestor_dirty_bits()
 
     def notify(self):
         for field in self.depended_lazy:
             field.mark()
-        for field in self.depended_eager:
-            field.mark()
+        self.set_ancestor_dirty_bits()
 
     def set(self, value):
         # if self.value != None:
@@ -154,13 +158,7 @@ class ProtectedField:
 
     def read(self, field):
         field.depended_lazy.add(self)
-        for dependant in self.depended_eager:
-            dependant.control(field)
         return field.get()
-
-    def control(self, source):
-        source.depended_eager.add(self)
-        self.dirty = True
 
     def copy(self, field):
         self.set(self.read(field))
@@ -233,7 +231,7 @@ class DocumentLayout:
         self.x = ProtectedField(node, "x")
         self.y = ProtectedField(node, "y")
 
-        self.descendants = ProtectedField(node, "descendants")
+        self.has_dirty_descendants = True
 
     def layout_needed(self):
         if self.zoom.dirty: return True
@@ -241,7 +239,7 @@ class DocumentLayout:
         if self.height.dirty: return True
         if self.x.dirty: return True
         if self.y.dirty: return True
-        if self.descendants.dirty: return True
+        if self.has_dirty_descendants: return True
         return False
 
     def layout(self, width, zoom):
@@ -260,7 +258,7 @@ class DocumentLayout:
         self.y.set(device_px(VSTEP, zoom))
 
         child.layout()
-        self.descendants.set(None)
+        self.has_dirty_descendants = False
 
         child_height = self.height.read(child.height)
         self.height.set(child_height + 2 * device_px(VSTEP, zoom))
@@ -285,21 +283,14 @@ class BlockLayout:
         self.previous = previous
         self.frame = frame
 
-        self.children = ProtectedField(node, "children")
-        self.zoom = ProtectedField(node, "zoom")
-        self.width = ProtectedField(node, "width")
-        self.height = ProtectedField(node, "height")
-        self.x = ProtectedField(node, "x")
-        self.y = ProtectedField(node, "y")
+        self.children = ProtectedField(node, "children", self.parent)
+        self.zoom = ProtectedField(node, "zoom", self.parent)
+        self.width = ProtectedField(node, "width", self.parent)
+        self.height = ProtectedField(node, "height", self.parent)
+        self.x = ProtectedField(node, "x", self.parent)
+        self.y = ProtectedField(node, "y", self.parent)
 
-        self.descendants = ProtectedField(node, "descendants")
-        self.parent.descendants.control(self.children)
-        self.parent.descendants.control(self.zoom)
-        self.parent.descendants.control(self.width)
-        self.parent.descendants.control(self.height)
-        self.parent.descendants.control(self.x)
-        self.parent.descendants.control(self.y)
-        self.parent.descendants.control(self.descendants)
+        self.has_dirty_descendants = True
 
     def layout_needed(self):
         if self.zoom.dirty: return True
@@ -308,7 +299,7 @@ class BlockLayout:
         if self.x.dirty: return True
         if self.y.dirty: return True
         if self.children.dirty: return True
-        if self.descendants.dirty: return True
+        if self.has_dirty_descendants: return True
         return False
 
     def layout(self):
@@ -338,15 +329,14 @@ class BlockLayout:
                 self.children.set(children)
         else:
             if self.children.dirty:
-                self.temp_children = []
+                self.children.set([])
                 self.new_line()
                 self.recurse(self.node)
-                self.children.set(self.temp_children)
-                self.temp_children = None
 
         for child in self.children.get():
             child.layout()
-        self.descendants.set(None)
+
+        self.has_dirty_descendants = False
 
         children = self.height.read(self.children)
         new_height = sum([
@@ -387,17 +377,17 @@ class BlockLayout:
     def new_line(self):
         self.previous_word = None
         self.cursor_x = 0
-        last_line = self.temp_children[-1] \
-            if self.temp_children else None
+        last_line = self.children.get()[-1] \
+            if self.children.get() else None
         new_line = LineLayout(self.node, self, last_line)
-        self.temp_children.append(new_line)
+        self.children.get().append(new_line)
 
     def add_inline_child(self, node, w, child_class,
         frame, word=None):
         width = self.children.read(self.width)
         if self.cursor_x + w > width:
             self.new_line()
-        line = self.temp_children[-1]
+        line = self.children.get()[-1]
         if word:
             child = child_class(node, line, self.previous_word, word)
         else:
@@ -455,23 +445,15 @@ class LineLayout:
         self.parent = parent
         self.previous = previous
         self.children = []
-        self.zoom = ProtectedField(node, "zoom")
-        self.x = ProtectedField(node, "x")
-        self.y = ProtectedField(node, "y")
-        self.width = ProtectedField(node, "width")
-        self.height = ProtectedField(node, "height")
-        self.ascent = ProtectedField(node, "ascent")
-        self.descent = ProtectedField(node, "descent")
+        self.zoom = ProtectedField(node, "zoom", self.parent)
+        self.x = ProtectedField(node, "x", self.parent)
+        self.y = ProtectedField(node, "y", self.parent)
+        self.width = ProtectedField(node, "width", self.parent)
+        self.height = ProtectedField(node, "height", self.parent)
+        self.ascent = ProtectedField(node, "ascent", self.parent)
+        self.descent = ProtectedField(node, "descent", self.parent)
 
-        self.descendants = ProtectedField(node, "descendants")
-        self.parent.descendants.control(self.zoom)
-        self.parent.descendants.control(self.width)
-        self.parent.descendants.control(self.height)
-        self.parent.descendants.control(self.x)
-        self.parent.descendants.control(self.y)
-        self.parent.descendants.control(self.ascent)
-        self.parent.descendants.control(self.descent)
-        self.parent.descendants.control(self.descendants)
+        self.has_dirty_descendants = True
 
     def layout_needed(self):
         if self.zoom.dirty: return True
@@ -481,7 +463,7 @@ class LineLayout:
         if self.y.dirty: return True
         if self.ascent.dirty: return True
         if self.descent.dirty: return True
-        if self.descendants.dirty: return True
+        if self.has_dirty_descendants: return True
         return False
 
     def layout(self):
@@ -499,7 +481,7 @@ class LineLayout:
 
         for word in self.children:
             word.layout()
-        self.descendants.set(0)
+        self.has_dirty_descendants = False
 
         if not self.children:
             self.height.set(0)
@@ -545,25 +527,16 @@ class TextLayout:
         self.children = []
         self.parent = parent
         self.previous = previous
-        self.zoom = ProtectedField(node, "zoom")
-        self.width = ProtectedField(node, "width")
-        self.height = ProtectedField(node, "height")
-        self.x = ProtectedField(node, "x")
-        self.y = ProtectedField(node, "y")
-        self.font = ProtectedField(node, "font")
-        self.ascent = ProtectedField(node, "ascent")
-        self.descent = ProtectedField(node, "descent")
+        self.zoom = ProtectedField(node, "zoom", self.parent)
+        self.width = ProtectedField(node, "width", self.parent)
+        self.height = ProtectedField(node, "height", self.parent)
+        self.x = ProtectedField(node, "x", self.parent)
+        self.y = ProtectedField(node, "y", self.parent)
+        self.font = ProtectedField(node, "font", self.parent)
+        self.ascent = ProtectedField(node, "ascent", self.parent)
+        self.descent = ProtectedField(node, "descent", self.parent)
 
-        self.descendants = ProtectedField(node, "descendants")
-        self.parent.descendants.control(self.font)
-        self.parent.descendants.control(self.zoom)
-        self.parent.descendants.control(self.width)
-        self.parent.descendants.control(self.height)
-        self.parent.descendants.control(self.x)
-        self.parent.descendants.control(self.y)
-        self.parent.descendants.control(self.ascent)
-        self.parent.descendants.control(self.descent)
-        self.parent.descendants.control(self.descendants)
+        self.has_dirty_descendants = True
 
     def layout_needed(self):
         if self.zoom.dirty: return True
@@ -574,7 +547,7 @@ class TextLayout:
         if self.ascent.dirty: return True
         if self.descent.dirty: return True
         if self.font.dirty: return True
-        if self.descendants.dirty: return True
+        if self.has_dirty_descendants: return True
         return False
 
     def layout(self):
@@ -621,25 +594,16 @@ class EmbedLayout:
         self.previous = previous
 
         self.children = []
-        self.zoom = ProtectedField(node, "zoom")
-        self.width = ProtectedField(node, "width")
-        self.height = ProtectedField(node, "height")
-        self.x = ProtectedField(node, "x")
-        self.y = ProtectedField(node, "y")
-        self.font = ProtectedField(node, "font")
-        self.ascent = ProtectedField(node, "ascent")
-        self.descent = ProtectedField(node, "descent")
+        self.zoom = ProtectedField(node, "zoom", self.parent)
+        self.width = ProtectedField(node, "width", self.parent)
+        self.height = ProtectedField(node, "height", self.parent)
+        self.x = ProtectedField(node, "x", self.parent)
+        self.y = ProtectedField(node, "y", self.parent)
+        self.font = ProtectedField(node, "font", self.parent)
+        self.ascent = ProtectedField(node, "ascent", self.parent)
+        self.descent = ProtectedField(node, "descent", self.parent)
 
-        self.descendants = ProtectedField(node, "descendants")
-        self.parent.descendants.control(self.font)
-        self.parent.descendants.control(self.zoom)
-        self.parent.descendants.control(self.width)
-        self.parent.descendants.control(self.height)
-        self.parent.descendants.control(self.x)
-        self.parent.descendants.control(self.y)
-        self.parent.descendants.control(self.ascent)
-        self.parent.descendants.control(self.descent)
-        self.parent.descendants.control(self.descendants)
+        self.has_dirty_descendants = True
 
     def layout_needed(self):
         if self.zoom.dirty: return True
@@ -650,7 +614,7 @@ class EmbedLayout:
         if self.ascent.dirty: return True
         if self.descent.dirty: return True
         if self.font.dirty: return True
-        if self.descendants.dirty: return True
+        if self.has_dirty_descendants: return True
         return False
 
     def layout_before(self):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -274,6 +274,7 @@ class DocumentLayout:
 
         display_list.extend(cmds)
 
+
 @wbetools.patch(BlockLayout)
 class BlockLayout:
     def __init__(self, node, parent, previous, frame):


### PR DESCRIPTION
And replace it with a dirty bit on each layout object.

`descendants` always depended on all of the `ProtectedField`s for each descendant anyway, so we can just
set the dirty bit directly.

As a result, we can get rid of the concept of an eager field which simplifies the code and the chapter.