### PR TITLE
Fix widgets broken by recent refactoring

### DIFF
--- a/infra/compile.py
+++ b/infra/compile.py
@@ -386,7 +386,7 @@ def compile_function(name, args, ctx):
         return "await (new " + name + "()).init(" + ", ".join(args_js) + ")"
     elif name == "str":
         assert len(args) == 1
-        return args_js[0] + ".toString()"
+        return "await " + args_js[0] + ".toString()"
     elif name == "len":
         assert len(args) == 1
         return args_js[0] + ".length"
@@ -696,7 +696,7 @@ def compile(tree, ctx, indent=0, patches=[]):
         to_import = []
         to_bind = []
         for name in names:
-            if name.isupper(): # Global constant
+            if name.isupper() and name != "URL": # Global constant
                 to_import.append("constants as {}_constants".format(tree.module))
                 to_bind.append(name)
             elif name[0].isupper(): # Class
@@ -715,8 +715,7 @@ def compile(tree, ctx, indent=0, patches=[]):
         ctx[tree.name] = {"is_class": True}
         ctx2 = Context("class", ctx)
         parts = [compile(part, indent=indent + INDENT, ctx=ctx2) for part in tree.body]
-        if tree.name not in patches:
-            EXPORTS.append(tree.name)
+        EXPORTS.append(tree.name)
         extends = ''
         if tree.bases:
             assert len(tree.bases) == 1
@@ -724,6 +723,11 @@ def compile(tree, ctx, indent=0, patches=[]):
         class_name = tree.name
         if class_name in patches:
             class_name = class_name + "Patch"
+        # Layout is renamed to BlockLayout in lab5. This rename
+        # to LayoutPatch enables the patching to work; code elsewhere
+        # creates the alias called BlockLayout.
+        elif "Layout" in patches and class_name == "BlockLayout":
+            class_name = "LayoutPatch"
         return " " * indent + "class " + class_name + extends + " {\n" + "\n\n".join(parts) + "\n}"
     elif isinstance(tree, ast.FunctionDef):
         if tree.name in SKIPPED_FNS:
@@ -749,6 +753,11 @@ def compile(tree, ctx, indent=0, patches=[]):
             return def_line + body + ret_line + last_line
         elif tree.name == "__repr__":
             # This actually defines a 'toString' operator
+            assert ctx.type == "class"
+            def_line = " " * indent + "async toString(" + ", ".join(args) + ") {\n"
+            last_line = "\n" + " " * indent + "}"
+            return def_line + body + last_line
+        elif tree.name == "__str__":
             assert ctx.type == "class"
             def_line = " " * indent + "async toString(" + ", ".join(args) + ") {\n"
             last_line = "\n" + " " * indent + "}"
@@ -943,6 +952,11 @@ def compile_module(tree, patches):
         items.append(
             "patch_class({cls}, {cls}Patch)\n".format(
             cls=name))
+        # Layout is renamed to BlockLayout in lab5. The Layout class is patched,
+        # but we also need to declare BLockLayout an alias of this patched
+        # class.
+        if name == "Layout":
+            items.append("var BlockLayout = Layout")
 
     exports = ""
     rt_imports = ""

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -146,7 +146,7 @@ translations:
     >>> Test.expr("repr(node)")
     (node.toString())
     >>> Test.expr("str(node)")
-    (node.toString())
+    (await node.toString())
     >>> Test.expr("ord(e.char)")
     (e.char.charCodeAt(0))
     >>> Test.expr("enumerate(self.tabs)")

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -13,13 +13,13 @@ import dukpy
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
 from lab8 import URL, Browser, Text, Element
-from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX
+from lab8 import BlockLayout, InputLayout, INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE, JSContext, Tab
 import wbetools
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -18,7 +18,7 @@ import wbetools
 
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab4 import print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS
+from lab5 import BLOCK_ELEMENTS, DocumentLayout
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import tree_to_list
@@ -27,7 +27,7 @@ from lab8 import Text, Element, INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, JSContext, URL
 from lab11 import get_font, FONTS, DrawLine, DrawRect, DrawOutline, linespace, DrawText, SaveLayer, ClipRRect
