### PR TITLE
Fix inlined versions of chapters 1-16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ widgets: \
 	www/widgets/lab12-browser.html www/widgets/lab12.js \
 	www/widgets/lab13-browser.html www/widgets/lab13.js
 
-src/lab%.full.py: src/lab%.py
+src/lab%.full.py: src/lab%.py infra/inline.py infra/asttools.py
 	python3 infra/inline.py $< > $@
 
 CHAPTER=all

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -158,13 +158,6 @@ class ResolvePatches(ast.NodeTransformer):
         self.visit(tree)
         return (self.visit(tree), self.patches)
 
-def has_js_hide(decorator_list):
-    return any([
-        isinstance(dec, ast.Attribute) and dec.attr == "js_hide"
-        and isinstance(dec.value, ast.Name) and dec.value.id == "wbetools"
-        for dec in decorator_list
-    ])
-
 class ResolveJSHide(ast.NodeTransformer):
     def visit_FunctionDef(self, cmd):
         if any([

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -113,8 +113,9 @@ class ResolvePatches(ast.NodeTransformer):
         if not cmd.decorator_list:
             patches = self.patches.get(cmd.name, [])
             if patches:
+                args2 = patches[-1].args
                 body2 = patches[-1].body
-                return ast.FunctionDef(cmd.name, cmd.args, body2, [])
+                return ast.FunctionDef(cmd.name, args2, body2, [])
             else:
                 return cmd
         else:

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -76,11 +76,16 @@ def iter_methods(cls):
 inline_cache = {}
 def load(filename):
     if filename not in inline_cache:
+        inline_cache[filename] = "in-progress"
         with open(filename) as f:
             ast = parse(f.read(), filename)
         ast = inline(ast)
         inline_cache[filename] = ast
-    return inline_cache[filename]
+        return ast
+    elif inline_cache[filename] == "in-progress":
+        raise ImportError(f"Detected a cycle when loading {filename}")
+    else:
+        return inline_cache[filename]
 
 class ResolveImports(ast.NodeTransformer):
     def visit_ImportFrom(self, cmd):

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -12,6 +12,7 @@ import skia
 import socket
 import ssl
 import urllib.parse
+from lab1 import parse_url
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -16,6 +16,7 @@ import time
 import urllib.parse
 import wbetools
 
+from lab1 import parse_url
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
@@ -25,11 +26,11 @@ from lab6 import resolve_url, tree_to_list
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX, layout_mode
 from lab9 import EVENT_DISPATCH_CODE
-from lab10 import request, url_origin
-from lab11 import DrawLine
+from lab10 import COOKIE_JAR, request, url_origin
+from lab11 import get_font, FONTS, DrawLine, linespace, DrawText, SaveLayer, ClipRRect
 from lab11 import draw_line, draw_text, draw_rect
 from lab11 import BlockLayout, DocumentLayout, LineLayout, TextLayout, InputLayout
-from lab11 import paint_visual_effects
+from lab11 import paint_visual_effects, parse_blend_mode, parse_color
 
 class MeasureTime:
     def __init__(self, name):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -17,6 +17,7 @@ import urllib.parse
 import wbetools
 import OpenGL.GL
 
+from lab1 import parse_url
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -24,6 +24,7 @@ import urllib.parse
 import wbetools
 import OpenGL.GL
 
+from lab1 import parse_url
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import Text, Element, print_tree, HTMLParser
 from lab5 import BLOCK_ELEMENTS
@@ -40,6 +41,7 @@ from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
 from lab12 import Task, REFRESH_RATE_SEC
 from lab13 import JSContext, diff_styles, clamp_scroll, add_parent_pointers
 from lab13 import absolute_bounds, absolute_bounds_for_obj
+from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
 from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -20,26 +20,27 @@ import wbetools
 
 from lab1 import parse_url
 from lab4 import print_tree
-from lab13 import Text, Element
+from lab5 import BLOCK_ELEMENTS
+from lab14 import Text, Element
 from lab6 import resolve_url
 from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab8 import layout_mode
 from lab10 import COOKIE_JAR, url_origin
-from lab11 import draw_text, get_font, linespace, \
+from lab11 import FONTS, draw_text, get_font, linespace, \
     parse_blend_mode, CHROME_PX, SCROLL_STEP
 import OpenGL.GL
 from lab12 import MeasureTime
 from lab13 import diff_styles, \
+    DisplayItem, DrawText, NumericAnimation, TranslateAnimation, \
     CompositedLayer, absolute_bounds, absolute_bounds_for_obj, \
     DrawCompositedLayer, Task, TaskRunner, SingleThreadedTaskRunner, \
-    clamp_scroll, add_parent_pointers, \
-    DisplayItem, DrawText, \
+    clamp_scroll, add_parent_pointers, parse_transform, \
     DrawLine, paint_visual_effects, WIDTH, HEIGHT, INPUT_WIDTH_PX, \
-    REFRESH_RATE_SEC, HSTEP, VSTEP, \
+    REFRESH_RATE_SEC, HSTEP, VSTEP, ClipRRect, \
     Transform, ANIMATED_PROPERTIES, SaveLayer
 
 from lab14 import parse_color, draw_rect, DrawRRect, \
-    is_focused, paint_outline, has_outline, \
+    is_focused, parse_outline, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
     is_focusable, get_tabindex, announce_text, speak_text, \
     CSSParser, DrawOutline, main_func, Browser

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -17,28 +17,33 @@ import threading
 import time
 import urllib.parse
 import wbetools
+import OpenGL.GL
 
 from lab1 import parse_url
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import print_tree
 from lab5 import BLOCK_ELEMENTS
 from lab14 import Text, Element
+from lab6 import TagSelector, DescendantSelector
 from lab6 import resolve_url
 from lab6 import tree_to_list, INHERITED_PROPERTIES
+from lab7 import CHROME_PX
+from lab8 import INPUT_WIDTH_PX
 from lab8 import layout_mode
+from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, url_origin
 from lab11 import FONTS, draw_text, get_font, linespace, \
-    parse_blend_mode, CHROME_PX, SCROLL_STEP
-import OpenGL.GL
-from lab12 import MeasureTime
-from lab13 import diff_styles, \
-    DisplayItem, DrawText, NumericAnimation, TranslateAnimation, \
-    CompositedLayer, absolute_bounds, absolute_bounds_for_obj, \
-    DrawCompositedLayer, Task, TaskRunner, SingleThreadedTaskRunner, \
-    clamp_scroll, add_parent_pointers, parse_transform, \
-    DrawLine, paint_visual_effects, WIDTH, HEIGHT, INPUT_WIDTH_PX, \
-    REFRESH_RATE_SEC, HSTEP, VSTEP, ClipRRect, \
-    Transform, ANIMATED_PROPERTIES, SaveLayer
-
+    parse_blend_mode
+from lab12 import MeasureTime, REFRESH_RATE_SEC
+from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
+from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointers
+from lab13 import absolute_bounds, absolute_bounds_for_obj
+from lab13 import NumericAnimation, TranslateAnimation
+from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
+from lab13 import CompositedLayer, paint_visual_effects
+from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
+from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, draw_rect, \
+    add_main_args
 from lab14 import parse_color, draw_rect, DrawRRect, \
     is_focused, parse_outline, paint_outline, has_outline, \
     device_px, cascade_priority, style, \

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -14,34 +14,39 @@ import socket
 import ssl
 import dukpy
 import time
+
 from lab1 import parse_url
+from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import print_tree
 from lab5 import BLOCK_ELEMENTS
-from lab15 import HTMLParser, AttributeParser
 from lab14 import Text, Element
+from lab6 import TagSelector, DescendantSelector
 from lab6 import resolve_url
 from lab6 import tree_to_list, INHERITED_PROPERTIES
+from lab7 import CHROME_PX
+from lab8 import INPUT_WIDTH_PX
 from lab8 import layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, url_origin
 from lab11 import FONTS, draw_text, get_font, linespace, \
-    parse_blend_mode, CHROME_PX, SCROLL_STEP
-from lab12 import MeasureTime
-from lab13 import diff_styles, \
-    DisplayItem, NumericAnimation, TranslateAnimation, \
-    CompositedLayer, absolute_bounds, absolute_bounds_for_obj, \
-    DrawCompositedLayer, Task, TaskRunner, SingleThreadedTaskRunner, \
-    clamp_scroll, add_parent_pointers, map_translation, \
-    DisplayItem, DrawText, ClipRRect, parse_transition, \
-    DrawLine, paint_visual_effects, parse_transform, WIDTH, HEIGHT, \
-    INPUT_WIDTH_PX, REFRESH_RATE_SEC, HSTEP, VSTEP, SETTIMEOUT_CODE, \
-    XHR_ONLOAD_CODE, Transform, ANIMATED_PROPERTIES, SaveLayer
+    parse_blend_mode
+from lab12 import MeasureTime, REFRESH_RATE_SEC
+from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
+from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointers
+from lab13 import absolute_bounds, absolute_bounds_for_obj
+from lab13 import NumericAnimation, TranslateAnimation
+from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
+from lab13 import CompositedLayer, paint_visual_effects
+from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
+from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, draw_rect, \
+    add_main_args
+
 from lab14 import parse_color, parse_outline, draw_rect, DrawRRect, \
     is_focused, paint_outline, has_outline, \
     device_px, cascade_priority, \
     is_focusable, get_tabindex, announce_text, speak_text, \
     CSSParser, main_func, DrawOutline
-from lab15 import request, DrawImage, DocumentLayout, BlockLayout, \
+from lab15 import request, HTMLParser, AttributeParser, DrawImage, DocumentLayout, BlockLayout, \
     EmbedLayout, InputLayout, LineLayout, TextLayout, ImageLayout, \
     IframeLayout, JSContext, style, AccessibilityNode, Frame, Tab, \
     CommitData, draw_line, Browser, BROKEN_IMAGE, font, \

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -8,22 +8,31 @@ import sdl2
 import skia
 import ctypes
 import math
+import OpenGL.GL
+import threading
+import socket
+import ssl
+import dukpy
+import time
+from lab1 import parse_url
 from lab4 import print_tree
-from lab4 import HTMLParser
-from lab13 import Text, Element
+from lab5 import BLOCK_ELEMENTS
+from lab15 import HTMLParser, AttributeParser
+from lab14 import Text, Element
 from lab6 import resolve_url
 from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab8 import layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, url_origin
-from lab11 import draw_text, get_font, linespace, \
-    ClipRRect, parse_blend_mode, CHROME_PX, SCROLL_STEP
+from lab11 import FONTS, draw_text, get_font, linespace, \
+    parse_blend_mode, CHROME_PX, SCROLL_STEP
 from lab12 import MeasureTime
 from lab13 import diff_styles, \
+    DisplayItem, NumericAnimation, TranslateAnimation, \
     CompositedLayer, absolute_bounds, absolute_bounds_for_obj, \
     DrawCompositedLayer, Task, TaskRunner, SingleThreadedTaskRunner, \
     clamp_scroll, add_parent_pointers, map_translation, \
-    DisplayItem, DrawText, ClipRRect, \
+    DisplayItem, DrawText, ClipRRect, parse_transition, \
     DrawLine, paint_visual_effects, parse_transform, WIDTH, HEIGHT, \
     INPUT_WIDTH_PX, REFRESH_RATE_SEC, HSTEP, VSTEP, SETTIMEOUT_CODE, \
     XHR_ONLOAD_CODE, Transform, ANIMATED_PROPERTIES, SaveLayer


### PR DESCRIPTION
This PR adds missing imports in a variety of chapters to make sure the `labXX.full.py` versions work correctly. I didn't test them super hard, but they do all render the book page roughly correctly.