### PR TITLE
Move `layout_mode` to be a method on `BlockLayout`

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -240,19 +240,20 @@ behavior within an inline context. These are also two examples of
 We can fix that with this change to `layout_mode`:
 
 ``` {.python}
-def layout_mode(node):
-    if isinstance(node, Text):
-        return "inline"
-    elif node.children:
-        for child in node.children:
-            if isinstance(child, Text): continue
-            if child.tag in BLOCK_ELEMENTS:
-                return "block"
-        return "inline"
-    elif node.tag == "input":
-        return "inline"
-    else:
-        return "block"
+class BlockLayout:
+    def layout_mode(self):
+        if isinstance(self.node, Text):
+            return "inline"
+        elif self.node.children:
+            for child in self.node.children:
+                if isinstance(child, Text): continue
+                if child.tag in BLOCK_ELEMENTS:
+                    return "block"
+            return "inline"
+        elif self.node.tag == "input":
+            return "inline"
+        else:
+            return "block"
 ```
 
 The second problem is that, again due to having block siblings, sometimes an

--- a/book/layout.md
+++ b/book/layout.md
@@ -197,18 +197,19 @@ of content its HTML node contains: text and text-related tags like
 like this:
 
 ``` {.python}
-def layout_mode(node):
-    if isinstance(node, Text):
-        return "inline"
-    elif node.children:
-        if any([isinstance(child, Element) and \
-                child.tag in BLOCK_ELEMENTS
-                for child in node.children]):
-            return "block"
-        else:
+class BlockLayout:
+    def layout_mode(self):
+        if isinstance(self.node, Text):
             return "inline"
-    else:
-        return "block"
+        elif self.node.children:
+            if any([isinstance(child, Element) and \
+                    child.tag in BLOCK_ELEMENTS
+                    for child in self.node.children]):
+                return "block"
+            else:
+                return "inline"
+        else:
+            return "block"
 ```
 
 Here the list of `BLOCK_ELEMENTS` is basically what you expect, a list
@@ -230,7 +231,7 @@ BLOCK_ELEMENTS = [
 ]
 ```
 
-Our `layout_mode` function has to handle one tricky case, where a node
+Our `layout_mode` method has to handle one tricky case, where a node
 contains both block children like a `<p>` element but also text
 children like a text node or a `<b>` element. I've chosen to use block
 mode in this case, but it's probably best to think of this as a kind
@@ -250,7 +251,7 @@ the `layout_mode` of its HTML node:
 ``` {.python}
 class BlockLayout:
     def layout(self):
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             previous = None
             for child in self.node.children:

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -19,7 +19,7 @@ from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
 from lab8 import URL, Browser, Text, Element
-from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode
+from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE, JSContext, Tab
 import wbetools
 

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -19,7 +19,7 @@ from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
-from lab8 import Text, Element, BlockLayout, InputLayout, INPUT_WIDTH_PX, layout_mode, Browser
+from lab8 import Text, Element, BlockLayout, InputLayout, INPUT_WIDTH_PX, Browser
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL, JSContext, Tab
 import wbetools

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -23,7 +23,7 @@ from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import tree_to_list
 from lab7 import CHROME_PX
-from lab8 import Text, Element, INPUT_WIDTH_PX, layout_mode
+from lab8 import Text, Element, INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL
 from lab11 import get_font, FONTS, DrawLine, DrawRect, DrawOutline, linespace, DrawText, SaveLayer, ClipRRect

--- a/src/lab13.hints
+++ b/src/lab13.hints
@@ -29,5 +29,6 @@
  {"code": "'style' in node.attributes", "type": "dict"},
  {"code": "property in ANIMATED_PROPERTIES", "type": "list"},
  {"code": "node in self.composited_updates", "type": "list"},
- {"code": "old_transitions", "type": "dict"}
+ {"code": "old_transitions", "type": "dict"},
+ {"code": "child.tag in BLOCK_ELEMENTS", "type": "list"}
 ]

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -24,7 +24,7 @@ from lab6 import TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, cascade_priority
 from lab6 import tree_to_list
 from lab7 import CHROME_PX
-from lab8 import Text, Element, INPUT_WIDTH_PX, layout_mode
+from lab8 import Text, Element, INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, parse_color, parse_blend_mode, linespace
@@ -428,7 +428,7 @@ class BlockLayout:
         else:
             self.y = self.parent.y
 
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             previous = None
             for child in self.node.children:
@@ -443,6 +443,20 @@ class BlockLayout:
             child.layout()
 
         self.height = sum([child.height for child in self.children])
