### PR TITLE
Fix the 'word' method's whitespace, such that its return statement is…

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -65,9 +65,8 @@ def word(self):
             self.i += 1
         else:
             break
-        if not (self.i > start):
-            raise Exception("Parsing error")
-        
+    if not (self.i > start):
+        raise Exception("Parsing error")
     return self.s[start:self.i]
 ```
 

--- a/book/styles.md
+++ b/book/styles.md
@@ -68,7 +68,7 @@ def word(self):
         if not (self.i > start):
             raise Exception("Parsing error")
         
-        return self.s[start:self.i]
+    return self.s[start:self.i]
 ```
 
 This function increments `i` through any word characters,[^word-chars]


### PR DESCRIPTION
The current, live version of chapter six features the following whitespace error, placing the _word_ method's _return_ statement inside of the _while_ loop.

![Screenshot 2023-08-31 at 5 59 02 AM](https://github.com/browserengineering/book/assets/11188759/ed4c62c8-d102-472f-9b2a-5f7b2c642e51)

The following change has been confirmed by comparing it to the chapter's source code at `/src/lab6.py`