### PR TITLE
Remove emphasis for glossary words inside definitions.

### DIFF
--- a/book/glossary.md
+++ b/book/glossary.md
@@ -40,7 +40,7 @@ page to the screen and interacting with it. There are three rendering engines
 actively maintained today: Chromium, WebKit and Gecko.
 
 __Script__: A piece of code that extends a web page with more functionality,
-usually written in __JavaScript__.
+usually written in JavaScript.
 
 __Web Security__: The ability of the web (or individual browsers or
 applications that are part of it) to be used without causing unintentional
@@ -50,15 +50,15 @@ security (a web application can't be harmed by its users), privacy (a third
 party can't harm a web user by observing their use of the web), and many
 others.
 
-__Web__: Simplified name for __WWW__.
+__Web__: Simplified name for WWW.
 
 __Web browser__: A software program that allows people to load and navigate
 web pages.
 
-__Web page__: The basic unit of the web; defined by unique __URL__.
+__Web page__: The basic unit of the web; defined by unique URL.
 
 __WWW__: World Wide Web. A name for the network of web pages built
-on __HTTP__, __hyperlinks__, __HTML__, __CSS__ and __JavaScript__, as
+on HTTP, hyperlinks, HTML, CSS and JavaScript, as
 well as the open and decentralized rules that (informally) govern them.
 
 Standards
@@ -74,10 +74,10 @@ __Khronos__: The Khronos Group. The standardization organization for WebGL
 and WebGPU.
 
 __W3C__: World Wide Web Consortium. The central standardization organization of
-the __WWW__. Among many other APIs, this is where __CSS__ is standardized.
+the __WWW__. Among many other APIs, this is where CSS is standardized.
 
 __WHATWG__: Web Hypertext Application Technology Working Group. The
-standardization organization for __HTML__, __DOM__, and a few other key web
+standardization organization for HTML, DOM, and a few other key web
 APIs.
 
 Web Documents
@@ -86,13 +86,13 @@ Web Documents
 __Animation__: A sequence of visual changes on a computer screen
 interpreted by humans to look like movement.
 
-__HTML Attribute__: A parameter on an __element__ indicating some
+__HTML Attribute__: A parameter on an element indicating some
 information, such as the source of an image or URL of a style sheet.
 
-__Parsing__: Turning a serialized representation (such as HTML or CSS) into a data structure such as the __document tree__ or a __style sheet__.
+__Parsing__: Turning a serialized representation (such as HTML or CSS) into a data structure such as the document tree or a style sheet.
 
 __CSS__: Cascading Style Sheet. A format for representing rules that specify the
-(mostly visual) styling of __element__s in the __DOM__.
+(mostly visual) styling of elements in the DOM.
 
 __Document__: The conceptual object created when loading a web page. Web pages
 use the metaphor of physical documents to explain how they work.
@@ -101,18 +101,18 @@ __Document tree__: The tree created from parsing HTML. Also sometimes called
 the DOM.
 
 __DOM__: Document Object Model. The object-oriented API interface to JavaScript
-for mutating the __document__. It contains in particular a tree of __Nodes__;
+for mutating the document It contains in particular a tree of nodes;
 on first page load this tree corresponds to the nested structure of the
-__HTML__.
+HTML.
 
-__Element__: Most __Nodes__ in the __DOM__ tree are Elements (except for
-text and the document object). (Inherits from __Node__.)
+__Element__: Most nodes in the DOM tree are elements (except for
+text and the document object).
 
 __Event__: A way for JavaScript to observe that something has happened on the
 document, and customize its results.
 
 __Focus__: The property of an element (sometimes in the web page, sometimes
-in the browser __chrome__) being the highlight, or "focus",
+in the browser chrome) being the highlight, or "focus",
 of user interaction, and therefore receiving keyboard events and being
 visually highlighted on the screen.
 
@@ -120,19 +120,19 @@ __Font__: A particular stylistic way of drawing a particular human language to
 computer screens. Times New Roman is one common example for Latin-based
 languages.
 