+
+    def layout_mode(self):
+        if isinstance(self.node, Text):
+            return "inline"
+        elif self.node.children:
+            for child in self.node.children:
+                if isinstance(child, Text): continue
+                if child.tag in BLOCK_ELEMENTS:
+                    return "block"
+            return "inline"
+        elif self.node.tag == "input":
+            return "inline"
+        else:
+            return "block"
 
     def recurse(self, node):
         if isinstance(node, Text):
@@ -520,7 +534,7 @@ class BlockLayout:
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
-            layout_mode(self.node), self.x, self.y, self.width, self.height, self.node)
+            self.layout_mode(), self.x, self.y, self.width, self.height, self.node)
 
 class DocumentLayout:
     def __init__(self, node):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -31,7 +31,7 @@ from lab6 import TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES
 from lab6 import tree_to_list
 from lab7 import CHROME_PX
-from lab8 import INPUT_WIDTH_PX, layout_mode
+from lab8 import INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, parse_blend_mode, linespace
@@ -139,7 +139,7 @@ class BlockLayout:
         else:
             self.y = self.parent.y
 
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             previous = None
             for child in self.node.children:
@@ -154,6 +154,20 @@ class BlockLayout:
             child.layout()
 
         self.height = sum([child.height for child in self.children])
+
+    def layout_mode(self):
+        if isinstance(self.node, Text):
+            return "inline"
+        elif self.node.children:
+            for child in self.node.children:
+                if isinstance(child, Text): continue
+                if child.tag in BLOCK_ELEMENTS:
+                    return "block"
+            return "inline"
+        elif self.node.tag == "input":
+            return "inline"
+        else:
+            return "block"
 
     def recurse(self, node):
         if isinstance(node, Text):
@@ -234,7 +248,7 @@ class BlockLayout:
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
-            layout_mode(self.node), self.x, self.y, self.width, self.height, self.node)
+            self.layout_mode(), self.x, self.y, self.width, self.height, self.node)
 
 class LineLayout:
     def __init__(self, node, parent, previous):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -27,7 +27,6 @@ from lab6 import TagSelector, DescendantSelector
 from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX
-from lab8 import layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, linespace, parse_blend_mode
@@ -195,7 +194,7 @@ class BlockLayout:
         else:
             self.y = self.parent.y
 
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             previous = None
             for child in self.node.children:
@@ -211,6 +210,19 @@ class BlockLayout:
 
         self.height = sum([child.height for child in self.children])
 
+    def layout_mode(self):
+        if isinstance(self.node, Text):
+            return "inline"
+        elif self.node.children:
+            for child in self.node.children:
+                if isinstance(child, Text): continue
+                if child.tag in BLOCK_ELEMENTS:
+                    return "block"
+            return "inline"
+        elif self.node.tag == "input":
+            return "inline"
+        else:
+            return "block"
 
     def recurse(self, node):
         if isinstance(node, Text):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -23,7 +23,6 @@ from lab6 import TagSelector, DescendantSelector
 from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab7 import CHROME_PX
 from lab8 import INPUT_WIDTH_PX
-from lab8 import layout_mode
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR
 from lab11 import FONTS, get_font, linespace, parse_blend_mode
@@ -381,7 +380,7 @@ class BlockLayout:
         else:
             self.y.copy(self.parent.y)
 
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             if self.children.dirty:
                 children = []

--- a/src/lab5-tests.md
+++ b/src/lab5-tests.md
@@ -13,7 +13,7 @@ adds support for drawing the background colors of document tree elements.
 Testing layout_mode
 ===================
 
-The `layout_mode` function returns "inline" if the object is a `Text` node
+The `layout_mode` method returns "inline" if the object is a `Text` node
 or has all inline children, and otherwise returns "block".
 
     >>> parser = lab5.HTMLParser("text")
@@ -22,9 +22,10 @@ or has all inline children, and otherwise returns "block".
      <html>
        <body>
          'text'
-    >>> lab5.layout_mode(document_tree)
+    >>> lmode = lambda n: lab5.BlockLayout(n, None, None).layout_mode()
+    >>> lmode(document_tree)
     'block'
-    >>> lab5.layout_mode(document_tree.children[0])
+    >>> lmode(document_tree.children[0])
     'inline'
     
 Here's some tests on a bigger, more complex document
@@ -47,32 +48,32 @@ Here's some tests on a bigger, more complex document
 
 The body element has block layout mode, because it has two block-element children.
 
-    >>> lab5.layout_mode(document_tree.children[0])
+    >>> lmode(document_tree.children[0])
     'block'
 
 The first div has block layout mode, because it has no children.
 
