### PR TITLE
`text` to `word`

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -295,7 +295,7 @@ We'll do this conversion to adjust the font sizes in the `text` and
 ``` {.python}
 class BlockLayout:
 	# ....
-    def text(self, node):
+    def word(self, node, word):
     	# ...
         size = device_px(float(node.style["font-size"][:-2]), self.zoom)
 

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -128,7 +128,7 @@ and clearing the `line` field. We don't want to do all that---we just
 want to create a new `LineLayout` object. So let's use a different
 method for that:
 
-``` {.python indent=12}
+``` {.python indent=8}
 if self.cursor_x + w > self.width:
     self.new_line()
 ```

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -447,15 +447,14 @@ class BlockLayout:
         self.cursor_x += w + font(node.style, self.zoom).measureText(" ")
 ```
 
-We can redefine  `text` and `input` in a satisfying way now:
+We can redefine  `word` and `input` in a satisfying way now:
 
 ``` {.python replace=TextLayout/TextLayout%2c%20self.frame,InputLayout/InputLayout%2c%20self.frame}
 class BlockLayout:
-    def text(self, node):
+    def word(self, node, word):
         node_font = font(node.style, self.zoom)
-        for word in node.text.split():
-            w = node_font.measureText(word)
-            self.add_inline_child(node, w, TextLayout, word)
+        w = node_font.measureText(word)
+        self.add_inline_child(node, w, TextLayout, word)
 
     def input(self, node):
         w = device_px(INPUT_WIDTH_PX, self.zoom)

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -447,7 +447,7 @@ class BlockLayout:
         self.cursor_x += w + font(node.style, self.zoom).measureText(" ")
 ```
 
-We can redefine  `word` and `input` in a satisfying way now:
+We can redefine `word` and `input` in a satisfying way now:
 
 ``` {.python replace=TextLayout/TextLayout%2c%20self.frame,InputLayout/InputLayout%2c%20self.frame}
 class BlockLayout:

--- a/book/forms.md
+++ b/book/forms.md
@@ -188,7 +188,7 @@ We now need to create some `InputLayout`s, which we can do in
 class BlockLayout:
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            # ...
         else:
             if node.tag == "br":
                 self.new_line()

--- a/book/html.md
+++ b/book/html.md
@@ -572,7 +572,8 @@ Now we need the `Layout` object to walk the node tree, calling `open_tag`,
 ``` {.python indent=4}
 def recurse(self, tree):
     if isinstance(tree, Text):
-        self.text(tree)
+        for word in tree.text.split():
+            self.word(word)
     else:
         self.open_tag(tree.tag)
         for child in tree.children:

--- a/book/layout.md
+++ b/book/layout.md
@@ -368,12 +368,11 @@ measure; instead, we'll wrap lines when `cursor_x` reaches the block's
 
 ``` {.python}
 class BlockLayout:
-    def text(self, node):
-        for word in node.text.split():
+    def word(self, word):
+        # ...
+        if self.cursor_x + w > self.width:
             # ...
