### PR TITLE
Fix URL parsing for url_origin

### DIFF
--- a/book/http.md
+++ b/book/http.md
@@ -250,11 +250,16 @@ url = url[len("http://"):]
 ```
 
 Now we must separate the host from the path. The host comes before the
-first `/`, while the path is that slash and everything after it:
+first `/`, while the path is that slash and everything after it. Let's
+add function that parses all parts of a URL:
 
-``` {.python}
-host, path = url.split("/", 1)
-path = "/" + path
+``` {python}
+def parse_url(url):
+    scheme, url = url.split("://", 1)
+    if "/" not in url:
+        url = url + "/"
+    host, path = url.split("/", 1)
+    return (scheme, host, "/" + path)
 ```
 
 The `split(s, n)` method splits a string at the first `n` copies of

--- a/book/security.md
+++ b/book/security.md
@@ -604,8 +604,8 @@ The `url_origin` function can just strip off the path from a URL:
 
 ``` {.python}
 def url_origin(url):
-    scheme_colon, _, host, _ = url.split("/", 3)
-    return scheme_colon + "//" + host
+    (scheme, host, path) = parse_url(url)
+    return scheme + "://" + host
 ```
 
 Now an attacker can't read the guest book web page. But can they write

--- a/src/lab1.hints
+++ b/src/lab1.hints
@@ -1,4 +1,4 @@
-[{"code": "'/' in url", "type": "str"},
+[{"code": "'/' not in url", "type": "str"},
  {"code": "':' in host", "type": "str"},
  {"code": "'transfer-encoding' not in headers", "type": "dict"},
  {"code": "'content-encoding' not in headers", "type": "dict"}

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -7,17 +7,18 @@ without exercises.
 import socket
 import ssl
 
-def request(url):
+def parse_url(url):
     scheme, url = url.split("://", 1)
+    if "/" not in url:
+        url = url + "/"
+    host, path = url.split("/", 1)
+    return (scheme, host, "/" + path)
+
+def request(url):
+    (scheme, host, path) = parse_url(url)
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    if ("/" in url):
-      host, path = url.split("/", 1)
-      path = "/" + path
-    else:
-      host = url
-      path = '/'
     port = 80 if scheme == "http" else 443
 
     if ":" in host:

--- a/src/lab10.hints
+++ b/src/lab10.hints
@@ -2,7 +2,6 @@
  {"code": "'action' in elt.attributes", "type": "dict"},
  {"code": "'href' in elt.attributes", "type": "dict"},
  {"code": "'name' in node.attributes", "type": "dict"},
- {"code": "'/' not in url", "type": "str"},
  {"code": "':' in host", "type": "str"},
  {"code": "':' in top_level_host", "type": "str"},
  {"code": "host in COOKIE_JAR", "type": "dict"},

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -10,6 +10,7 @@ import tkinter
 import tkinter.font
 import urllib.parse
 import dukpy
+from lab1 import parse_url
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
@@ -20,13 +21,6 @@ from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
 from lab9 import EVENT_DISPATCH_CODE
-
-def parse_url(url):
-    scheme, url = url.split("://", 1)
-    if "/" not in url:
-        url = url + "/"
-    host, path = url.split("/", 1)
-    return (scheme, host, path)
 
 def url_origin(url):
     (scheme, host, path) = parse_url(url)

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -21,20 +21,23 @@ from lab7 import LineLayout, TextLayout, CHROME_PX
 from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 
+def parse_url(url):
+    scheme, url = url.split("://", 1)
+    if "/" not in url:
+        url = url + "/"
+    host, path = url.split("/", 1)
+    return (scheme, host, path)
+
 def url_origin(url):
-    scheme_colon, _, host, _ = url.split("/", 3)
-    return scheme_colon + "//" + host
+    (scheme, host, path) = parse_url(url)
+    return scheme + "://" + host
         
 COOKIE_JAR = {}
 
 def request(url, top_level_url, payload=None):
-    scheme, url = url.split("://", 1)
+    (scheme, host, path) = parse_url(url)
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
-
-    if "/" not in url:
-        url = url + "/"
-    host, path = url.split("/", 1)
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -33,7 +33,6 @@ def request(url, top_level_url, payload=None):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    path = "/" + path
     port = 80 if scheme == "http" else 443
 
     if ":" in host:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -177,7 +177,10 @@ class DocumentLayout:
 def font(style, zoom):
     weight = style["font-weight"]
     variant = style["font-style"]
-    size = float(style["font-size"][:-2])
+    if style["font-size"].endswith("px"):
+        size = float(style["font-size"][:-2])
+    else:
+        size = 12
     font_size = device_px(size, zoom)
     return get_font(font_size, weight, variant)
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -173,10 +173,10 @@ class DocumentLayout:
 def font(style, zoom):
     weight = style["font-weight"]
     variant = style["font-style"]
-    if style["font-size"].endswith("px"):
+    try:
         size = float(style["font-size"][:-2])
-    else:
-        size = 12
+    except ValueError:
+        size = 16
     font_size = device_px(size, zoom)
     return get_font(font_size, weight, variant)
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -18,6 +18,7 @@ import time
 import urllib.parse
 import wbetools
 
+from lab1 import parse_url
 from lab4 import print_tree
 from lab13 import Text, Element
 from lab6 import resolve_url
@@ -44,15 +45,10 @@ from lab14 import parse_color, draw_rect, DrawRRect, \
     CSSParser, DrawOutline, main_func, Browser
 
 def request(url, top_level_url, payload=None):
-    scheme, url = url.split("://", 1)
+    (scheme, host, path) = parse_url(url)
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    if "/" not in url:
-        url = url + "/"
-    host, path = url.split("/", 1)
-
-    path = "/" + path
     port = 80 if scheme == "http" else 443
 
     if ":" in host:

--- a/src/lab8.hints
+++ b/src/lab8.hints
@@ -1,5 +1,4 @@
-[{"code": "'/' in url", "type": "str"},
- {"code": "':' in host", "type": "str"},
+[{"code": "':' in host", "type": "str"},
  {"code": "'transfer-encoding' not in headers", "type": "dict"},
  {"code": "'content-encoding' not in headers", "type": "dict"},
  {"code": "child.tag in BLOCK_ELEMENTS", "type": "list"},

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -9,6 +9,7 @@ import ssl
 import tkinter
 import tkinter.font
 import urllib.parse
+from lab1 import parse_url
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
@@ -19,16 +20,10 @@ from lab6 import DrawText, resolve_url, tree_to_list
 from lab7 import LineLayout, TextLayout, CHROME_PX
 
 def request(url, payload=None):
-    scheme, url = url.split("://", 1)
+    (scheme, host, path) = parse_url(url)
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    if ("/" in url):
-      host, path = url.split("/", 1)
-      path = "/" + path
-    else:
-      host = url
-      path = '/'
     port = 80 if scheme == "http" else 443
 
     if ":" in host:


### PR DESCRIPTION
For lab15 and lab16, if you tried to run `lab15.py http://browser.engineering`, it would complain that the trailing slash was missing from the URL. This bug is not present in previous chapters.

I fixed it by factoring out URL parsing into a `parse_url` method and used in in all chapters, so that we don't have different code in some places than others (it also aligns better with the commentary in chapter 1 about not reinventing wheels).

I also added some code to avoid crashing on `calc(...` syntax for browser.engineering iframes in chapter 15
(copied from chapter 16).