### PR TITLE
Pass on conclusion chapter

### DIFF
--- a/book/change.md
+++ b/book/change.md
@@ -9,7 +9,7 @@ The web is a dynamic, ever-changing place. The first web browser, in
 1989, did not support colors, images, styling, or scripting. Three
 decades of evolution driven by market forces, implementation quirks,
 and the ever-expanding reach of the web then made browsers what they
-are today. Those forces are as strong as ever.  Browsers will continue to evolve!
+are today. Those forces are as strong as ever.  Browsers continue to evolve!
 
 Sooner or later this book will be obsolete---the sooner the better!
 Whether it is WebAssembly or WebGPU, hardware access or new CSS

--- a/book/skipped.md
+++ b/book/skipped.md
@@ -79,12 +79,6 @@ level, connection security is established via the TLS protocol (which
 cameos in [Chapter 1](http.md)) and maintained by an ecosystem of
 cryptographers, certificate authorities, and open-source projects.
 
-[privacy]: https://developer.mozilla.org/en-US/docs/Web/Privacy
-
-[tpc]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#third-party_cookies
-
-[fingerprinting]: https://developer.mozilla.org/en-US/docs/Glossary/Fingerprinting
-
 I chose to skip an in-depth discussion of TLS because this book's
 irreverent attitude toward completeness and validation is incompatible
 with real security engineering. A minimal and incomplete version of
@@ -101,6 +95,12 @@ advertising. I chose to skip this topic because many basic concepts
 remain unsettled: what the standards of privacy are and what role
 governments, browser developers, website authors, and users should
 play in them.
+
+[privacy]: https://developer.mozilla.org/en-US/docs/Web/Privacy
+
+[tpc]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#third-party_cookies
+
+[fingerprinting]: https://developer.mozilla.org/en-US/docs/Glossary/Fingerprinting
 
 Network Caching and Media
 =========================

--- a/book/skipped.md
+++ b/book/skipped.md
@@ -12,11 +12,6 @@ such a vast topic I had to leave a few things out. Here's my list of
 the most important things not covered by this book, in no particular
 order.
 
-When I teach from this book, I often cover these topics in lecture.
-That not only saves me from ignoring important topics but also gives
-me the flexibility to cover topics where implementation would be
-inappropriate.
-
 JavaScript Execution
 ====================
 
@@ -44,41 +39,37 @@ Text rendering is much more complex than it may seem at the surface.
 Letters differ in widths and heights. Accents may need to be stacked
 atop characters. Characters may change shape by proximity to other
 characters, like for ligatures or for *shaping* (for cursive fonts).
-Sometimes languages are written right-to-left or top-to-bottom.
-Then there are typographic features, like kerning and variants. But
-the most complex of all is *hinting*, which is a little computer
-program embedded in a font that modifies it to better match the
-discrete pixel grid. Some of text rendering is in Skia, but a whole
-lot of it actually has to be done in layout to determine sizing and
-positions of content on the screen.
+Sometimes languages are written right-to-left or top-to-bottom. Then
+there are typographic features, like kerning and variants. But the
+most complex of all is *hinting*, which is a little computer program
+embedded in a font that modifies it to better match the discrete pixel
+grid. Text rendering of course affects Skia, but it also affects
+layout, determining the size and position of content on the screen.
 
-
-As for graphics in general, our toy browser ended up using Skia,
-which is the real rasterization engine of Chromium and some other
-browsers. But we didn't really talk at all about how Skia actually
-works (just how to use it and create surfaces for different pieces
-of the display list). Skia is, of course, a tremendously complex
-piece of software, which solves the problems of high-quality, fast text
-and shape rendering on basically all CPUs and GPU architectures. But
-even that is only part of the story. In addition to Skia, real browsers
-have a much more complicated and fancy compositing system, graphics
-process security sandboxing, and various platform-specific font and
-OS compositing integrations. And there is a whole lot of additional
-effort to support high-quality implementations
-of all details of JavaScript-exposed APIs like [Canvas], [WebGL], and
-[WebGPU].
+And more broadly, graphics in general is pretty complex! Our toy
+browser uses Skia, which is the real rasterization engine of Chromium
+and some other browsers. But we didn't really talk at all about how
+Skia actually works, and it turns out to be pretty complex. It not
+only renders text but applies all sorts of blends and effects quickly
+and with high quality on basically all CPUs and GPUs. In a real
+browser this becomes even more complex, with fancy compositing
+systems, graphics process security sandboxing, and various
+platform-specific font and OS compositing integrations. And there is a
+whole lot of additional effort to implementation lower-level
+JavaScript-exposed APIs like [Canvas], [WebGL], and [WebGPU].
 
 [Canvas]: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API
 [WebGL]: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API
 [WebGPU]: https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API
 