-__IFrame__: A way of embedding a child __document__ within a parent, through
+__Iframe__: A way of embedding a child document within a parent, through
 a rectangular window on the screen reserved for it that participates in the
 layout of the parent.
 
 __Image__: A representation of a picture to draw on a computer screen. An
 HTML element of the same name, for the same purpose.
 
-__Node__: A point in the __DOM__ tree, with parent and child pointers.
+__Node__: A point in the DOM tree, with parent and child pointers.
 
-__Page__: The conceptual container for a __document__. Unlike its physical
-analogue, a page can have multiple documents (through use of __iframes__).
+__Page__: The conceptual container for a document. Unlike its physical
+analogue, a page can have multiple documents (through use of iframes).
 
-__Style sheet__: A document resource that contains __CSS__ rules.
+__Style sheet__: A document resource that contains CSS rules.
 
 __Tag name__: The name of a particular type of HTML element, indicating its
 semantic function in the document. Usually comes with special style rules
@@ -157,40 +157,39 @@ __POST__: The mode of HTTP that submits a change to server state and expects
 a newly updated web page in response.
 
 __Scheme__: The first part of a URL, indicating which protocol to use for
-communication, such as __HTTP__ or __HTTPS__.
+communication, such as HTTP or HTTPS.
 
 __TLS/SSL__: Secure Sockets Layer. An encryption-based protocol that enables
-secure __HTTP__ (i.e., __HTTPS__) connections. TLS is a newer protocol
+secure HTTP (i.e., HTTPS) connections. TLS is a newer protocol
 replacing SSL, but SSL is often used to describe both.
 
 CSS
 ===
 
-__Cascade order__: The order of application of multiple __CSS rules__ to a
+__Cascade order__: The order of application of multiple CSS rules to a
 single element.
 
-__Computed Style__: The values for the __CSS Properties__ that apply to
-elements after applying all __rules__ according to the __cascade__ order.
+__Computed Style__: The values for the CSS Properties that apply to
+elements after applying all rules according to the cascade order.
 
 __CSS property__: A single concept (such as "color" or "width") used to style
-a specific part of an __element__.
+a specific part of an element.
 
-__CSS Property value__: a key-value pair of a __CSS property__ and its value
+__CSS Property value__: a key-value pair of a CSS property and its value
 (e.g. "color" and "blue" or "width" and "30px").
 
-__CSS Rule__: The combination of a __selector__ and __property values__.
+__CSS Rule__: The combination of a selector and property values.
 
-__CSS Selector__: A way of specifying to which __Elements__ a given list of
+__CSS Selector__: A way of specifying to which Elements a given list of
 __property values__ apply.
 
-__Inheritance__: The property of certain CSS styles (such as font sizing) applying to descendant elements in the __document tree__ by default.
+__Inheritance__: The property of certain CSS styles (such as font sizing) applying to descendant elements in the document tree by default.
 
 __Style__: All the pieces of information necessary to determine the visual
-display of an __element__.
+display of an element.
 
 __Cascade__: The order in which to apply multiple rules to the same
-__Element__.
-
+element.
 
 Coordinate spaces
 =================
@@ -199,7 +198,7 @@ There are several 2D coordinate spaces that are very convenient to answer
 questions like: where is this element relative to another one? Where is it
 relative to the web page? where is it on the screen?
 
-Most of the coordinate systems we'll cover in this book are __physical__, meaning
+Most of the coordinate systems we'll cover in this book are physical, meaning
 that all that is needed is the `(x=0, y=0)` origin of the coordinate space; `x`
 grows in the horizontal direction towards the right, and `y` grows in the
 vertical direction towards the bottom. Unless otherwise indicated, all
@@ -219,22 +218,22 @@ which the web page is drawn.
 __Page__: The origin is at the top-left of the web page's root element. When
 a web page is scrolled, this top-left may be off the top of the screen.
 