-            if self.cursor_x + w > self.width:
-                # ...
-            # ...
+        # ...
 ```
 
 So now that leaves us with the problem of computing these `x`, `y`,

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -244,7 +244,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.new_line()
@@ -261,20 +262,19 @@ class BlockLayout:
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def text(self, node):
+    def word(self, node, word):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         size = float(node.style["font-size"][:-2])
         font = get_font(size, weight, style)
-        for word in node.text.split():
-            w = font.measureText(word)
-            if self.cursor_x + w > self.width:
-                self.new_line()
-            line = self.children[-1]
-            text = TextLayout(node, word, line, self.previous_word)
-            line.children.append(text)
-            self.previous_word = text
-            self.cursor_x += w + font.measureText(" ")
+        w = font.measureText(word)
+        if self.cursor_x + w > self.width:
+            self.new_line()
+        line = self.children[-1]
+        text = TextLayout(node, word, line, self.previous_word)
+        line.children.append(text)
+        self.previous_word = text
+        self.cursor_x += w + font.measureText(" ")
 
     def input(self, node):
         w = INPUT_WIDTH_PX

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -447,7 +447,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.new_line()
@@ -464,20 +465,19 @@ class BlockLayout:
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def text(self, node):
+    def word(self, node, word):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         size = float(node.style["font-size"][:-2])
         font = get_font(size, weight, size)
-        for word in node.text.split():
-            w = font.measureText(word)
-            if self.cursor_x + w > self.width:
-                self.new_line()
-            line = self.children[-1]
-            text = TextLayout(node, word, line, self.previous_word)
-            line.children.append(text)
-            self.previous_word = text
-            self.cursor_x += w + font.measureText(" ")
+        w = font.measureText(word)
+        if self.cursor_x + w > self.width:
+            self.new_line()
+        line = self.children[-1]
+        text = TextLayout(node, word, line, self.previous_word)
+        line.children.append(text)
+        self.previous_word = text
+        self.cursor_x += w + font.measureText(" ")
 
     def input(self, node):
         w = INPUT_WIDTH_PX

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -158,7 +158,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.new_line()
@@ -175,20 +176,19 @@ class BlockLayout:
         new_line = LineLayout(self.node, self, last_line)
         self.children.append(new_line)
 
-    def text(self, node):
+    def word(self, node, word):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         size = device_px(float(node.style["font-size"][:-2]), self.zoom)
         font = get_font(size, weight, size)
-        for word in node.text.split():
-            w = font.measureText(word)
-            if self.cursor_x + w > self.width:
-                self.new_line()
-            line = self.children[-1]
-            text = TextLayout(node, word, line, self.previous_word)
-            line.children.append(text)
-            self.previous_word = text
-            self.cursor_x += w + font.measureText(" ")
+        w = font.measureText(word)
+        if self.cursor_x + w > self.width:
+            self.new_line()
+        line = self.children[-1]
+        text = TextLayout(node, word, line, self.previous_word)
+        line.children.append(text)
+        self.previous_word = text
+        self.cursor_x += w + font.measureText(" ")
 
     def input(self, node):
         w = device_px(INPUT_WIDTH_PX, self.zoom)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -226,7 +226,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.new_line()
@@ -260,11 +261,10 @@ class BlockLayout:
         self.previous_word = child
         self.cursor_x += w + font(node.style, self.zoom).measureText(" ")
 
-    def text(self, node):
+    def word(self, node, word):
         node_font = font(node.style, self.zoom)
-        for word in node.text.split():
-            w = node_font.measureText(word)
-            self.add_inline_child(node, w, TextLayout, self.frame, word)
+        w = node_font.measureText(word)
+        self.add_inline_child(node, w, TextLayout, self.frame, word)
 
     def input(self, node):
         w = device_px(INPUT_WIDTH_PX, self.zoom)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -446,13 +446,12 @@ class BlockLayout:
             w = IFRAME_WIDTH_PX + device_px(2, zoom)
         self.add_inline_child(node, w, IframeLayout, self.frame)
 
-    def text(self, node):
+    def word(self, node, word):
         zoom = self.zoom.read(notify=self.children)
         node_font = font(self.children, node.style, zoom)
-        for word in node.text.split():
-            w = node_font.measureText(word)
-            self.add_inline_child(
-                node, w, TextLayout, self.frame, word)
+        w = node_font.measureText(word)
+        self.add_inline_child(
+            node, w, TextLayout, self.frame, word)
 
     def new_line(self):
         self.previous_word = None

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -72,7 +72,8 @@ class Layout:
 
     def token(self, tok):
         if isinstance(tok, Text):
-            self.text(tok)
+            for word in tok.text.split():
+                self.word(word)
         elif tok.tag == "i":
             self.style = "italic"
         elif tok.tag == "/i":
@@ -95,14 +96,13 @@ class Layout:
             self.flush()
             self.cursor_y += VSTEP
         
-    def text(self, tok):
+    def word(self, word):
         font = get_font(self.size, self.weight, self.style)
-        for word in tok.text.split():
-            w = font.measure(word)
-            if self.cursor_x + w > WIDTH - HSTEP:
-                self.flush()
-            self.line.append((self.cursor_x, word, font))
-            self.cursor_x += w + font.measure(" ")
+        w = font.measure(word)
+        if self.cursor_x + w > WIDTH - HSTEP:
+            self.flush()
+        self.line.append((self.cursor_x, word, font))
+        self.cursor_x += w + font.measure(" ")
 
     def flush(self):
         if not self.line: return

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -155,7 +155,8 @@ class Layout:
 
     def recurse(self, tree):
         if isinstance(tree, Text):
-            self.text(tree)
+            for word in tree.text.split():
+                self.word(word)
         else:
             self.open_tag(tree.tag)
             for child in tree.children:
@@ -187,14 +188,13 @@ class Layout:
             self.flush()
             self.cursor_y += VSTEP
         
-    def text(self, node):
+    def word(self, word):
         font = get_font(self.size, self.weight, self.style)
-        for word in node.text.split():
-            w = font.measure(word)
-            if self.cursor_x + w > WIDTH - HSTEP:
-                self.flush()
-            self.line.append((self.cursor_x, word, font))
-            self.cursor_x += w + font.measure(" ")
+        w = font.measure(word)
+        if self.cursor_x + w > WIDTH - HSTEP:
+            self.flush()
+        self.line.append((self.cursor_x, word, font))
+        self.cursor_x += w + font.measure(" ")
 
     def flush(self):
         if not self.line: return

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -91,7 +91,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(word)
         else:
             self.open_tag(node.tag)
             for child in node.children:
@@ -123,14 +124,13 @@ class BlockLayout:
             self.flush()
             self.cursor_y += VSTEP
         
-    def text(self, node):
+    def word(self, word):
         font = get_font(self.size, self.weight, self.style)
-        for word in node.text.split():
-            w = font.measure(word)
-            if self.cursor_x + w > self.width:
-                self.flush()
-            self.line.append((self.cursor_x, word, font))
-            self.cursor_x += w + font.measure(" ")
+        w = font.measure(word)
+        if self.cursor_x + w > self.width:
+            self.flush()
+        self.line.append((self.cursor_x, word, font))
+        self.cursor_x += w + font.measure(" ")
 
     def flush(self):
         if not self.line: return

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -235,7 +235,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.flush()
@@ -249,15 +250,14 @@ class BlockLayout:
         size = int(float(node.style["font-size"][:-2]) * .75)
         return get_font(size, weight, style)
 
-    def text(self, node):
+    def word(self, node, word):
         color = node.style["color"]
         font = self.get_font(node)
-        for word in node.text.split():
-            w = font.measure(word)
-            if self.cursor_x + w > self.width:
-                self.flush()
-            self.line.append((self.cursor_x, word, font, color))
-            self.cursor_x += w + font.measure(" ")
+        w = font.measure(word)
+        if self.cursor_x + w > self.width:
+            self.flush()
+        self.line.append((self.cursor_x, word, font, color))
+        self.cursor_x += w + font.measure(" ")
 
     def flush(self):
         if not self.line: return

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -146,7 +146,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.new_line()
@@ -167,17 +168,16 @@ class BlockLayout:
         size = int(float(node.style["font-size"][:-2]) * .75)
         return get_font(size, weight, style)
 
-    def text(self, node):
+    def word(self, node, word):
         font = self.get_font(node)
-        for word in node.text.split():
-            w = font.measure(word)
-            if self.cursor_x + w > self.width:
-                self.new_line()
-            line = self.children[-1]
-            text = TextLayout(node, word, line, self.previous_word)
-            line.children.append(text)
-            self.previous_word = text
-            self.cursor_x += w + font.measure(" ")
+        w = font.measure(word)
+        if self.cursor_x + w > self.width:
+            self.new_line()
+        line = self.children[-1]
+        text = TextLayout(node, word, line, self.previous_word)
+        line.children.append(text)
+        self.previous_word = text
+        self.cursor_x += w + font.measure(" ")
 
     def paint(self, display_list):
         bgcolor = self.node.style.get("background-color",

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -183,7 +183,8 @@ class BlockLayout:
 
     def recurse(self, node):
         if isinstance(node, Text):
-            self.text(node)
+            for word in node.text.split():
+                self.word(node, word)
         else:
             if node.tag == "br":
                 self.new_line()
@@ -207,17 +208,16 @@ class BlockLayout:
         size = int(float(node.style["font-size"][:-2]) * .75)
         return get_font(size, weight, style)
 
-    def text(self, node):
+    def word(self, node, word):
         font = self.get_font(node)
-        for word in node.text.split():
-            w = font.measure(word)
-            if self.cursor_x + w > self.width:
-                self.new_line()
-            line = self.children[-1]
-            text = TextLayout(node, word, line, self.previous_word)
-            line.children.append(text)
-            self.previous_word = text
-            self.cursor_x += w + font.measure(" ")
+        w = font.measure(word)
+        if self.cursor_x + w > self.width:
+            self.new_line()
+        line = self.children[-1]
+        text = TextLayout(node, word, line, self.previous_word)
+        line.children.append(text)
+        self.previous_word = text
+        self.cursor_x += w + font.measure(" ")
 
     def input(self, node):
         w = INPUT_WIDTH_PX


### PR DESCRIPTION
This PR changes how text layout works a little bit. Currently, a whole `Text` node is passed a method called `text`, which splits it into words and adds each of those words to the current line. This PR changes it to a method called `word`, and moves the splitting and looping into the caller. The main advantage is that `word` is now similar in scope to other methods like `input`, `iframe`, `image`, and so on. The changes required are quite modest.