-from lab11 import BlockLayout, DocumentLayout, LineLayout, TextLayout, InputLayout
+from lab11 import BlockLayout, LineLayout, TextLayout, InputLayout
 from lab11 import paint_visual_effects, parse_blend_mode, parse_color, Tab, Browser
 
 class MeasureTime:

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -12,10 +12,10 @@ import tkinter.font
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
-from lab6 import DrawText, URL, tree_to_list, BlockLayout, DocumentLayout
+from lab6 import DrawText, URL, tree_to_list, BlockLayout
 import wbetools
 
 @wbetools.patch(URL)

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -13,11 +13,11 @@ import urllib.parse
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, URL, tree_to_list
-from lab7 import DrawLine, DrawOutline, DocumentLayout, BlockLayout, LineLayout, TextLayout
+from lab7 import DrawLine, DrawOutline, BlockLayout, LineLayout, TextLayout
 from lab7 import CHROME_PX, Tab, Browser
 
 @wbetools.patch(Element)

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -14,13 +14,13 @@ import dukpy
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, tree_to_list
 from lab7 import DrawLine, DrawOutline, LineLayout, TextLayout, CHROME_PX
 from lab8 import URL, Element, Text, Browser, Tab
-from lab8 import DocumentLayout, BlockLayout, InputLayout, INPUT_WIDTH_PX
+from lab8 import BlockLayout, InputLayout, INPUT_WIDTH_PX
 
 EVENT_DISPATCH_CODE = \
     "new Node(dukpy.handle).dispatchEvent(new Event(dukpy.type))"

--- a/www/widgets/lab10-browser.html
+++ b/www/widgets/lab10-browser.html
@@ -11,8 +11,10 @@
 <script type="module" src="lab10.js"></script>
 <script type="module">
 import { rt_constants, socket, Widget } from "./rt.js";
-import { Browser, constants } from "./lab10.js";
+import { constants } from "./lab10.js";
+import { Browser } from "./lab8.js";
 import { handle_connection } from "./server10.js";
+import { URL } from "./lab8.js";
 
 socket.accept(8000, handle_connection);
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
@@ -22,7 +24,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://localhost:8000/";
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)));
 });
 widget.next();
 </script>

--- a/www/widgets/lab11-browser.html
+++ b/www/widgets/lab11-browser.html
@@ -20,10 +20,11 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
     let typeface = font_manager.MakeTypefaceFromData(
             robotoData);
 
