### PR TITLE
Rename depended_on to invalidations

### DIFF
--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -784,22 +784,22 @@ pain, and it's easy to forget a dependency. What we need is something
 seamless: `set`-ting to a field should automatically mark all the
 fields that depend on it.
 
-To do that, we're going to need to keep around a `depended_on` set
-of fields that depend on this one:
+To do that, we're going to need to keep around a set of fields that
+depend on this one, called its `invalidations`:
 
-``` {.python replace=(self)/(self%2c%20node%2c%20name%2c%20parent%3dNone),depended_on/depended_lazy}
+``` {.python replace=(self)/(self%2c%20node%2c%20name%2c%20parent%3dNone)}
 class ProtectedField:
     def __init__(self):
         # ...
-        self.depended_on = set()
+        self.invalidations = set()
 ```
 
 We can mark all of the dependencies with `notify`:
 
-``` {.python replace=depended_on/depended_lazy}
+``` {.python}
 class ProtectedField:
     def notify(self):
-        for field in self.depended_on:
+        for field in self.invalidations:
             field.mark()
 ```
 
@@ -821,7 +821,7 @@ dependant fields get marked:
 class BlockLayout:
     def __init__(self, node, parent, previous, frame):
         # ...
-        self.parent.zoom.depended_on.add(self.zoom)
+        self.parent.zoom.invalidations.add(self.zoom)
 ```
 
 That's definitely less error-prone, but it'd be even better if we
@@ -830,10 +830,10 @@ child's `zoom` need to depend on its parent's? It's because we read
 from the parent's zoom, with `get`, when computing the child's. We can
 make a variant of `get` that captures this pattern:
 
-``` {.python replace=depended_on/depended_lazy}
+``` {.python}
 class ProtectedField:
     def read(self, field):
-        field.depended_on.add(self)
+        field.invalidations.add(self)
         return field.get()
 ```
 

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -126,7 +126,7 @@ class ProtectedField:
 
         self.value = None
         self.dirty = True
-        self.depended_lazy = set()
+        self.invalidations = set()
 
     def set_ancestor_dirty_bits(self):
         parent = self.parent
@@ -140,7 +140,7 @@ class ProtectedField:
         self.set_ancestor_dirty_bits()
 
     def notify(self):
-        for field in self.depended_lazy:
+        for field in self.invalidations:
             field.mark()
         self.set_ancestor_dirty_bits()
 
@@ -157,7 +157,7 @@ class ProtectedField:
         return self.value
 
     def read(self, field):
-        field.depended_lazy.add(self)
+        field.invalidations.add(self)
         return field.get()
 
     def copy(self, field):


### PR DESCRIPTION
I found `depended_on` confusing and hard to say. This new name seems better.