### PR TITLE
Create an index and add some of the glossary entries to it

### DIFF
--- a/book/glossary.md
+++ b/book/glossary.md
@@ -53,7 +53,7 @@ others.
 *Web*: Simplified name for the WWW.
 
 *Web browser*: A software program that allows people to load and
-navigate web pages.
+navigate web pages. Also often just called a "browser".
 
 *Web page*: The basic unit of the web; defined by unique URL.
 
@@ -61,7 +61,7 @@ navigate web pages.
 resources, but so are many of their component parts, such as scripts,
 images, and style sheets.
 
-*Web site*: A collection of web pages that together provide some user
+*Website*: A collection of web pages that together provide some user
 service.
 
 *WWW*: World Wide Web. A name for the network of web pages built on

--- a/book/history.md
+++ b/book/history.md
@@ -6,9 +6,9 @@ prev: intro
 ...
 
 If you've read this far, hopefully you're convinced that browsers are
-interesting and important to study. Now we'll dig a bit into the web itself,
-where it came from, and how the web and browsers have evolved to date. This
-history is by no means exhaustive.[^sgml] Instead, it'll focus on some key
+interesting and important to study. Now we'll dig a bit into the web\index{web}
+itself, where it came from, and how the web and browsers have evolved to date.
+This history is by no means exhaustive.[^sgml] Instead, it'll focus on some key
 events and ideas that led to the web. These ideas and events will explain how
 exactly a thing such as the web came to be, as well as the motivations and goals
 of those who created it and its predecessors.
@@ -82,7 +82,7 @@ what the web can do today.
 The web emerges
 ===============
 
-The concept of [hypertext][hypertext] documents linked by
+The concept of [hypertext][hypertext]\index{hypertext} documents linked by
 [hyperlinks][hyperlink] was invented in 1964-65 by [Project Xanadu][xanadu], led
 by Ted Nelson.[^literary-criticism] Hypertext is text that is marked up with
 hyperlinks to other text. A successor called the [Hypertext Editing System] was
@@ -98,10 +98,10 @@ criticism in academic and literary communities. The Project Xanadu research
 papers were heavily motivated by this use case.
 
 Hypertext is text that is marked up with hyperlinks to other text. Sounds
-familiar? A web page is hypertext, and links between web pages are hyperlinks.
-The format for writing web pages is HTML, which is short for HyperText Markup
-Language. The protocol for loading web pages is HTTP, which is short for
-HyperText Transport Protocol.
+familiar? A web page\index{web page} is hypertext, and links between web pages
+are hyperlinks. The format for writing web pages is HTML, which is short for
+HyperText Markup Language. The protocol for loading web pages is HTTP, which is
+short for HyperText Transport Protocol.
 
 <figure>
 	<img src="im/hes.jpg" alt="A computer operator using a hypertext editing system in 1969">
@@ -160,14 +160,14 @@ just text, unlike most predecessors.
 [^world-wide-web-terminology]: Nowadays the World Wide Web is called just “the
 web”, or “the web ecosystem”---ecosystem being another way to capture the same
 concept as “World Wide”. The original wording lives on in the "www" in many