-  Promise.all([import("./rt.js"), import("./lab11.js"),
+  Promise.all([import("./rt.js"), import("./lab8.js"), import("./lab11.js"),
     import("./server10.js")]).then(
-  ([rt, lab11, server10]) => {
+  ([rt, lab8, lab11, server10]) => {
     let { init_skia, init_window, socket, Widget, rt_constants } = rt;
+    let { URL } = lab8;
     let { Browser, constants } = lab11;
     let { handle_connection } = server10;
 
@@ -38,7 +39,7 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
         let url = "https://localhost:8000/";
         let b = await (new Browser()).init();
         init_window(b);
-        await b.load(url);
+        await b.load(await (new URL().init(url)));
     });
     widget.next();
   });

--- a/www/widgets/lab12-browser.html
+++ b/www/widgets/lab12-browser.html
@@ -20,10 +20,11 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
     let typeface = font_manager.MakeTypefaceFromData(
             robotoData);
 
-  Promise.all([import("./rt.js"), import("./lab12.js"),
+  Promise.all([import("./rt.js"), import("./lab8.js"), import("./lab12.js"),
     import("./server10.js")]).then(
-  ([rt, lab11, server10]) => {
+  ([rt, lab8, lab11, server10]) => {
     let { init_skia, init_window, socket, Widget, rt_constants } = rt;
+    let { URL } = lab8;
     let { Browser, constants } = lab11;
     let { handle_connection } = server10;
 
@@ -40,7 +41,7 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
         let url = "https://localhost:8000/";
         let b = await (new Browser()).init();
         init_window(b);
-        await b.load(url);
+        await b.load(await (new URL().init(url)));
         await b.render();
         interval = setInterval(async function() {
           await b.render();

--- a/www/widgets/lab13-browser.html
+++ b/www/widgets/lab13-browser.html
@@ -20,10 +20,11 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
     let typeface = font_manager.MakeTypefaceFromData(
             robotoData);
 
-  Promise.all([import("./rt.js"), import("./lab13.js"),
+  Promise.all([import("./rt.js"), import("./lab8.js"), import("./lab13.js"),
     import("./server10.js")]).then(
-  ([rt, lab11, server10]) => {
+  ([rt, lab8, lab11, server10]) => {
     let { init_skia, init_window, socket, Widget, rt_constants} = rt;
+    let { URL } = lab8;
     let { Browser, constants } = lab11;
     let { handle_connection } = server10;
 
@@ -40,7 +41,7 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
         let url = "https://localhost:8000";
         let b = await (new Browser()).init();
         init_window(b);
-        await b.load(url);
+        await b.load(await (new URL().init(url)));
         await b.render();
         interval = setInterval(async function() {
           await b.render();

--- a/www/widgets/lab2-browser.html
+++ b/www/widgets/lab2-browser.html
@@ -22,6 +22,7 @@
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab2.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
@@ -30,7 +31,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/" + document.getElementById("input").value;
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab2-render.html
+++ b/www/widgets/lab2-render.html
@@ -24,6 +24,7 @@
 <script type="module">
 import { http_textarea, rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab2.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 rt_constants.URLS = {
@@ -38,6 +39,6 @@ widget.run(async function() {
     constants.HSTEP = 16;
     constants.VSTEP = 20;
     let b = await (new Browser()).init();
-    await b.load("http://input/");
+    await b.load(await (new URL().init("http://input/")));
 });
 </script>

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -79,6 +79,7 @@ line.baseline { stroke-dasharray: 5, 5; }
 <script type="module">
 import { http_textarea, rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab3.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ZOOM = 1.5;
 rt_constants.ROOT_CANVAS = document.createElement("canvas");
@@ -240,6 +241,6 @@ widget.pause("final_y", record("final_y"));
 widget.run(async function() {
     STATE = {};
     let b = await (new Browser()).init();
-    await b.load("http://input/")
+    await b.load(await (new URL().init("http://input/")))
 });
 </script>

--- a/www/widgets/lab3-browser.html
+++ b/www/widgets/lab3-browser.html
@@ -22,6 +22,7 @@
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab3.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
@@ -30,7 +31,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/" + document.getElementById("input").value;
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab4-browser.html
+++ b/www/widgets/lab4-browser.html
@@ -22,6 +22,7 @@
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab4.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
@@ -30,7 +31,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/" + document.getElementById("input").value;
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab5-browser.html
+++ b/www/widgets/lab5-browser.html
@@ -22,6 +22,7 @@
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab5.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
@@ -30,7 +31,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/" + document.getElementById("input").value;
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab6-browser.html
+++ b/www/widgets/lab6-browser.html
@@ -22,6 +22,7 @@
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab6.js";
+import { URL } from "./lab1.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
@@ -30,7 +31,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/" + document.getElementById("input").value;
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab7-browser.html
+++ b/www/widgets/lab7-browser.html
@@ -12,6 +12,7 @@
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab7.js";
+import { URL } from "./lab7.js";
 
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
 
@@ -20,7 +21,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/chrome.html";
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab8-browser.html
+++ b/www/widgets/lab8-browser.html
@@ -13,6 +13,7 @@
 import { rt_constants, socket, Widget } from "./rt.js";
 import { Browser, constants } from "./lab8.js";
 import { handle_connection } from "./server8.js";
+import { URL } from "./lab8.js";
 
 socket.accept(8000, handle_connection);
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
@@ -22,7 +23,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://localhost:8000/";
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab9-browser.html
+++ b/www/widgets/lab9-browser.html
@@ -11,8 +11,10 @@
 <script type="module" src="lab9.js"></script>
 <script type="module">
 import { rt_constants, socket, Widget } from "./rt.js";
-import { Browser, constants } from "./lab9.js";
+import { constants } from "./lab9.js";
+import { Browser } from "./lab8.js";
 import { handle_connection } from "./server9.js";
+import { URL } from "./lab8.js";
 
 socket.accept(8000, handle_connection);
 rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
@@ -22,7 +24,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://localhost:8000/";
     let b = await (new Browser()).init();
-    await b.load(url)
+    await b.load(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -656,7 +656,11 @@ class skia {
                 return true;
             };
             rect.outset = (x, y) => {
-                rect.outset(x, y)
+                return skia.Rect.MakeLTRB(
+                    rect.left() - 1,
+                    rect.top() - 1,
+                    rect.right() + 1,
+                    rect.bottom() + 1);
             };
         },
 


### PR DESCRIPTION
* Need to pass a `URL` argument to `load`
* Special code needed rename `Layout` to `BlockLayout`
* Fix `toString` to work when writing the URL in the browser chrome
* Special-case `URL` as a class name that happens to be all caps
* Re-export patched classes
* Fix `outset` on rects
* Must import objects from the JS module that actually declared them (hence changes to `DocumentLayout` imports)