-__Element__: The origin is at the top-left of the __border rectangle__ of the
+__Element__: The origin is at the top-left of the layout bounds of the
 element.
 
 Rendering
 =========
 
 __Accessibility tree__: A tree representing the semantic meaning of a web page
-meant for consumption by __assistive technologies__.
+meant for consumption by assistive technologies.
 
 __Canvas__: A conceptual object which can execute drawing commands, typically
-backed by a __surface__. Also a web API of the same name that serves the same
+backed by a surface. Also a web API of the same name that serves the same
 purpose.
 
 __Compositing__: The phase of a browser rendering pipeline that divides the
 display list into pieces suitable for rendering into independent
-__surfaces__ on a __GPU__, in order to speed up animations.
+surfaces on a GPU, in order to speed up animations.
 
 __Decode__: converting from a compressed format for a resource (such as an 
 an image) into a simpler format in memory (such as a bitmap).
@@ -243,43 +242,43 @@ __Display list__: A sequence of graphics commands explaining how to draw a
 web page to a computer screen.
 
 __Draw__: The phase of a browser rendering pipeline that puts a set of surfaces
-onto the screen with various positions and __visual effects__.
+onto the screen with various positions and visual effects.
 
 __Event loop__: An infinite loop in browsers that alternates between receiving
 user input and drawing to the screen.
 
-__Hit testing__: Determining which __element__ or __accessibility tree__ node
+__Hit testing__: Determining which element or accessibility tree node
 is  at a given pixel location on the screen.
 
 __Invalidation__: Marking some rendering state as no longer valid, because its
 input dependencies have changed.
 
 __Layout__: The phase of a browser rendering pipeline that determines the
-size and position of __elements__ in the __DOM__. 
+size and position of elements in the DOM. 
 
 __Layout tree__: A second tree that mirrors the DOM, except that it represents
 the output of the layout pipeline phase.
 
 __Paint__: The phase of a browser rendering pipeline that creates a display
-list from the __DOM__.
+list from the DOM.
 
 __Rendering pipeline__: The sequence of phases by which a browser draws
 a web page onto a computer screen.
 
-__Raster__: The process of executing a __display list__ and outputting pixels
-into a __surface__.
+__Raster__: The process of executing a display list and outputting pixels
+into a surface.
 
 __Scroll__: adjusting the horizontal or vertical offset of a web page
 in response to user input, in order to see parts of it not currently visible.
 
 __Style__: The phase of a browser rendering pipeline that applies CSS rules to
-determine the visual appearance and behavior of __elements__ in the __DOM__.
+determine the visual appearance and behavior of elements in the DOM.
 Or, the set of CSS properties applied to an element after this phase.
 
 __Surface__: A buffer or texture within a GPU that represents a 2D array of
 pixels.
 
-__Visual effect__: A CSS property that does not affect __layout__.
+__Visual effect__: A CSS property that does not affect layout.
 
 __Zoom__: Changing the ratio of CSS sizes to pixels in order to  make
 content on a web page larger or smaller.
@@ -306,7 +305,7 @@ __Python__: A common computer programming language, used in this
 book to implement a toy browser.
 
 __Thread__: A single execution command sequence on a CPU. Most CPUs have
-these days can execute multiple threads at once within a single __process__.
+these days can execute multiple threads at once within a single process.
 
 __SDL__: A windowing library for computer programs used in later chapters of
 this book.

--- a/book/glossary.md
+++ b/book/glossary.md
@@ -10,39 +10,39 @@ clear names*.
 Key web terms
 =============
 
-__Accessibility__: The ability of any person to access and use a web page,
+*Accessibility*: The ability of any person to access and use a web page,
 regardless of ability; technology to achieve the same.
 
-__Browser chrome__: The UI of a browser, such as tabs or a URL bar,
+*Browser chrome*: The UI of a browser, such as tabs or a URL bar,
 outside of any web pages it's currently displaying.
 
