### PR TITLE
Don't use asserts in CSSParser

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -78,8 +78,8 @@ it started and extracts the substring it moved through.
     and colors (which use the hash sign). Real CSS values have a more
     complex syntax but this is enough for our toy browser.
 
-Parsing functions can fail. The `word` function we just wrote has an
-assertion to check that `i` advanced though at least one
+Parsing functions can fail. The `word` function we just wrote raises
+an exception if `i` hasn't advanced though at least one
 character---otherwise it didn't point at a word to begin
 with.[^add-a-comma] Likewise, to check for a literal colon (or some
 other punctuation character) you'd do this:
@@ -91,8 +91,8 @@ def literal(self, literal):
     self.i += 1
 ```
 
-[^add-a-comma]: You can add error text to the assertion, too; I
-    recommend doing that to help you debug problems.
+[^add-a-comma]: You can add error text to the exception-raising
+code, too; I recommend doing that to help you debug problems.
 
 The great thing about parsing functions is that they can build on one
 another. For example, property-value pairs are a property, a colon,

--- a/book/styles.md
+++ b/book/styles.md
@@ -62,8 +62,10 @@ def word(self):
             self.i += 1
         else:
             break
-    assert self.i > start
-    return self.s[start:self.i]
+        if not (self.i > start):
+            raise Exception("Parsing error")
+        
+        return self.s[start:self.i]
 ```
 
 This function increments `i` through any word characters,[^word-chars]
@@ -84,7 +86,8 @@ other punctuation character) you'd do this:
 
 ``` {.python}
 def literal(self, literal):
-    assert self.i < len(self.s) and self.s[self.i] == literal
+    if not (self.i < len(self.s) and self.s[self.i] == literal):
+        raise Exception("Parsing error")
     self.i += 1
 ```
 
@@ -151,7 +154,7 @@ def body(self):
     while self.i < len(self.s):
         try:
             # ...
-        except AssertionError:
+        except Exception:
             why = self.ignore_until([";"])
             if why == ";":
                 self.literal(";")
@@ -407,7 +410,7 @@ def body(self):
     while self.i < len(self.s) and self.s[self.i] != "}":
         try:
             # ...
-        except AssertionError:
+        except Exception:
             why = self.ignore_until([";", "}"])
             if why == ";":
                 self.literal(";")
@@ -426,7 +429,7 @@ def parse(self):
     while self.i < len(self.s):
         try:
             # ...
-        except AssertionError:
+        except Exception:
             why = self.ignore_until(["}"])
             if why == "}":
                 self.literal("}")

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -636,7 +636,7 @@ def compile_expr(tree, ctx):
             return "this"
         elif tree.id in RT_IMPORTS or tree.id in OUR_CLASSES:
             return tree.id
-        elif tree.id == "AssertionError":
+        elif tree.id == "Exception":
             return "Error"
         elif tree.id in OUR_CONSTANTS:
             return "constants.{}".format(tree.id)

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -405,7 +405,7 @@ JavaScript. This test asks doctest to ignore whitespace changes,
 because there's something going wrong with the way doctest parses
 indentation.
 
-    >>> Test.stmt("try:\n assert False\nexcept AssertionError:\n foo()") # doctest: +NORMALIZE_WHITESPACE
+    >>> Test.stmt("try:\n assert False\nexcept Exception:\n foo()") # doctest: +NORMALIZE_WHITESPACE
     try {
       if (!truthy(false)) throw Error();
     } catch ($err) {

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -41,6 +41,10 @@ class MeasureTime:
     def start_timing(self):
         self.start_time = time.time()
 
+    def text_current(self, name):
+        print("Time after {}: {}ms".format(
+            name, (time.time() - self.start_time) * 1000))
+
     def stop_timing(self):
         self.total_s += time.time() - self.start_time
         self.count += 1

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -297,7 +297,8 @@ class CSSParser:
             self.i += 1
 
     def literal(self, literal):
-        assert self.i < len(self.s) and self.s[self.i] == literal
+        if not (self.i < len(self.s) and self.s[self.i] == literal):
+            raise Exception("Parsing error")
         self.i += 1
 
     def word(self):
@@ -312,7 +313,8 @@ class CSSParser:
                 self.i += 1
             else:
                 break
-        assert self.i > start
+        if not (self.i > start):
+            raise Exception("Parsing error")
         return self.s[start:self.i]
 
     def until_semicolon(self):
@@ -348,7 +350,7 @@ class CSSParser:
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()
-            except AssertionError:
+            except Exception:
                 why = self.ignore_until([";", "}"])
                 if why == ";":
                     self.literal(";")
@@ -378,7 +380,7 @@ class CSSParser:
                 body = self.body()
                 self.literal("}")
                 rules.append((selector, body))
-            except AssertionError:
+            except Exception:
                 why = self.ignore_until(["}"])
                 if why == "}":
                     self.literal("}")

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -671,7 +671,8 @@ class CSSParser:
             self.i += 1
 
     def literal(self, literal):
-        assert self.i < len(self.s) and self.s[self.i] == literal
+        if not (self.i < len(self.s) and self.s[self.i] == literal):
+            raise Exception("Parsing error")
         self.i += 1
 
     def word(self):
@@ -688,7 +689,9 @@ class CSSParser:
                 self.i += 1
             else:
                 break
-        assert self.i > start
+        if not (self.i > start):
+            raise Exception("Parsing error")
+
         return self.s[start:self.i]
 
     def until_char(self, chars):
@@ -721,7 +724,7 @@ class CSSParser:
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()
-            except AssertionError:
+            except Exception:
                 why = self.ignore_until([";", "}"])
                 if why == ";":
                     self.literal(";")
@@ -783,7 +786,7 @@ class CSSParser:
                     self.literal("}")
                     self.whitespace()
                     rules.append((media, selector, body))
-            except AssertionError:
+            except Exception:
                 why = self.ignore_until(["}"])
                 if why == "}":
                     self.literal("}")

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -49,7 +49,8 @@ class CSSParser:
             self.i += 1
 
     def literal(self, literal):
-        assert self.i < len(self.s) and self.s[self.i] == literal
+        if not (self.i < len(self.s) and self.s[self.i] == literal):
+            raise Exception("Parsing error")
         self.i += 1
 
     def word(self):
@@ -59,7 +60,8 @@ class CSSParser:
                 self.i += 1
             else:
                 break
-        assert self.i > start
+        if not (self.i > start):
+            raise Exception("Parsing error")
         return self.s[start:self.i]
 
     def pair(self):
@@ -86,7 +88,7 @@ class CSSParser:
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()
-            except AssertionError:
+            except Exception:
                 why = self.ignore_until([";", "}"])
                 if why == ";":
                     self.literal(";")
@@ -116,7 +118,7 @@ class CSSParser:
                 body = self.body()
                 self.literal("}")
                 rules.append((selector, body))
-            except AssertionError:
+            except Exception:
                 why = self.ignore_until(["}"])
                 if why == "}":
                     self.literal("}")


### PR DESCRIPTION
Instead use exceptions. This allow us to use the `-O` commandline parameter to remove asserts and test 
performance of the browser.

Also adds a helper method to `MeasureTime` to print out a snapshot of time after particular points of interest
(e.g. it could be used for after layout)).