### PR TITLE
Generate all chapters into one book output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,23 +41,23 @@ PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-
 
 PANDOC_LATEX=pandoc --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json $(FLAGS)
 
+# Generates a simple chapter latex rendering meant to be inserted into the larger book skeleton.
 latex-chapters: $(patsubst %,latex/%-chapter.tex,$(CHAPTERS))
 latex/%-chapter.tex:  book/%.md infra/template-chapter.tex infra/filter.lua config.json
 	$(PANDOC_LATEX)  --metadata=mode:book --template infra/template-chapter.tex  $< -o $@
 
+# Generates a skeleton latex output that has all of the setup necessary to render chapters.
 latex/book-skeleton.tex: $(patsubst %,book/%.md,$(CHAPTERS)) infra/template-book.tex infra/filter.lua config.json
-	$(PANDOC_LATEX) --file-scope --metadata=mode:book --template infra/template-book.tex $(patsubst %,book/%.md,$(CHAPTERS)) -o latex/book-skeleton.tex
+	$(PANDOC_LATEX) --file-scope --template infra/template-book.tex $(patsubst %,book/%.md,$(CHAPTERS)) -o latex/book-skeleton.tex
 
-latex/book-content.tex: latex-chapters
-	cat $(patsubst %,latex/%-chapter.tex,$(CHAPTERS)) > latex/book-contents.tex
-
+# Inserts the chapters into the book skeleton.
 latex/book.tex: latex/book-skeleton.tex latex-chapters
 	cat $(patsubst %,latex/%-chapter.tex,$(CHAPTERS)) > latex/book-contents.tex
 	sed '/---Contents---/r latex/book-contents.tex' latex/book-skeleton.tex > latex/book.tex
 	rm latex/book-contents.tex
 	sed -i '/---Contents---/d' latex/book.tex
 
-book.pdf: latex/book.tex
+latex/book.pdf: latex/book.tex
 	(cd latex && pdflatex book.tex)
 
 www/%.html: book/%.md infra/template.html infra/signup.html infra/filter.lua config.json

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@
 
 FLAGS=
 