-    >>> lab5.layout_mode(document_tree.children[0].children[0])
+    >>> lmode(document_tree.children[0].children[0])
     'block'
 
 The second div has inline layout mode, because it has one text child.
 
-    >>> lab5.layout_mode(document_tree.children[0].children[1])
+    >>> lmode(document_tree.children[0].children[1])
     'inline'
 
 The third div has block layout mode, because it has one block and one inline child.
 
-    >>> lab5.layout_mode(document_tree.children[0].children[2])
+    >>> lmode(document_tree.children[0].children[2])
     'block'
 
 The first span has block layout mode, even though spans are inline normally:
 
-    >>> lab5.layout_mode(document_tree.children[0].children[3])
+    >>> lmode(document_tree.children[0].children[3])
     'block'
 
 The span has block layout mode, even though spans are inline normally:
 
-    >>> lab5.layout_mode(document_tree.children[0].children[4])
+    >>> lmode(document_tree.children[0].children[4])
     'inline'
 
 Testing the layout tree

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -23,19 +23,6 @@ BLOCK_ELEMENTS = [
     "legend", "details", "summary"
 ]
 
-def layout_mode(node):
-    if isinstance(node, Text):
-        return "inline"
-    elif node.children:
-        if any([isinstance(child, Element) and \
-                child.tag in BLOCK_ELEMENTS
-                for child in node.children]):
-            return "block"
-        else:
-            return "inline"
-    else:
-        return "block"
-
 @wbetools.patch(Layout)
 class BlockLayout:
     def __init__(self, node, parent, previous):
@@ -60,7 +47,7 @@ class BlockLayout:
         else:
             self.y = self.parent.y
 
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             previous = None
             for child in self.node.children:
@@ -88,6 +75,19 @@ class BlockLayout:
             self.height = self.cursor_y
 
         wbetools.record("layout_post", self)
+
+    def layout_mode(self):
+        if isinstance(self.node, Text):
+            return "inline"
+        elif self.node.children:
+            if any([isinstance(child, Element) and \
+                    child.tag in BLOCK_ELEMENTS
+                    for child in self.node.children]):
+                return "block"
+            else:
+                return "inline"
+        else:
+            return "block"
 
     def word(self, word):
         font = get_font(self.size, self.weight, self.style)
@@ -117,7 +117,7 @@ class BlockLayout:
             rect = DrawRect(self.x, self.y, x2, y2, "gray")
             display_list.append(rect)
 
-        if layout_mode(self.node) == "inline":
+        if self.layout_mode() == "inline":
             for x, y, word, font in self.display_list:
                 display_list.append(DrawText(x, y, word, font))
 
@@ -127,7 +127,7 @@ class BlockLayout:
     @wbetools.js_hide
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
-            layout_mode(self.node), self.x, self.y, self.width, self.height, self.node)
+            self.layout_mode(), self.x, self.y, self.width, self.height, self.node)
 
 class DocumentLayout:
     def __init__(self, node):

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -13,7 +13,7 @@ from lab1 import URL
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect, DrawText
+from lab5 import BLOCK_ELEMENTS, DrawRect, DrawText
 from lab5 import BlockLayout, DocumentLayout, Browser
 import wbetools
 
@@ -249,7 +249,7 @@ class BlockLayout:
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(
-            layout_mode(self.node), self.x, self.y, self.width, self.height)
+            self.layout_mode(), self.x, self.y, self.width, self.height)
 
 @wbetools.patch(DrawText)
 class DrawText:

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -12,7 +12,7 @@ import tkinter.font
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, layout_mode, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, URL, tree_to_list, BlockLayout, DocumentLayout
@@ -127,7 +127,7 @@ class BlockLayout:
         else:
             self.y = self.parent.y
 
-        mode = layout_mode(self.node)
+        mode = self.layout_mode()
         if mode == "block":
             previous = None
             for child in self.node.children:
@@ -186,7 +186,7 @@ class BlockLayout:
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(
-            layout_mode(self.node), self.x, self.y, self.width, self.height)
+            self.layout_mode(), self.x, self.y, self.width, self.height)
 
 class DrawLine:
     def __init__(self, x1, y1, x2, y2, color, thickness):

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -19,7 +19,7 @@ from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
-from lab8 import URL, layout_mode, Element, Text, Browser, Tab
+from lab8 import URL, Element, Text, Browser, Tab
 from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX
 
 EVENT_DISPATCH_CODE = \


### PR DESCRIPTION
This PR turns this function into a method of `BlockLayout`. The function is only ever called by `BlockLayout` and also making it a method makes the function signature simpler.