-__HTML__: HyperText Markup Language, the XML-like format of web pages.
+*HTML*: HyperText Markup Language, the XML-like format of web pages.
 
-__Hyperlink__: A reference from one web page to another.
+*Hyperlink*: A reference from one web page to another.
 
-__HTTP__: HyperText Transport Protocol, the network protocol for loading web
+*HTTP*: HyperText Transport Protocol, the network protocol for loading web
 pages.
 
-__HTTPS__: A variant of HTTP that uses public-key cryptography for
+*HTTPS*: A variant of HTTP that uses public-key cryptography for
 network security.
 
-__Hypertext__: A non-linear form of information comprised of multiple documents
+*Hypertext*: A non-linear form of information comprised of multiple documents
 connected with contextual links.
 
-__JavaScript__: The scripting language for the web. (WebAssembly also now
+*JavaScript*: The scripting language for the web. (WebAssembly also now
 exists but is much less common.)
 
-__URL__: Uniform Resource Locator. The name used to refer uniquely to a web
+*URL*: Uniform Resource Locator. The name used to refer uniquely to a web
 page.
 
-__Rendering engine__: The part of a web browser concerned with drawing a web
+*Rendering engine*: The part of a web browser concerned with drawing a web
 page to the screen and interacting with it. There are three rendering engines
 actively maintained today: Chromium, WebKit and Gecko.
 
-__Script__: A piece of code that extends a web page with more functionality,
+*Script*: A piece of code that extends a web page with more functionality,
 usually written in JavaScript.
 
-__Web Security__: The ability of the web (or individual browsers or
+*Web Security*: The ability of the web (or individual browsers or
 applications that are part of it) to be used without causing unintentional
 harm. There are lots of different aspects of security: browser security (the
 computer system a browser is running on can't be harmed by it), web application
@@ -50,145 +50,145 @@ security (a web application can't be harmed by its users), privacy (a third
 party can't harm a web user by observing their use of the web), and many
 others.
 
-__Web__: Simplified name for WWW.
+*Web*: Simplified name for WWW.
 
-__Web browser__: A software program that allows people to load and navigate
+*Web browser*: A software program that allows people to load and navigate
 web pages.
 
-__Web page__: The basic unit of the web; defined by unique URL.
+*Web page*: The basic unit of the web; defined by unique URL.
 
-__WWW__: World Wide Web. A name for the network of web pages built
+*WWW*: World Wide Web. A name for the network of web pages built
 on HTTP, hyperlinks, HTML, CSS and JavaScript, as
 well as the open and decentralized rules that (informally) govern them.
 
 Standards
 =========
 
-__IETF__: Internet Engineering Task Force. The standardization organization
-for __HTTP__ as well as some other APIs.
+*IETF*: Internet Engineering Task Force. The standardization organization
+for HTTP as well as some other APIs.
 
-__TC39__: Technical Committee 39. The standardization organization for
+*TC39*: Technical Committee 39. The standardization organization for
 JavaScript.
 
-__Khronos__: The Khronos Group. The standardization organization for WebGL
+*Khronos*: The Khronos Group. The standardization organization for WebGL
 and WebGPU.
 
-__W3C__: World Wide Web Consortium. The central standardization organization of
-the __WWW__. Among many other APIs, this is where CSS is standardized.
+*W3C*: World Wide Web Consortium. The central standardization organization of
+the WWW. Among many other APIs, this is where CSS is standardized.
 
-__WHATWG__: Web Hypertext Application Technology Working Group. The
+*WHATWG*: Web Hypertext Application Technology Working Group. The
 standardization organization for HTML, DOM, and a few other key web
 APIs.
 
 Web Documents
 =============
 
-__Animation__: A sequence of visual changes on a computer screen
+*Animation*: A sequence of visual changes on a computer screen
 interpreted by humans to look like movement.
 
-__HTML Attribute__: A parameter on an element indicating some
+*HTML Attribute*: A parameter on an element indicating some
 information, such as the source of an image or URL of a style sheet.
 
-__Parsing__: Turning a serialized representation (such as HTML or CSS) into a data structure such as the document tree or a style sheet.
+*Parsing*: Turning a serialized representation (such as HTML or CSS) into a data structure such as the document tree or a style sheet.
 
-__CSS__: Cascading Style Sheet. A format for representing rules that specify the
+*CSS*: Cascading Style Sheet. A format for representing rules that specify the
 (mostly visual) styling of elements in the DOM.
 
-__Document__: The conceptual object created when loading a web page. Web pages
+*Document*: The conceptual object created when loading a web page. Web pages
 use the metaphor of physical documents to explain how they work.
 
-__Document tree__: The tree created from parsing HTML. Also sometimes called
+*Document tree*: The tree created from parsing HTML. Also sometimes called
 the DOM.
 
-__DOM__: Document Object Model. The object-oriented API interface to JavaScript
+*DOM*: Document Object Model. The object-oriented API interface to JavaScript
 for mutating the document It contains in particular a tree of nodes;
 on first page load this tree corresponds to the nested structure of the
 HTML.
 
-__Element__: Most nodes in the DOM tree are elements (except for
+*Element*: Most nodes in the DOM tree are elements (except for
 text and the document object).
 
-__Event__: A way for JavaScript to observe that something has happened on the
+*Event*: A way for JavaScript to observe that something has happened on the
 document, and customize its results.
 
-__Focus__: The property of an element (sometimes in the web page, sometimes
+*Focus*: The property of an element (sometimes in the web page, sometimes
 in the browser chrome) being the highlight, or "focus",
 of user interaction, and therefore receiving keyboard events and being
 visually highlighted on the screen.
 
-__Font__: A particular stylistic way of drawing a particular human language to
+*Font*: A particular stylistic way of drawing a particular human language to
 computer screens. Times New Roman is one common example for Latin-based
 languages.
 
-__Iframe__: A way of embedding a child document within a parent, through
+*Iframe*: A way of embedding a child document within a parent, through
 a rectangular window on the screen reserved for it that participates in the
 layout of the parent.
 
-__Image__: A representation of a picture to draw on a computer screen. An
+*Image*: A representation of a picture to draw on a computer screen. An
 HTML element of the same name, for the same purpose.
 
-__Node__: A point in the DOM tree, with parent and child pointers.
+*Node*: A point in the DOM tree, with parent and child pointers.
 
-__Page__: The conceptual container for a document. Unlike its physical
+*Page*: The conceptual container for a document. Unlike its physical
 analogue, a page can have multiple documents (through use of iframes).
 
-__Style sheet__: A document resource that contains CSS rules.
+*Style sheet*: A document resource that contains CSS rules.
 
-__Tag name__: The name of a particular type of HTML element, indicating its
+*Tag name*: The name of a particular type of HTML element, indicating its
 semantic function in the document. Usually comes with special style rules
 and functionality specific to it.
 
 Networking
 ==========
 
-__GET__: The mode of HTTP that retrieves a server resource without changing it.
+*GET*: The mode of HTTP that retrieves a server resource without changing it.
 
-__Cookie__: A piece of persistent, per-site state stored by web browsers
+*Cookie*: A piece of persistent, per-site state stored by web browsers
 to enable use cases like user logged-in status for access-controlled content.
 
-__Domain__: The name of a website, used to locate it on the internet.
+*Domain*: The name of a website, used to locate it on the internet.
 
-__Path__: The part of a URL after the domain and port.
+*Path*: The part of a URL after the domain and port.
 
-__Port__: A number after the domain and before the path in a URL, indicating
+*Port*: A number after the domain and before the path in a URL, indicating
 a numbered place on that domain with which to communicate.
 
-__POST__: The mode of HTTP that submits a change to server state and expects
+*POST*: The mode of HTTP that submits a change to server state and expects
 a newly updated web page in response.
 
-__Scheme__: The first part of a URL, indicating which protocol to use for
+*Scheme*: The first part of a URL, indicating which protocol to use for
 communication, such as HTTP or HTTPS.
 
-__TLS/SSL__: Secure Sockets Layer. An encryption-based protocol that enables
+*TLS/SSL*: Secure Sockets Layer. An encryption-based protocol that enables
 secure HTTP (i.e., HTTPS) connections. TLS is a newer protocol
 replacing SSL, but SSL is often used to describe both.
 
 CSS
 ===
 
-__Cascade order__: The order of application of multiple CSS rules to a
+*Cascade order*: The order of application of multiple CSS rules to a
 single element.
 
-__Computed Style__: The values for the CSS Properties that apply to
+*Computed Style*: The values for the CSS Properties that apply to
 elements after applying all rules according to the cascade order.
 
-__CSS property__: A single concept (such as "color" or "width") used to style
+*CSS property*: A single concept (such as "color" or "width") used to style
 a specific part of an element.
 
-__CSS Property value__: a key-value pair of a CSS property and its value
+*CSS Property value*: a key-value pair of a CSS property and its value
 (e.g. "color" and "blue" or "width" and "30px").
 
-__CSS Rule__: The combination of a selector and property values.
+*CSS Rule*: The combination of a selector and property values.
 
-__CSS Selector__: A way of specifying to which Elements a given list of
-__property values__ apply.
+*CSS Selector*: A way of specifying to which Elements a given list of
+*property values* apply.
 
-__Inheritance__: The property of certain CSS styles (such as font sizing) applying to descendant elements in the document tree by default.
+*Inheritance*: The property of certain CSS styles (such as font sizing) applying to descendant elements in the document tree by default.
 
-__Style__: All the pieces of information necessary to determine the visual
+*Style*: All the pieces of information necessary to determine the visual
 display of an element.
 
-__Cascade__: The order in which to apply multiple rules to the same
+*Cascade*: The order in which to apply multiple rules to the same
 element.
 
 Coordinate spaces
@@ -212,107 +212,107 @@ containing blocks, scrolling and positioning. For example, in Arabic it makes
 sense for `x` to grow towards the left, and the origin is often at the
 top-right, not the top-left.
 
-__Viewport__: The origin is at the top-left of the rectangle on the screen into
+*Viewport*: The origin is at the top-left of the rectangle on the screen into
 which the web page is drawn.
 
-__Page__: The origin is at the top-left of the web page's root element. When
+*Page*: The origin is at the top-left of the web page's root element. When
 a web page is scrolled, this top-left may be off the top of the screen.
 
-__Element__: The origin is at the top-left of the layout bounds of the
+*Element*: The origin is at the top-left of the layout bounds of the
 element.
 
 Rendering
 =========
 
-__Accessibility tree__: A tree representing the semantic meaning of a web page
+*Accessibility tree*: A tree representing the semantic meaning of a web page
 meant for consumption by assistive technologies.
 
-__Canvas__: A conceptual object which can execute drawing commands, typically
+*Canvas*: A conceptual object which can execute drawing commands, typically
 backed by a surface. Also a web API of the same name that serves the same
 purpose.
 
-__Compositing__: The phase of a browser rendering pipeline that divides the
+*Compositing*: The phase of a browser rendering pipeline that divides the
 display list into pieces suitable for rendering into independent
 surfaces on a GPU, in order to speed up animations.
 
-__Decode__: converting from a compressed format for a resource (such as an 
+*Decode*: converting from a compressed format for a resource (such as an 
 an image) into a simpler format in memory (such as a bitmap).
 
-__Display list__: A sequence of graphics commands explaining how to draw a
+*Display list*: A sequence of graphics commands explaining how to draw a
 web page to a computer screen.
 
-__Draw__: The phase of a browser rendering pipeline that puts a set of surfaces
+*Draw*: The phase of a browser rendering pipeline that puts a set of surfaces
 onto the screen with various positions and visual effects.
 
-__Event loop__: An infinite loop in browsers that alternates between receiving
+*Event loop*: An infinite loop in browsers that alternates between receiving
 user input and drawing to the screen.
 
-__Hit testing__: Determining which element or accessibility tree node
+*Hit testing*: Determining which element or accessibility tree node
 is  at a given pixel location on the screen.
 
-__Invalidation__: Marking some rendering state as no longer valid, because its
+*Invalidation*: Marking some rendering state as no longer valid, because its
 input dependencies have changed.
 
-__Layout__: The phase of a browser rendering pipeline that determines the
+*Layout*: The phase of a browser rendering pipeline that determines the
 size and position of elements in the DOM. 
 
-__Layout tree__: A second tree that mirrors the DOM, except that it represents
+*Layout tree*: A second tree that mirrors the DOM, except that it represents
 the output of the layout pipeline phase.
 
-__Paint__: The phase of a browser rendering pipeline that creates a display
+*Paint*: The phase of a browser rendering pipeline that creates a display
 list from the DOM.
 
-__Rendering pipeline__: The sequence of phases by which a browser draws
+*Rendering pipeline*: The sequence of phases by which a browser draws
 a web page onto a computer screen.
 
-__Raster__: The process of executing a display list and outputting pixels
+*Raster*: The process of executing a display list and outputting pixels
 into a surface.
 
-__Scroll__: adjusting the horizontal or vertical offset of a web page
+*Scroll*: adjusting the horizontal or vertical offset of a web page
 in response to user input, in order to see parts of it not currently visible.
 
-__Style__: The phase of a browser rendering pipeline that applies CSS rules to
+*Style*: The phase of a browser rendering pipeline that applies CSS rules to
 determine the visual appearance and behavior of elements in the DOM.
 Or, the set of CSS properties applied to an element after this phase.
 
-__Surface__: A buffer or texture within a GPU that represents a 2D array of
+*Surface*: A buffer or texture within a GPU that represents a 2D array of
 pixels.
 
-__Visual effect__: A CSS property that does not affect layout.
+*Visual effect*: A CSS property that does not affect layout.
 
-__Zoom__: Changing the ratio of CSS sizes to pixels in order to  make
+*Zoom*: Changing the ratio of CSS sizes to pixels in order to  make
 content on a web page larger or smaller.
 
 Computer technologies
 =====================
 
-__Assistive technology__: Computer software used to assist people in using
+*Assistive technology*: Computer software used to assist people in using
 the computer or web browser. The most common are screen readers.
 
-__CPU__: Central Processing Unit, the hardware component in a computer that
+*CPU*: Central Processing Unit, the hardware component in a computer that
 executes generic compute programs.
 
-__DukPy__: A JavaScript interpreter used in this book.
+*DukPy*: A JavaScript interpreter used in this book.
 
-__GPU__: Graphics Processing Unit, a specialized computing chip optimized for
+*GPU*: Graphics Processing Unit, a specialized computing chip optimized for
 tasks common to generating pixel output on computer screens.
 
-__Process__: A conceptual execution environment with its own code and
+*Process*: A conceptual execution environment with its own code and
 memory, isolated from other processes by hardware and software computer
 mechanisms.
 
-__Python__: A common computer programming language, used in this
+*Python*: A common computer programming language, used in this
 book to implement a toy browser.
 
-__Thread__: A single execution command sequence on a CPU. Most CPUs have
+*Thread*: A single execution command sequence on a CPU. Most CPUs have
 these days can execute multiple threads at once within a single process.
 
-__SDL__: A windowing library for computer programs used in later chapters of
+*SDL*: A windowing library for computer programs used in later chapters of
 this book.
 
-__Skia__: A raster drawing library for computer programs used in later chapters
+*Skia*: A raster drawing library for computer programs used in later chapters
 of this book.
 
-__Tk__: A UI drawing library for computer programs used in early chapters of
+*Tk*: A UI drawing library for computer programs used in early chapters of
 this book.
 


### PR DESCRIPTION
I think that it ended up being more distracting than useful.