-CHAPTERS=$(patsubst book/%.md,%,$(wildcard book/*.md))
+CHAPTERS=about preface intro history http graphics text html \
+layout styles chrome forms scripts security visual-effects \
+scheduling animations accessibility embeds invalidation skipped \
+change glossary bibliography
 
 EXAMPLE_HTML=$(patsubst src/example%.html,%,$(wildcard src/example*.html))
 EXAMPLE_JS=$(patsubst src/example%.js,%,$(wildcard src/example*.js))
 EXAMPLE_CSS=$(patsubst src/example%.css,%,$(wildcard src/example*.css))
 
-latex: $(patsubst %,latex/%.tex,$(CHAPTERS))
 book: $(patsubst %,www/%.html,$(CHAPTERS)) www/rss.xml widgets examples
 draft: $(patsubst %,www/draft/%.html,$(CHAPTERS)) www/onepage.html widgets
 examples: $(patsubst %,www/examples/example%.html,$(EXAMPLE_HTML)) \
@@ -39,9 +41,24 @@ PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-
 
 PANDOC_LATEX=pandoc --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json $(FLAGS)
 
-latex/%.tex:  book/%.md infra/template.tex infra/filter.lua config.json
-	$(PANDOC_LATEX)  --metadata=mode:book --template infra/template.tex  $< -o $@
-	(cd latex && pdflatex ../$@)
+latex-chapters: $(patsubst %,latex/%-chapter.tex,$(CHAPTERS))
+latex/%-chapter.tex:  book/%.md infra/template-chapter.tex infra/filter.lua config.json
+	$(PANDOC_LATEX)  --metadata=mode:book --template infra/template-chapter.tex  $< -o $@
+
+latex/book-skeleton.tex: $(patsubst %,book/%.md,$(CHAPTERS)) infra/template-book.tex infra/filter.lua config.json
+	$(PANDOC_LATEX) --file-scope --metadata=mode:book --template infra/template-book.tex $(patsubst %,book/%.md,$(CHAPTERS)) -o latex/book-skeleton.tex
+
+latex/book-content.tex: latex-chapters
+	cat $(patsubst %,latex/%-chapter.tex,$(CHAPTERS)) > latex/book-contents.tex
+
+latex/book.tex: latex/book-skeleton.tex latex-chapters
+	cat $(patsubst %,latex/%-chapter.tex,$(CHAPTERS)) > latex/book-contents.tex
+	sed '/---Contents---/r latex/book-contents.tex' latex/book-skeleton.tex > latex/book.tex
+	rm latex/book-contents.tex
+	sed -i '/---Contents---/d' latex/book.tex
+
+book.pdf: latex/book.tex
+	(cd latex && pdflatex book.tex)
 
 www/%.html: book/%.md infra/template.html infra/signup.html infra/filter.lua config.json
 	$(PANDOC) --toc --metadata=mode:book --template infra/template.html -c book.css $< -o $@

--- a/book/book.md
+++ b/book/book.md
@@ -1,0 +1,5 @@
+---
+title: Web Browser Engineering
+documentclass: book
+...
+Contents

--- a/book/book.md
+++ b/book/book.md
@@ -1,5 +1,0 @@
----
-title: Web Browser Engineering
-documentclass: book
-...
-Contents

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -567,7 +567,6 @@ direction to scroll. Unfortunately, Mac and Windows give the
 `event.delta` objects opposite sign and different scales, and on
 Linux, scrolling instead uses the `<Button-4>` and `<Button-5>`
 events.[^more-mousewheel]
-
 [^why-only-top]: It's harder to stop scrolling past the bottom of the
     page; we will implement this in [Chapter 5](layout.md)
 
@@ -580,7 +579,8 @@ events.[^more-mousewheel]
 
 [tk-mousewheel]: https://wiki.tcl-lang.org/page/mousewheel
 
-*Emoji*: Add support for emoji 😀 to our browser. Emoji are
+
+*Emoji*: Add support for emoji to our browser. Emoji are
 characters, and you can call `create_text` to draw them, but the
 results aren't very good. Instead, head to [the OpenMoji
 project](https://openmoji.org), download the emoji for ["grinning

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -567,6 +567,7 @@ direction to scroll. Unfortunately, Mac and Windows give the
 `event.delta` objects opposite sign and different scales, and on
 Linux, scrolling instead uses the `<Button-4>` and `<Button-5>`
 events.[^more-mousewheel]
+
 [^why-only-top]: It's harder to stop scrolling past the bottom of the
     page; we will implement this in [Chapter 5](layout.md)
 

--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -13,7 +13,9 @@
 % ---- NOTE(chrishtr): The default pandoc latex template is below. Everything
 % above this line is our custom add-on. The template below *may* change with
 % future pandoc releases; to regenerate it, paste the output of
-% `pandoc -D latex` below.
+% `pandoc -D latex` below, then replace $$body$$ with "Book contents go here".
+% This text will be replaced via Makefile commands with the actual
+% book chapter contents.
 
 % Options for packages loaded elsewhere
 \PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}
@@ -44,7 +46,7 @@ $endif$
 $for(classoption)$
   $classoption$$sep$,
 $endfor$
-]{$documentclass$}
+]{book}
 $if(beamer)$
 $if(background-image)$
 \usebackgroundtemplate{%
@@ -466,7 +468,7 @@ $endif$
   pdfcreator={LaTeX via pandoc}}
 
 $if(title)$
-\title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
+\title{Web Browser Engineering$if(thanks)$\thanks{$thanks$}$endif$}
 $endif$
 $if(subtitle)$
 $if(beamer)$
@@ -548,7 +550,8 @@ $endif$
 $if(has-frontmatter)$
 \mainmatter
 $endif$
-$body$
+
+---Contents---
 
 $if(has-frontmatter)$
 \backmatter

--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -2,7 +2,7 @@
 % above this line is our custom add-on. The template below *may* change with
 % future pandoc releases. To regenerate it, paste the output of
 % `pandoc -D latex` below, then:
-% * replace the body template with "Contents" and three dashes around each side;
+% * Replace the body template with "Contents" and three dashes around each side;
 %   this text will be replaced via Makefile commands with the actual
 %   book chapter contents.
 % * Add the CJKutf8 package.

--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -13,7 +13,8 @@
 % ---- NOTE(chrishtr): The default pandoc latex template is below. Everything
 % above this line is our custom add-on. The template below *may* change with
 % future pandoc releases; to regenerate it, paste the output of
-% `pandoc -D latex` below, then replace $$body$$ with "Book contents go here".
+% `pandoc -D latex` below, then replace $$body$$ with "Contents" and three
+% dashes around each side.
 % This text will be replaced via Makefile commands with the actual
 % book chapter contents.
 

--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -1,22 +1,11 @@
-% TODO(chrishtr): find a way to render these characters.
-% Some are Chinese, some unusual characters, and one a special
-% space character.
-\DeclareUnicodeCharacter{FFFD}{ }
-\DeclareUnicodeCharacter{897F}{ }
-\DeclareUnicodeCharacter{6E38}{ }
-\DeclareUnicodeCharacter{8BB0}{ }
-\DeclareUnicodeCharacter{5F00}{ }
-\DeclareUnicodeCharacter{5173}{ }
-\DeclareUnicodeCharacter{1F600}{ }
-
-
 % ---- NOTE(chrishtr): The default pandoc latex template is below. Everything
 % above this line is our custom add-on. The template below *may* change with
-% future pandoc releases; to regenerate it, paste the output of
-% `pandoc -D latex` below, then replace $$body$$ with "Contents" and three
-% dashes around each side.
-% This text will be replaced via Makefile commands with the actual
-% book chapter contents.
+% future pandoc releases. To regenerate it, paste the output of
+% `pandoc -D latex` below, then:
+% * replace the body template with "Contents" and three dashes around each side;
+%   this text will be replaced via Makefile commands with the actual
+%   book chapter contents.
+% * Add the CJKutf8 package.
 
 % Options for packages loaded elsewhere
 \PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}
@@ -48,6 +37,10 @@ $for(classoption)$
   $classoption$$sep$,
 $endfor$
 ]{book}
+
+\usepackage{CJKutf8}
+
+
 $if(beamer)$
 $if(background-image)$
 \usebackgroundtemplate{%
@@ -498,6 +491,7 @@ $endif$
 $endif$
 
 \begin{document}
+\begin{CJK}{UTF8}{gbsn}
 $if(has-frontmatter)$
 \frontmatter
 $endif$
@@ -592,4 +586,5 @@ $for(include-after)$
 $include-after$
 
 $endfor$
+\end{CJK}
 \end{document}

--- a/infra/template-chapter.tex
+++ b/infra/template-chapter.tex
@@ -1,0 +1,4 @@
+
+
+\chapter{$title$}
+$body$


### PR DESCRIPTION
This PR creates a latex file for the whole book. It works as follows:

1. Generates a simple sub-template for each chapter named `latex/<chapter name>-chapter.tex`
2. Generates a skeleton overall latex output for the book named `latex/book-skeleton.tex`. This is done by running all of the chapters together through pandoc with a latex output mode, and then throwing away the actual chapter content. This has the effect of including all definitions and packages from `template-book.tex` that are necessary to render any of the chapters
3. Inserts the sub-templates from the chapters into the output of step 2, resulting in `book.tex` for the entire book
4. Renders `book.tex` into a PDF

Also adds support for Chinese characters to the template, and removes one emoji character that is hard to render.

I installed the `texlive-lang-cjk` Debian package, which contains CJK fonts.