### PR TITLE
Deduplicate and delete some methods

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1247,7 +1247,7 @@ class PseudoclassSelector:
         if not self.base.matches(node):
             return False
         if self.pseudoclass == "focus":
-            return is_focused(node)
+            return node.is_focused
         else:
             return False
 ```
@@ -1773,7 +1773,7 @@ class AccessibilityNode:
         elif self.role == "focusable text":
             self.text = "Focusable text: " + self.node.text
         elif self.role == "focusable":
-            self.text = "Focusable"
+            self.text = "Focusable element"
         elif self.role == "textbox":
             if "value" in self.node.attributes:
                 value = self.node.attributes["value"]
@@ -1792,7 +1792,7 @@ class AccessibilityNode:
         elif self.role == "document":
             self.text = "Document"
 
-        if is_focused(self.node):
+        if self.node.is_focused:
             self.text += " is focused"
 ```
 

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1741,7 +1741,6 @@ class Browser:
         # ...
         if self.needs_accessibility:
             self.update_accessibility()
-
 ```
 
 Now, what should the screen reader say? Well, that's not really up to

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -154,10 +154,6 @@ class ResolvePatches(ast.NodeTransformer):
         self.visit(tree)
         return self.visit(tree)
         
-    def double_visit_and_patches(self, tree):
-        self.visit(tree)
-        return (self.visit(tree), self.patches)
-
 class ResolveJSHide(ast.NodeTransformer):
     def visit_FunctionDef(self, cmd):
         if any([
@@ -210,8 +206,9 @@ def inline(tree):
     return ast.fix_missing_locations(tree4)
 
 def resolve_patches_and_return_them(tree):
-    (tree2, patches) = ResolvePatches().double_visit_and_patches(tree)
-    return (ast.fix_missing_locations(tree2), patches)
+    r = ResolvePatches()
+    tree2 = ResolvePatches().double_visit(tree)
+    return (ast.fix_missing_locations(tree2), r.patches)
 
 def unparse(tree, explain=False):
     return AST39.unparse(tree, explain=explain)

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -207,7 +207,7 @@ def inline(tree):
 
 def resolve_patches_and_return_them(tree):
     r = ResolvePatches()
-    tree2 = ResolvePatches().double_visit(tree)
+    tree2 = r.double_visit(tree)
     return (ast.fix_missing_locations(tree2), r.patches)
 
 def unparse(tree, explain=False):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -511,31 +511,6 @@ def is_focusable(node):
     else:
         return node.tag in ["input", "button", "a"]
     
-def announce_text(node, role):
-    text = ""
-    if role == "StaticText":
-        text = node.text
-    elif role == "focusable text":
-        text = "focusable text: " + node.text
-    elif role == "textbox":
-        if "value" in node.attributes:
-            value = node.attributes["value"]
-        elif node.tag != "input" and node.children and \
-            isinstance(node.children[0], Text):
-            value = node.children[0].text
-        else:
-            value = ""
-        text = "Input box: " + value
-    elif role == "button":
-        text = "Button"
-    elif role == "link":
-        text = "Link"
-    elif role == "alert":
-        text = "Alert"
-    if is_focused(node):
-        text += " is focused"
-    return text
-
 class AccessibilityNode:
     def __init__(self, node):
         self.node = node

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -786,6 +786,7 @@ class CSSParser:
                     break
         return rules
 
+@wbetools.patch(JSContext)
 class JSContext:
     def __init__(self, tab):
         self.tab = tab

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -547,7 +547,7 @@ class AccessibilityNode:
         elif self.role == "focusable text":
             self.text = "Focusable text: " + self.node.text
         elif self.role == "focusable":
-            self.text = "Focusable"
+            self.text = "Focusable element"
         elif self.role == "textbox":
             if "value" in self.node.attributes:
                 value = self.node.attributes["value"]

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -101,11 +101,6 @@ def parse_outline(outline_str, zoom):
     if values[1] != "solid": return None
     return (device_px(int(values[0][:-2]), zoom), values[2])
 
-def is_focused(node):
-    if isinstance(node, Text):
-        node = node.parent
-    return node.is_focused
-
 def has_outline(node):
     return parse_outline(node.style.get("outline"), 1)
 
@@ -571,7 +566,7 @@ class AccessibilityNode:
         elif self.role == "document":
             self.text = "Document"
 
-        if is_focused(self.node):
+        if self.node.is_focused:
             self.text += " is focused"
 
     def build_internal(self, child_node):
@@ -619,7 +614,7 @@ class PseudoclassSelector:
         if not self.base.matches(node):
             return False
         if self.pseudoclass == "focus":
-            return is_focused(node)
+            return node.is_focused
         else:
             return False
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -42,7 +42,7 @@ from lab13 import ClipRRect, Transform, DrawLine, DrawRRect
 from lab14 import parse_color, \
     is_focused, parse_outline, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
-    is_focusable, get_tabindex, announce_text, speak_text, \
+    is_focusable, get_tabindex, speak_text, \
     CSSParser, DrawOutline, main_func, Browser
 
 @wbetools.patch(URL)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -40,7 +40,7 @@ from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
 from lab13 import ClipRRect, Transform, DrawLine, DrawRRect
 from lab14 import parse_color, \
-    is_focused, parse_outline, paint_outline, has_outline, \
+    parse_outline, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
     is_focusable, get_tabindex, speak_text, \
     CSSParser, DrawOutline, main_func, Browser
@@ -1035,7 +1035,7 @@ class AccessibilityNode:
         elif self.role == "focusable text":
             self.text = "Focusable text: " + self.node.text
         elif self.role == "focusable":
-            self.text = "Focusable"
+            self.text = "Focusable element"
         elif self.role == "textbox":
             if "value" in self.node.attributes:
                 value = self.node.attributes["value"]
@@ -1061,7 +1061,7 @@ class AccessibilityNode:
         elif self.role == "iframe":
             self.text = "Child document"
 
-        if is_focused(self.node):
+        if self.node.is_focused:
             self.text += " is focused"
 
     def build_internal(self, child_node):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -38,8 +38,8 @@ from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
 from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
-from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, add_main_args
-from lab14 import parse_color, DrawRRect, \
+from lab13 import ClipRRect, Transform, DrawLine, DrawRRect
+from lab14 import parse_color, \
     is_focused, parse_outline, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
     is_focusable, get_tabindex, announce_text, speak_text, \

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -34,8 +34,7 @@ from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
 from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
-from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, \
-    add_main_args
+from lab13 import ClipRRect, Transform, DrawLine
 from lab14 import parse_color, parse_outline, DrawRRect, \
     is_focused, paint_outline, has_outline, \
     device_px, cascade_priority, \
@@ -917,6 +916,7 @@ def init_style(node):
             for property in CSS_PROPERTIES
         ])
 
+@wbetools.patch(style)
 def style(node, rules, frame):
     if not node.style:
         init_style(node)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -36,7 +36,7 @@ from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
 from lab13 import ClipRRect, Transform, DrawLine
 from lab14 import parse_color, parse_outline, DrawRRect, \
-    is_focused, paint_outline, has_outline, \
+    paint_outline, has_outline, \
     device_px, cascade_priority, \
     is_focusable, get_tabindex, speak_text, \
     CSSParser, main_func, DrawOutline

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -38,7 +38,7 @@ from lab13 import ClipRRect, Transform, DrawLine
 from lab14 import parse_color, parse_outline, DrawRRect, \
     is_focused, paint_outline, has_outline, \
     device_px, cascade_priority, \
-    is_focusable, get_tabindex, announce_text, speak_text, \
+    is_focusable, get_tabindex, speak_text, \
     CSSParser, main_func, DrawOutline
 from lab15 import URL, HTMLParser, AttributeParser, DrawImage, DocumentLayout, BlockLayout, \
     EmbedLayout, InputLayout, LineLayout, TextLayout, ImageLayout, \

--- a/src/lab5.hints
+++ b/src/lab5.hints
@@ -1,3 +1,2 @@
 [
-{"code": "child.tag in BLOCK_ELEMENTS", "type": "list"}
 ]

--- a/src/lab5.hints
+++ b/src/lab5.hints
@@ -1,2 +1,3 @@
 [
+{"code": "child.tag in BLOCK_ELEMENTS", "type": "list"}
 ]


### PR DESCRIPTION
This PR fixes some minor issues:

1. Sometimes we imported a function twice, and then it ended up in the outline twice
2. We had an unused method `announce_text`, which was an obsolete duplicate of `AccessibilityNode.text`
3. Removed the `is_focused` method, which I tested and determined was unneeded