-website domain names.
+website\index{website} domain names.
 
 [^realize-web-decades]: Just as the web itself is a realization of previous
 ambitions and dreams, today we strive to realize the vision laid out by the web.
 (No, it's not done yet!)
 
-In 1989-1990, the first web browser (named “WorldWideWeb”) and web server (named
-“`httpd`”, for “HTTP Daemon” according to UNIX naming conventions) were born,
+In 1989-1990, the first web browser\index{web browser} (named “WorldWideWeb”)
+and web server (named “`httpd`”, for “HTTP Daemon” according to UNIX naming conventions) were born,
 written by Tim Berners-Lee. Interestingly, while that browser’s capabilities
 were in some ways inferior to the browser you will implement in this
 book,[^no-css] in other ways they go beyond the capabilities available even in
@@ -309,20 +309,20 @@ Web standards
 
 In parallel with these developments was another, equally important, one---the
 standardization of web APIs. In October 1994, the [World Wide Web
-Consortium](https://www.w3.org/Consortium/facts) (W3C) was founded to provide
-oversight and standards for web features. Prior to this point, browsers would
-often introduce new HTML elements or APIs, and competing browsers would have to
-copy them. With a standards organization, those elements and APIs could
-subsequently be agreed upon and documented in specifications. (These days, an
-initial discussion, design and specification precedes any new feature.) Later
+Consortium](https://www.w3.org/Consortium/facts) (W3C)\index{W3C} was founded
+to provide oversight and standards for web features. Prior to this point,
+browsers would often introduce new HTML elements or APIs, and competing browsers would have to copy them. With a standards organization, those elements and APIs
+could subsequently be agreed upon and documented in specifications. (These days,
+an initial discussion, design and specification precedes any new feature.) Later
 on, the HTML specification ended up moving to a different standards body called
-the [WHATWG](https://whatwg.org/), but [CSS](https://drafts.csswg.org/) and
-other features are still standardized at the W3C. JavaScript is standardized at
-[TC39](https://tc39.es/) (“Technical Committee 39” at
+the [WHATWG](https://whatwg.org/)\index{WHATWG}, but
+[CSS](https://drafts.csswg.org/) and other features are still standardized at
+the W3C. JavaScript is standardized at [TC39](https://tc39.es/)\index{TC39}
+(“Technical Committee 39” at
 [ECMA](https://www.ecma-international.org/about-ecma/history/), yet another
 standards body). [HTTP](https://tools.ietf.org/html/rfc2616) is standardized by
-the [IETF](https://www.ietf.org/about/). The point is that the standards process
-set up in the mid-nineties is still with us.
+the [IETF](https://www.ietf.org/about/)\index{IETF}. The point is that the
+standards process set up in the mid-nineties is still with us.
 
 In the first years of the web, it was not so clear that browsers would remain
 standard and that one browser might not end up “winning” and becoming another

--- a/book/http.md
+++ b/book/http.md
@@ -12,7 +12,7 @@ from a server somewhere on the Internet.
 Connecting to a server
 ======================
 
-Browsing the internet starts with a URL,[^url] a short string that
+Browsing the internet starts with a URL\index{URL},[^url] a short string that
 identifies a particular web page that the browser should visit. A URL
 looks like this:
 
@@ -109,16 +109,18 @@ should type it into `telnet`:
 
 Make sure to type a blank line after the `Host` line.
 
-Here, the word `GET` means that the browser would like to receive
+Here, the word `GET`\index{GET} means that the browser would like to receive
 information,[^11] then comes the path, and finally there is the word
 `HTTP/1.0` which tells the host that the browser speaks version 1.0 of
-HTTP.[^12] There are several versions of HTTP ([0.9, 1.0, 1.1, and
+[HTTP]\index{HTTP}.[^12] There are several versions of HTTP ([0.9, 1.0, 1.1, and
 2.0](https://medium.com/platform-engineer/evolution-of-http-69cfe6531ba0)).
 The HTTP 1.1 standard adds a variety of useful features, like
 keep-alive, but in the interest of simplicity our browser won't use
 them. We're also not implementing HTTP 2.0; HTTP 2.0 is much more
 complex than the 1.X series, and is intended for large and complex web
 applications, which our browser can't run anyway.
+
+[HTTP]: https://developer.mozilla.org/en-US/docs/Web/HTTP
 
 After the first line, each line contains a *header*, which has a name
 (like `Host`) and a value (like `example.org`). Different headers mean
@@ -211,11 +213,13 @@ server (`Server`, `X-Cache`), about how long the browser should cache
 this information (`Cache-Control`, `Expires`, `Etag`), about all sorts
 of other stuff. Let's move on for now.
 
-After the headers there is a blank line followed by a bunch of HTML
-code. This is called the *body* of the server's response, and your
-browser knows that it is HTML because of the `Content-Type` header,
-which says that it is `text/html`. It's this HTML code that contains
-the content of the web page itself.
+After the headers there is a blank line followed by a bunch of
+[HTML]\index{HTML} code. This is called the *body* of the server's
+response, and your browser knows that it is HTML because of the
+`Content-Type` header, which says that it is `text/html`. It's this HTML
+code that contains the content of the web page itself.
+
+[html]:  https://developer.mozilla.org/en-US/docs/Web/HTML
 
 Let's now switch gears from manual connections to Python.
 
@@ -621,15 +625,15 @@ Encrypted connections
 
 So far, our browser supports the `http` scheme. That's pretty good:
 it's the most common scheme on the web today. But more and more,
-websites are migrating to the `https` scheme. I'd like this toy
-browser to support `https` because many websites today require it.
+websites are migrating to the `https`\index{HTTPS} scheme. I'd like this
+toy browser to support `https` because many websites today require it.
 
 The difference between `http` and `https` is that `https` is more
 secure---but let's be a little more specific. The `https` scheme, or
-more formally HTTP over TLS, is identical to the normal `http` scheme,
-except that all communication between the browser and the host is
-encrypted. There are quite a few details to how this works: which
-encryption algorithms are used, how a common encryption key is agreed
+more formally HTTP over TLS\index{TLS}\index{SSL}, is identical to the
+normal `http` scheme, except that all communication between the browser
+and the host is encrypted. There are quite a few details to how this works:
+which encryption algorithms are used, how a common encryption key is agreed
 to, and of course how to make sure that the browser is connecting to
 the correct host.
 

--- a/book/security.md
+++ b/book/security.md
@@ -567,7 +567,7 @@ user = x.responseText.split(" ")[2].split("<")[0];
 ```
 
 The issue here is that one server's web page content is being sent to
-a script running on a web site delivered by another server. Since the
+a script running on a website delivered by another server. Since the
 content is derived from cookies, this leaks private data.
 
 To prevent issues like this, browsers have a [*same-origin

--- a/book/styles.md
+++ b/book/styles.md
@@ -7,7 +7,7 @@ next: chrome
 
 In the [last chapter](layout.md), we gave each `pre` element a gray
 background. It looks OK, and it *is* good to have defaults... but of
-course sites want a say in how they look. Web sites do that with
+course sites want a say in how they look. Websites do that with
 _Cascading Style Sheets_, which allow web authors (and, as we'll see,
 browser developers) to define how a web page ought to look.
 

--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -38,8 +38,9 @@ $for(classoption)$
 $endfor$
 ]{book}
 
+\usepackage{imakeidx}
+\makeindex
 \usepackage{CJKutf8}
-
 
 $if(beamer)$
 $if(background-image)$
@@ -587,4 +588,5 @@ $include-after$
 
 $endfor$
 \end{CJK}
+\printindex
 \end{document}


### PR DESCRIPTION
The latex commands are ignored by pandoc when compiling to HTML.

I only looked at glossary entries referenced in chapter 1/history for now, the rest will be in subsequent PRs.