### PR TITLE
Test iframe resizing

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1810,14 +1810,22 @@ class JSContext:
     def querySelectorAll(self, selector_text, window_id):
         frame = self.tab.window_id_to_frame[window_id]
         self.throw_if_cross_origin(frame)
+        # ...
+
+    def setAttribute(self, handle, attr, value, window_id):
+        frame = self.tab.window_id_to_frame[window_id]
+        self.throw_if_cross_origin(frame)
+        # ...
 
     def innerHTML_set(self, handle, s, window_id):
-        frame = self.tab.window_id_to_frame[window_id]        
+        frame = self.tab.window_id_to_frame[window_id]
         self.throw_if_cross_origin(frame)
+        # ...
 
     def style_set(self, handle, s, window_id):
-        frame = self.tab.window_id_to_frame[window_id]        
+        frame = self.tab.window_id_to_frame[window_id]
         self.throw_if_cross_origin(frame)
+        # ...
 ```
 
 So via `parent`, same-origin iframes can communicate. But what about

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1033,7 +1033,7 @@ field:[^protect-style-attr]
     protected field, and have the `style` field depend on it, but I'm
     taking a short-cut in the interest of simplicity.
 
-``` {.python}
+``` {.python expected=False}
 class JSContext:
     def style_set(self, handle, s, window_id):
         # ...

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -2047,8 +2047,21 @@ CSS_PROPERTIES = {
 }
 ```
 