-Text and graphics rendering are always available in system libraries, and
-implementing them is very difficult and arguably not browser-specific, so
-it seemed reasonable to skip them in this book. A book on these
-subjects is the best place to learn more.
+I skipped this topic in the book because high-quality implementations
+are available in libraries like Skia (for graphics) and Harfbuzz (for
+text), as well as various system libraries, so are arguably not
+browser-specific. But there is a depth here best served by a book on
+these specific subjects.
 
-Connection Security
-===================
+Connection Security & Privacy
+=============================
 
 Web browsers now ship with a sophisticated suite of cryptographic
 protocols with bewildering names like AES-GCM, ChaCha20, and
@@ -88,69 +79,85 @@ level, connection security is established via the TLS protocol (which
 cameos in [Chapter 1](http.md)) and maintained by an ecosystem of
 cryptographers, certificate authorities, and open-source projects.
 
+[privacy]: https://developer.mozilla.org/en-US/docs/Web/Privacy
+
+[tpc]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#third-party_cookies
+
+[fingerprinting]: https://developer.mozilla.org/en-US/docs/Glossary/Fingerprinting
+
 I chose to skip an in-depth discussion of TLS because this book's
 irreverent attitude toward completeness and validation is incompatible
 with real security engineering. A minimal and incomplete version of
-TLS is a broken and insecure version of it: contrary to the intended
+TLS is a broken and insecure version of it, contrary to the intended
 goal and pedagogically counterproductive. The best way to learn about
 modern cryptography and network security is a book on that topic.
 
-Network Caching
-===============
+[Privacy on the web][privacy] is another important topic that I
+skipped. In some ways security and privacy are related (and certainly
+complement one other), but they are not the same. And privacy on the
+web is in flux, such as debates around [third-party cookies][tpc],
+[fingerprinting], and whether there should be APIs to help with
+advertising. I chose to skip this topic because many basic concepts
+remain unsettled: what the standards of privacy are and what role
+governments, browser developers, website authors, and users should
+play in them.
+
+Network Caching and Media
+=========================
 
 Caching makes network requests faster by skipping most of them. What
 makes it more than a mere optimization, however, is the extent to
 which HTTP is designed to enable caching. Implementing a network cache
-deepens one's understanding of HTTP significantly.
+deepens one's understanding of HTTP significantly. That said, the
+networking portion of this book is long enough, and at no point in the
+book did the lack of a cache feel painful, so I decided to leave this
+topic out.
 