-Now, in `style`, we will need to recompute a node's style if *any* of
-their style properties are dirty:
+Now, we have to invalidate fields one by one. For example, when
+setting the `style` property from JavaScript, I'll invalidate all of
+the fields:
+
+``` {.python}
+class JSContext:
+    def style_set(self, handle, s, window_id):
+        # ...
+        for property, value in elt.style:
+            value.mark()
+        # ...
+```
+
+Similarly, in `style`, we will need to recompute a node's style if
+*any* of their style properties are dirty:
 
 ``` {.python}
 def style(node, rules, frame):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -771,6 +771,8 @@ class JSContext:
             self.querySelectorAll)
         self.interp.export_function("getAttribute",
             self.getAttribute)
+        self.interp.export_function("setAttribute",
+            self.setAttribute)
         self.interp.export_function("innerHTML_set", self.innerHTML_set)
         self.interp.export_function("style_set", self.style_set)
         self.interp.export_function("XMLHttpRequest_send",
@@ -844,6 +846,13 @@ class JSContext:
     def getAttribute(self, handle, attr):
         elt = self.handle_to_node[handle]
         return elt.attributes.get(attr, None)
+
+    def setAttribute(self, handle, attr, value, window_id):
+        frame = self.tab.window_id_to_frame[window_id]        
+        self.throw_if_cross_origin(frame)
+        elt = self.handle_to_node[handle]
+        elt.attributes[attr] = value
+        self.tab.set_needs_render_all_frames()
 
     def parent(self, window_id):
         parent_frame = \

--- a/src/lab16-tests.md
+++ b/src/lab16-tests.md
@@ -206,7 +206,7 @@ The parent frame should now have resized the iframe:
            LineLayout(x=13.0, y=18.0, width=774.0, height=152.0, node=<body>)
              IframeLayout(src=http://test/2, x=13.0, y=18.0, width=102.0, height=152.0)
 
-But also the child frame should have resided as well:
+But also the child frame should have resized as well:
 
     >>> lab16.print_tree(frame2.document)
      DocumentLayout()

--- a/src/lab16-tests.md
+++ b/src/lab16-tests.md
@@ -149,6 +149,10 @@ Next, we can execute some JavaScript to change the page:
 Test iframe resizing
 ====================
 
+(This duplicates a test from [the Chapter 15 tests](lab15-tests.md),
+but modifies the styling because leading works differently in the two
+chapters.)
+
 Here's web page with an iframe inside of it. We make it narrow so that
 resizing is dramatic:
 

--- a/src/lab16-tests.md
+++ b/src/lab16-tests.md
@@ -145,3 +145,77 @@ Next, we can execute some JavaScript to change the page:
                  LineLayout(x=13.0, y=38.0, width=774.0, height=20.0, node=<div>)
                    TextLayout(x=13.0, y=38.0, width=80.0, height=20.0, node=..., word=Short)
                    TextLayout(x=109.0, y=38.0, width=64.0, height=20.0, node=..., word=body)
+
+Test iframe resizing
+====================
+
+Here's web page with an iframe inside of it. We make it narrow so that
+resizing is dramatic:
+
+    >>> url2 = test.socket.serve("""
+    ... <!doctype html>
+    ... <p>A B C D</p>
+    ... """)
+    >>> url1 = test.socket.serve("""
+    ... <!doctype html>
+    ... <iframe width=50 src=""" + url2 + """ />
+    ... """)
+    >>> browser = lab16.Browser()
+    >>> browser.load(url1)
+    >>> browser.render()
+    >>> frame1 = browser.tabs[0].root_frame
+    >>> iframe = [
+    ...    n for n in lab16.tree_to_list(frame1.nodes, [])
+    ...    if isinstance(n, lab16.Element) and n.tag == "iframe"][0]
+    >>> frame2 = iframe.frame
+    >>> lab16.print_tree(frame1.document)
+     DocumentLayout()
+       BlockLayout(x=13.0, y=13.0, width=774.0, height=152.0, node=<html>)
+         BlockLayout(x=13.0, y=13.0, width=774.0, height=152.0, node=<body>)
+           LineLayout(x=13.0, y=18.0, width=774.0, height=152.0, node=<body>)
+             IframeLayout(src=http://test/2, x=13.0, y=18.0, width=52.0, height=152.0)
+    >>> lab16.print_tree(frame2.document)
+     DocumentLayout()
+       BlockLayout(x=13.0, y=13.0, width=24.0, height=80.0, node=<html>)
+         BlockLayout(x=13.0, y=13.0, width=24.0, height=80.0, node=<body>)
+           BlockLayout(x=13.0, y=13.0, width=24.0, height=80.0, node=<p>)
+             LineLayout(x=13.0, y=18.0, width=24.0, height=20.0, node=<p>)
+               TextLayout(x=13.0, y=18.0, width=16.0, height=20.0, node='A B C D', word=A)
+             LineLayout(x=13.0, y=38.0, width=24.0, height=20.0, node=<p>)
+               TextLayout(x=13.0, y=38.0, width=16.0, height=20.0, node='A B C D', word=B)
+             LineLayout(x=13.0, y=58.0, width=24.0, height=20.0, node=<p>)
+               TextLayout(x=13.0, y=58.0, width=16.0, height=20.0, node='A B C D', word=C)
+             LineLayout(x=13.0, y=78.0, width=24.0, height=20.0, node=<p>)
+               TextLayout(x=13.0, y=78.0, width=16.0, height=20.0, node='A B C D', word=D)
+
+Now, let's resize it:
+
+    >>> script = """
+    ... var iframe = window.document.querySelectorAll("iframe")[0]
+    ... iframe.setAttribute("width", "100");
+    ... """
+    >>> frame1.js.run("<test>", script, frame1.window_id)
+    >>> browser.render()
+
+The parent frame should now have resized the iframe:
+
+    >>> lab16.print_tree(frame1.document)
+     DocumentLayout()
+       BlockLayout(x=13.0, y=13.0, width=774.0, height=152.0, node=<html>)
+         BlockLayout(x=13.0, y=13.0, width=774.0, height=152.0, node=<body>)
+           LineLayout(x=13.0, y=18.0, width=774.0, height=152.0, node=<body>)
+             IframeLayout(src=http://test/2, x=13.0, y=18.0, width=102.0, height=152.0)
+
+But also the child frame should have resided as well:
+
+    >>> lab16.print_tree(frame2.document)
+     DocumentLayout()
+       BlockLayout(x=13.0, y=13.0, width=74.0, height=40.0, node=<html>)
+         BlockLayout(x=13.0, y=13.0, width=74.0, height=40.0, node=<body>)
+           BlockLayout(x=13.0, y=13.0, width=74.0, height=40.0, node=<p>)
+             LineLayout(x=13.0, y=18.0, width=74.0, height=20.0, node=<p>)
+               TextLayout(x=13.0, y=18.0, width=16.0, height=20.0, node='A B C D', word=A)
+               TextLayout(x=45.0, y=18.0, width=16.0, height=20.0, node='A B C D', word=B)
+             LineLayout(x=13.0, y=38.0, width=74.0, height=20.0, node=<p>)
+               TextLayout(x=13.0, y=38.0, width=16.0, height=20.0, node='A B C D', word=C)
+               TextLayout(x=45.0, y=38.0, width=16.0, height=20.0, node='A B C D', word=D)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -871,7 +871,8 @@ class JSContext:
         self.throw_if_cross_origin(frame)
         elt = self.handle_to_node[handle]
         elt.attributes['style'] = s
-        elt.style.mark()
+        for property, value in elt.style:
+            value.mark()
         frame.set_needs_render()
 
 @wbetools.patch(Frame)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -867,7 +867,7 @@ class JSContext:
                 obj.width.mark()
             if attr == "height":
                 obj.height.mark()
-        frame.set_needs_render()
+        self.tab.set_needs_render_all_frames()
 
     def style_set(self, handle, s, window_id):
         frame = self.tab.window_id_to_frame[window_id]

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -511,8 +511,6 @@ class LineLayout:
             new_y += child.y.read(self.ascent)
             new_y += child.y.read(child.ascent)
             child.y.set(new_y)
-        self.descendants.set(None)
-
 
         max_ascent = self.height.read(self.ascent)
         max_descent = self.height.read(self.descent)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -855,6 +855,17 @@ class JSContext:
         obj.children.mark()
         frame.set_needs_render()
 
+    def setAttribute(self, handle, attr, value, window_id):
+        frame = self.tab.window_id_to_frame[window_id]        
+        self.throw_if_cross_origin(frame)
+        elt = self.handle_to_node[handle]
+        elt.attributes[attr] = value
+        obj = elt.layout_object
+        while not isinstance(obj, BlockLayout):
+            obj = obj.parent
+        obj.children.mark()
+        self.tab.set_needs_render_all_frames()
+
     def style_set(self, handle, s, window_id):
         frame = self.tab.window_id_to_frame[window_id]
         self.throw_if_cross_origin(frame)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -488,7 +488,6 @@ class LineLayout:
 
         for word in self.children:
             word.layout()
-        self.has_dirty_descendants = False
 
         if not self.children:
             self.ascent.set(0)
@@ -512,6 +511,7 @@ class LineLayout:
             new_y += child.y.read(self.ascent)
             new_y += child.y.read(child.ascent)
             child.y.set(new_y)
+        self.descendants.set(None)
 
 
         max_ascent = self.height.read(self.ascent)
@@ -867,7 +867,7 @@ class JSContext:
                 obj.width.mark()
             if attr == "height":
                 obj.height.mark()
-        self.tab.set_needs_render_all_frames()
+        frame.set_needs_render()
 
     def style_set(self, handle, s, window_id):
         frame = self.tab.window_id_to_frame[window_id]

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -861,9 +861,12 @@ class JSContext:
         elt = self.handle_to_node[handle]
         elt.attributes[attr] = value
         obj = elt.layout_object
-        while not isinstance(obj, BlockLayout):
-            obj = obj.parent
-        obj.children.mark()
+        if isinstance(obj, IframeLayout) or \
+           isinstance(obj, ImageLayout):
+            if attr == "width":
+                obj.width.mark()
+            if attr == "height":
+                obj.height.mark()
         self.tab.set_needs_render_all_frames()
 
     def style_set(self, handle, s, window_id):

--- a/src/runtime15.js
+++ b/src/runtime15.js
@@ -11,6 +11,10 @@ window.Node.prototype.getAttribute = function(attr) {
     return call_python("getAttribute", this.handle, attr);
 }
 
+window.Node.prototype.setAttribute = function(attr, value) {
+    return call_python("setAttribute", this.handle, attr, value, window._id);
+}
+
 window.LISTENERS = {}
 
 window.Event = function(type) {
@@ -31,17 +35,6 @@ window.Node.prototype.addEventListener = function(type, listener) {
     list.push(listener);
 }
 
-window.Node.prototype.dispatchEvent = function(evt) {
-    var type = evt.type;
-    var handle = this.handle
-    var list = (window.LISTENERS[handle] &&
-        window.LISTENERS[handle][type]) || [];
-    for (var i = 0; i < list.length; i++) {
-        list[i].call(this, evt);
-    }
-    return evt.do_default;
-}
-
 Object.defineProperty(window.Node.prototype, 'innerHTML', {
     set: function(s) {
         call_python("innerHTML_set", this.handle, s.toString(), window._id);
@@ -53,6 +46,17 @@ Object.defineProperty(window.Node.prototype, 'style', {
         call_python("style_set", this.handle, s.toString(), window._id);
     }
 });
+
+window.Node.prototype.dispatchEvent = function(evt) {
+    var type = evt.type;
+    var handle = this.handle
+    var list = (window.LISTENERS[handle] &&
+        window.LISTENERS[handle][type]) || [];
+    for (var i = 0; i < list.length; i++) {
+        list[i].call(this, evt);
+    }
+    return evt.do_default;
+}
 
 window.SET_TIMEOUT_REQUESTS = {}
 


### PR DESCRIPTION
This PR adds a test to Chapter 16 that tests what happens when one frame's script resizes, using `setAttribute`, another frame. (It should force a re-layout in that frame.)

Funny enough, Chapter 14 added `setAttribute` but somehow Chapter 15 lost it. So this PR first adds `setAttribute` back into Chapter 15, describes it in the Chapter 15 text, and then adds it to Chapter 16, and describes it in the Chapter 16 text.

For some reason, the test passes without having to protect the `frame_width` field. Not sure why, will investigate tomorrow.