-That said, the networking portion of this book is long enough, and at
-no point in the book did the lack of a cache feel painful, so I
-decided to leave this topic out. Nor, sadly, did I find a chapter
-where caching would make a good exercise.
-
-Browser UI
-==========
-
-A real browser has a *much* more complex and powerful "browser UI"---meaning
-the chrome around the web page, where you can enter URLs, see tabs, and so
-on---than our toy browser. In fact, a pretty big proportion of a real browser
-team works just on this, and not on the "web platform" itself. The challenges
-of browser UI are mostly the same as any other application, except for the
-multi-process nature of a modern browser, which can make things like
-integration with synchronous OS APIs very difficult.^[A well-known example
-is accessibility, which I touched on in [Chapter 14](accessibility.md#the-accessibility-tree).]
-
-Media
-=====
-
-There is a whole world of complexity in real-time video encoding, decoding and
-rendering. Real browsers have large teams devoted to these services and APIs,
-since most network bandwidth and battery life is eaten up by video
-and video conferencing these days. This book skips it entirely, and I suggest
+And since the majority of network bandwidth and battery life is today
+eaten up by video playback and video conferencing, there is a whole
+world of complexity in real-time video encoding, decoding and
+rendering. Real browsers have large teams devoted to these services
+and APIs, and many researchers across the world work on video
+compression. Video codecs are fascinating, but again not very
+browser-specific, so this book skips it entirely, and I suggest
 dedicated books on these subjects.
 
-Debugging & Extensions
-======================
+Browser UIs and Developer tools
+===============================
 
-It'd be almost impossible to build complex web apps without some kind of
-debugging aid. But believe it or not, there were not actually any good web
-page debuggers for quite a long time---just a lot of [printf debugging][printf].
-This changed in a big way with the advent of debuggers built into web browsers,
-starting with the innovative [Firebug] browser extension for Firefox. Today
-such debuggers are indispensable for a real browser, and integrating one
-is quite challenging and interesting.^[For example, to implement features like
-observing the styles of elements in real time, pausing/stepping through
-execution, and being written in HTML themselves.]
+A real browser has a *much* more complex and powerful "browser
+UI"---meaning the chrome around the web page, where you can enter
+URLs, see tabs, and so on---than our toy browser. In fact, a large
+fraction of a real browser team works just on this, and not on the
+"web platform" itself. The multi-process nature of a modern browser
+also makes it difficult to interact with synchronous OS APIs, as we
+saw with accessibility in [Chapter
+14](accessibility.md#the-accessibility-tree). Plus, many browsers
+(desktop ones, at least) support powerful [extension
+APIs](https://en.wikipedia.org/wiki/Browser_extension) that enable
+developers to extend the browser UI. To help with that, browser UIs
+are often implemented in HTML and rendered by the browser itself.
+
+Also, it'd be almost impossible to build complex web apps without some
+kind of debugging aid, so all real browsres have built-in debuggers.
+Believe it or not, for quite a long time browser engineers just did a
+lot of [printf debugging][printf]. This changed in a big way with the
+innovative [Firebug] browser extension for Firefox, and eventually
+today's integrated developer tools. These developer tools have deep
+integration with the browser engine itself to implement features like
+observing the styles of elements in real time or pausing and stepping
+through JavaScript execution.
 
 [printf]: https://en.wikipedia.org/wiki/Debugging#printf_debugging
 [firebug]: https://en.wikipedia.org/wiki/Firebug_(software)
 
-All real browsers (desktop ones, at least) support powerful
-[extension APIs](https://en.wikipedia.org/wiki/Browser_extension)
-that allow developers to inject JavaScript into web pages to add useful
-features. Implementing these APIs, and in a relatively secure and performant
-way, is very challenging. I'm not aware of a book on this topic; conceptually
-it is somewhat similar to building a debugger.
+I skipped this topic because many challenges in browser UI are the
+same those of as any other UI: design, usability, complexity, and so
+on. That would make for a tedious book. Even the debugger,
+conceptually quite interesting, is only useful if a substantial amount
+of UI work is done to make it usable. Unfortunately, I'm not aware of
+any book on developer tools, but many books will cover basic user
+interface development.
 
 Testing
 =======
@@ -171,21 +178,3 @@ extensive [frameworks][testing-features] to make testing easy.
 [integration]: https://en.wikipedia.org/wiki/Integration_testing
 [interoperability]: https://wpt.fyi/interop-2023
 [testing-features]: https://web-platform-tests.org/
-
-Privacy
-=======
-
-[Privacy on the web](https://developer.mozilla.org/en-US/docs/Web/Privacy)
-is an important topic, and one we have not covered at all. In some ways
-security and privacy are related (and certainly complement one other),
-but they are not the same, and I haven't covered the latter at all. Privacy
-is also a tricky subject, because it involves additional concepts such as what
-does or does not constitute privacy, or what changes the web should take to
-increase privacy, that are actively debated today. For example, there are
-debates about what to do if [third-party cookies][tpc] are removed, reduce
-the risk of [fingerprinting], and whether there should be APIs to help with
-advertising use cases.
-
-[tpc]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#third-party_cookies
-
-[fingerprinting]: https://developer.mozilla.org/en-US/docs/Glossary/Fingerprinting


### PR DESCRIPTION
This PR does a pass over the `skipped.md` chapter. The main goal was to make all of the sections similar in scope by merging some of the smaller ones, but there were various minor textual tweaks too.