### PR TITLE
Split `DisplayItem` into two classes

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -430,7 +430,9 @@ class ClipRRect:
             return "ClipRRect(<no-op>)"
 ```
 
-Now we can print out our browser's display list:
+You'll also need to add `children` fields to all of the paint
+commands, since `print_tree` relies on those. Now we can print out our
+browser's display list:
 
 ``` {.python expected=False}
 class Tab:
@@ -1664,37 +1666,6 @@ class Browser:
 
 The multiple `if` statements inside the list comprehension are "and"ed
 together.
-=======
-Since internal nodes can now be in a `CompositedLayer`, there is also a bit of
-added complexity to `composited_bounds`.  We'll need to recursively union the
-rects of the subtree of non-composited display items, so let's add a
-`DisplayItem` method to do that:
-
-``` {.python}
-class DisplayItem:
-    def __init__(self, rect, children=[], node=None):
-        self.rect = rect
-    # ...
-
-    def add_composited_bounds(self, rect):
-        rect.join(self.rect)
-        for cmd in self.children:
-            cmd.add_composited_bounds(rect)
-```
-
-And use this new method as follows:
-
-``` {.python}
-class CompositedLayer:
-    # ...
-    def composited_bounds(self):
-        rect = skia.Rect.MakeEmpty()
-        for item in self.display_items:
-            item.add_composited_bounds(rect)
-        rect.outset(1, 1)
-        return rect
-```
->>>>>>> main
 
 Our compositing algorithm now creates way fewer layers! It does a good job of
 grouping together non-animating content to reduce the number of composited

--- a/book/animations.md
+++ b/book/animations.md
@@ -401,48 +401,12 @@ of multiple windows. "Compositing" can also refer to multi-threaded rendering.
 
 [compositing]: https://en.wikipedia.org/wiki/Compositing
 
-To explain compositing, we'll need to think about our browser's display list,
-and to do that it's useful to print it out. Printing it is going to require
-similar code in every display command, so let's give them all a new
-`DisplayItem` superclass. This also makes it easy to create default behavior
-that's overridden for specific display commands. For example, we can make sure
-that every display command has a `children` field:
+To explain compositing, we'll need to think about our browser's
+display list, and to do that it's useful to print it out. For example,
+for `DrawRect` you might print:
 
-``` {.python replace=children%3d[]/rect%2c%20children%3d[]%2c%20node%3dNone}
-class DisplayItem:
-    def __init__(self, children=[]):
-        self.children = children
-```
-
-We'll need that `children` field to use `print_tree` to print the
-display list.
-
-Now each display command needs to be a subclass of `DisplayItem`; to
-do that, you need to name the superclass when the class is declared
-and also use some special syntax in the constructor:
-
-``` {.python expected=False}
-class DrawRect(DisplayItem):
-    def __init__(self, x1, y1, x2, y2, color):
-        super().__init__()
-        # ...
-```
-
-Commands that already had a `children` field need to pass it to the
-`__init__` call:
-
-``` {.python replace=children)/rect%2c%20children)}
-class ClipRRect(DisplayItem):
-    def __init__(self, rect, radius, children, should_clip=True):
-        super().__init__(children)
-        # ...
-```
-
-To print the display list in a useful form, let's add a printable form
-to each display command. For example, for `DrawRect` you might print:
-
-``` {.python}
-class DrawRect(DisplayItem):
+``` {.python replace=DrawRect:/DrawRect(DrawCommand):}
+class DrawRect:
     def __repr__(self):
         return ("DrawRect(top={} left={} " +
             "bottom={} right={} color={})").format(
@@ -454,8 +418,8 @@ Some of our display commands have a flag to do nothing, like
 `ClipRRect`'s `should_clip` flag. It's useful to explicitly indicate
 that:
 
-``` {.python}
-class ClipRRect(DisplayItem):
+``` {.python replace=ClipRRect:/ClipRRect(VisualEffect):}
+class ClipRRect:
     def __repr__(self):
         if self.should_clip:
             return "ClipRRect({})".format(str(self.rrect))
@@ -584,29 +548,59 @@ size.
 Compositing leaves
 ==================
 
-Let's implementing compositing. We'll need to traverse the display
-list, identify paint commands, and move them to composited layers.
-Then we'll need to create the draw display list that combines these
-composited layers. To keep things simple, we'll start by creating a
-composited layer for every paint command.
+Let's implementing compositing. We'll need identify paint commands and
+move them to composited layers. Then we'll need to create the draw
+display list that combines these composited layers. To keep things
+simple, we'll start by creating a composited layer for every paint
+command.
 
-We'll want an `is_paint_command` method on display items to identify
-paint commands. It'll return `False` by default:
-
-``` {.python}
-class DisplayItem:
-    def is_paint_command(self):
-        return False
-```
-
-But for `DrawLine`, `DrawRRect`, `DrawRect`, and `DrawText` it'll
-return `True` instead. For example, here's `DrawLine`:
+To identify paint commands, it'll be helpful to give them all a
+superclass. I call it `DrawCommand`, since all the paint commands
+already start with `Draw`:
 
 ``` {.python}
-class DrawLine(DisplayItem):
-    def is_paint_command(self):
-        return True
+class DrawCommand:
+    def __init__(self, rect):
+        self.rect = rect
+        self.children = []
 ```
+
+Now each paint command needs to be a subclass of `DrawCommand`; to do
+that, you need to name the superclass when the class is declared and
+also use some special syntax in the constructor:
+
+``` {.python}
+class DrawLine(DrawCommand):
+    def __init__(self, x1, y1, x2, y2, color, thickness):
+        super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
+        # ...
+```
+
+The `MakeLTRB` creates the `rect` for the `DrawCommand` constructor.
+It'll be useful to have these as Skia `Rect` objects instead of just
+four `x1`/`y1`/`x2`/`y2` fields.
+
+We can also give a superclass to visual effects:
+
+``` {.python replace=):/%2c%20node%3dNone):}
+class VisualEffect:
+    def __init__(self, rect, children):
+        self.rect = rect.makeOffset(0.0, 0.0)
+        self.children = children
+        for child in self.children:
+            self.rect.join(child.rect)
+```
+
+Note that since visual effects have children, we need to not only pass
+those to the constructor, but also add their `rect` fields to our own.
+I use the `makeOffset` function to make a copy of the original `rect`,
+which is then grown by later `join` methods to include all of the
+children as well.
+
+Go ahead and modify each paint command and visual effect class to be a
+subclass of one of these two new classes. Make sure you both declare
+the superclass on the `class` line and also call the superclass
+constructor in the `__init__` method using the `super()` syntax.
 
 We can now list all of the paint_commands using `tree_to_list`:
 
@@ -616,8 +610,8 @@ class Browser:
         all_commands = []
         for cmd in self.active_tab_display_list:
             all_commands = tree_to_list(cmd, all_commands)
-        paint_commands = [cmd
-            for cmd in all_commands if cmd.is_paint_command()]
+        paint_commands = [cmd for cmd in all_commands
+            if isinstance(cmd, DrawCommand)]
 ```
 
 Next we need to group paint commands into layers. For now, let's do the
@@ -676,7 +670,7 @@ to the visual effects classes. For `SaveLayer`, it'll create a new
 `SaveLayer` with the same parameters but new children:
 
 ``` {.python}
-class SaveLayer(DisplayItem):
+class SaveLayer(VisualEffect):
     # ...
     def clone(self, children):
         return SaveLayer(self.sk_paint, self.node, children, \
@@ -728,33 +722,12 @@ class Browser:
             composited_layer.raster()
 ```
 
-Inside `raster`, the composited layer needs to allocate a surface to raster
-itself into. To start, it'll need to know how big a surface
-to allocate. That's just the union of the bounding boxes of all of its
-paint commands. First add a `rect` field to display items:
-
-
-``` {.python expected=False}
-class DisplayItem:
-    def __init__(self, rect, children=[]):
-        self.rect = rect
-```
-
-Drawing commands then need to pass that argument to the superclass
-constructor. Here's `DrawText`, for example:
+Inside `raster`, the composited layer needs to allocate a surface to
+raster itself into. To start, it'll need to know how big a surface to
+allocate. That's just the union of the bounding boxes of all of its
+paint commands---the `rect` field:
 
 ``` {.python}
-class DrawText(DisplayItem):
-    def __init__(self, x1, y1, text, font, color):
-        # ...
-        super().__init__(skia.Rect.MakeLTRB(x1, y1,
-            self.right, self.bottom))
-```
-
-Now a `CompositedLayer` can just union the bounding boxes of its
-display items:
-
-``` {.python expected=False}
 class CompositedLayer:
     # ...
     def composited_bounds(self):
@@ -805,7 +778,7 @@ to implement the `DrawCompositedLayer` command. It takes a composited
 layer to draw:
 
 ``` {.python}
-class DrawCompositedLayer(DisplayItem):
+class DrawCompositedLayer(DrawCommand):
     def __init__(self, composited_layer):
         self.composited_layer = composited_layer
         super().__init__(
@@ -819,7 +792,7 @@ Executing a `DrawCompositedLayer` is straightforward---just draw its surface
 into the parent surface, adjusting for the correct offset:
 
 ``` {.python}
-class DrawCompositedLayer(DisplayItem):
+class DrawCompositedLayer(DrawCommand):
     def execute(self, canvas):
         layer = self.composited_layer
         bounds = layer.composited_bounds()
@@ -1293,8 +1266,8 @@ add a `node` field to each display item, storing the node that painted
 it, as a sort of identifier:
 
 ``` {.python}
-class DisplayItem:
-    def __init__(self, rect, children=[], node=None):
+class VisualEffect:
+    def __init__(self, rect, children, node=None):
         # ...
         self.node = node
 ```
@@ -1608,17 +1581,25 @@ aren't animating into the same composited layer. This will let us run
 some visual effects in the raster phase, reducing the number of
 composited layers even more.
 
-To implement this, replace the `is_paint_command` method on
-`DisplayItem`s with a new `needs_compositing` field, which is `True`
-when a visual effect should go in the draw display list and `False`
-when it should go into a composited layer. As a simple heuristic,
-we'll always set it to `True` for `SaveLayer`s (when they actually do
-something, not for no-ops), regardless of whether they are animating,
-but we'll set it to `False` for `ClipRRect` commands, since those
-can't animate in our browser.
+To implement this, add a new `needs_compositing` field, which is
+`True` when a visual effect should go in the draw display list and
+`False` when it should go into a composited layer. We'll set it to
+`False` for most visual effects:
+
+``` {.python expected=False}
+class VisualEffect:
+    def __init__(self, rect, children):
+        self.needs_compositing=False
+```
+
+We should set it to `True` when compositing would help us animate
+something. There are all sorts of complex heuristics real browsers
+use, but to keep things simple let's just set it to `True` for
+`SaveLayer`s (when they actually do something, not for no-ops),
+regardless of whether they are animating:
 
 ``` {.python replace=self.should_save/wbetools.USE_COMPOSITING%20and%20self.should_save}
-class SaveLayer(DisplayItem):
+class SaveLayer(VisualEffect):
     def __init__(self, sk_paint, node, children, should_save=True):
         # ...
         if self.should_save:
@@ -1631,8 +1612,8 @@ run on the GPU, then one way or another the ones above it will have to be as
 well:
 
 ``` {.python}
-class DisplayItem:
-    def __init__(self, rect, children=[], node=None):
+class VisualEffect:
+    def __init__(self, rect, children, node=None):
         # ...
         self.needs_compositing = any([
             child.needs_compositing for child in self.children
@@ -1648,9 +1629,8 @@ class Browser:
         # ...
         non_composited_commands = [cmd
             for cmd in all_commands
-            if not cmd.needs_compositing and \
-                (not cmd.parent or \
-                 cmd.parent.needs_compositing)
+            if isinstance(cmd, DrawCommand) or not cmd.needs_compositing
+            if not cmd.parent or cmd.parent.needs_compositing
         ]
         # ...
         for cmd in non_composited_commands:
@@ -1658,34 +1638,8 @@ class Browser:
 
 ```
 
-Since internal nodes can now be in a `CompositedLayer`, there is also a bit of
-added complexity to `composited_bounds`.  We'll need to recursively union the
-rects of the subtree of non-composited display items, so let's add a
-`DisplayItem` method to do that:
-
-``` {.python}
-class DisplayItem:
-    def __init__(self, rect, children=[], node=None):
-        self.rect = rect
-    # ...
-
-    def add_composited_bounds(self, rect):
-        rect.join(self.rect)
-        for cmd in self.children:
-            cmd.add_composited_bounds(rect)
-```
-
-And use this new method as follows:
-
-``` {.python}
-class CompositedLayer:
-    # ...
-    def composited_bounds(self):
-        rect = skia.Rect.MakeEmpty()
-        for item in self.display_items:
-            item.add_composited_bounds(rect)
-        return rect
-```
+The multiple `if` statements inside the list comprehension are "and"ed
+together.
 
 Our compositing algorithm now creates way fewer layers! It does a good job of
 grouping together non-animating content to reduce the number of composited
@@ -1735,7 +1689,7 @@ class CompositedLayer:
 ```
 
 I also recommend you add a mode to your browser that disables compositing
-(i.e. set `needs_compositing` to `False` for every `DisplayItem`), and
+(i.e. set `needs_compositing` to `False` for every `VisualEffect`), and
 disables use of the GPU (i.e. go back to the old way of making Skia surfaces).
 Everything should still work (albeit more slowly) in all of the modes, and you
 can use these additional modes to debug your browser more fully and benchmark
@@ -1885,7 +1839,7 @@ These `Transform` display items just call the conveniently built-in
 Skia canvas `translate` method:
 
 ``` {.python replace=self.translation%20or/USE_COMPOSITING%20and%20self.translation%20or}
-class Transform(DisplayItem):
+class Transform(VisualEffect):
     def __init__(self, translation, rect, node, children):
         super().__init__(rect, children, node)
         self.translation = translation
@@ -1987,13 +1941,19 @@ the output of calling `map` on a rect would translate it by 20 pixels
 in the *x* direction.
 
 ``` {.python}
-class DisplayItem:
-    def map(self, rect):
-        return rect
-
-class Transform(DisplayItem):
+class Transform(VisualEffect):
     def map(self, rect):
         return map_translation(rect, self.translation)
+
+class ClipRRect(VisualEffect):
+    def map(self, rect):
+        bounds = self.rrect.rect()
+        bounds.intersect(rect)
+        return bounds
+
+class SaveLayer(VisualEffect):
+    def map(self, rect):
+        return rect
 ```
 
 Now we can compute the absolute bounds of a display item mapping its
@@ -2003,12 +1963,10 @@ display list and not the layout object tree:
 
 ``` {.python}
 def absolute_bounds(display_item):
-    rect = skia.Rect.MakeEmpty()
-    display_item.add_composited_bounds(rect)
-    effect = display_item.parent
-    while effect:
-        rect = effect.map(rect)
-        effect = effect.parent
+    rect = display_item.rect
+    while display_item.parent:
+        rect = display_item.parent.map(rect)
+        display_item = display_item.parent
     return rect
 ```
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -183,7 +183,7 @@ Luckily, Skia will automatically do the decoding for us, so drawing
 the image is pretty simple:
 
 ``` {.python replace=%2c%20rect/%2c%20rect%2c%20quality,self.rect)/self.rect%2c%20paint)}
-class DrawImage(DisplayItem):
+class DrawImage(DrawCommand):
     def __init__(self, image, rect):
         super().__init__(rect)
         self.image = image
@@ -235,7 +235,7 @@ indicates which algorithm to use. Let's add that as an argument to
 [image-rendering]: https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering
 
 ``` {.python}
-class DrawImage(DisplayItem):
+class DrawImage(DrawCommand):
     def __init__(self, image, rect, quality):
         # ...
         if quality == "high-quality":

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -172,9 +172,12 @@ LIBRARY_METHODS = [
     "height",
     "isEmpty",
     "roundOut",
+    "rect",
+    "intersect",
     "intersects",
     "Intersects",
     "join",
+    "makeOffset",
 
     # skia.RRect
     "MakeRectXY",

--- a/src/lab13.hints
+++ b/src/lab13.hints
@@ -20,7 +20,7 @@
  {"code": "('TextLayout(x={}, y={}, width={}, height={}, ' + 'node={}, word={})').format(self.x, self.y, self.width, self.height, self.node, self.word)", "js": ""},
  {"code": "('NumericAnimation(' + 'old_value={old_value}, change_per_frame={change_per_frame}, ' + 'num_frames={num_frames})').format(old_value=self.old_value, change_per_frame=self.change_per_frame, num_frames=self.num_frames)", "js": ""},
  {"code": "('TranslateAnimation(' + 'old_value=({old_x},{old_y}), ' + 'change_per_frame=({change_x},{change_y}), ' + 'num_frames={num_frames})').format(old_x=self.old_x, old_y=self.old_y, change_x=self.change_per_frame_x, change_y=self.change_per_frame_y, num_frames=self.num_frames)", "js": ""},
- {"code": "('layer: composited_bounds={} ' + 'absolute_bounds={} first_chunk={}').format(composited_bounds, absolute_bounds, self.display_items if len(self.display_items) > 0 else 'None')", "js": ""},
+ {"code": "('layer: composited_bounds={} ' + 'absolute_bounds={} first_chunk={}').format(self.composited_bounds(), self.absolute_bounds(), self.display_items if len(self.display_items) > 0 else 'None')", "js": ""},
  {"code": "('OpenGL initialized: vendor={},' + 'renderer={}').format(OpenGL.GL.glGetString(OpenGL.GL.GL_VENDOR), OpenGL.GL.glGetString(OpenGL.GL.GL_RENDERER))", "js": ""},
  {"code": "self.s[self.i] in chars", "js": "chars.find((c) => c == this.s[this.i])"},
  {"code": "property not in new_transitions", "type": "dict"},

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -52,25 +52,22 @@ class Element:
         self.is_focused = False
         self.animations = {}
 
-class DisplayItem:
-    def __init__(self, rect, children=[], node=None):
+class DrawCommand:
+    def __init__(self, rect):
         self.rect = rect
+        self.children = []
+
+class VisualEffect:
+    def __init__(self, rect, children, node=None):
+        self.rect = rect.makeOffset(0.0, 0.0)
         self.children = children
+        for child in self.children:
+            self.rect.join(child.rect)
         self.node = node
         self.needs_compositing = any([
             child.needs_compositing for child in self.children
+            if isinstance(child, VisualEffect)
         ])
-
-    def is_paint_command(self):
-        return False
-
-    def map(self, rect):
-        return rect
-
-    def add_composited_bounds(self, rect):
-        rect.join(self.rect)
-        for cmd in self.children:
-            cmd.add_composited_bounds(rect)
 
 def map_translation(rect, translation):
     if not translation:
@@ -81,7 +78,7 @@ def map_translation(rect, translation):
         matrix.setTranslate(x, y)
         return matrix.mapRect(rect)
 
-class Transform(DisplayItem):
+class Transform(VisualEffect):
     def __init__(self, translation, rect, node, children):
         super().__init__(rect, children, node)
         self.translation = translation
@@ -110,7 +107,7 @@ class Transform(DisplayItem):
         else:
             return "Transform(<no-op>)"
 
-class DrawLine(DisplayItem):
+class DrawLine(DrawCommand):
     def __init__(self, x1, y1, x2, y2, color, thickness):
         super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
         self.x1 = x1
@@ -119,9 +116,6 @@ class DrawLine(DisplayItem):
         self.y2 = y2
         self.color = color
         self.thickness = thickness
-
-    def is_paint_command(self):
-        return True
 
     def execute(self, canvas):
         path = skia.Path().moveTo(self.x1, self.y1).lineTo(self.x2, self.y2)
@@ -134,14 +128,11 @@ class DrawLine(DisplayItem):
         return "DrawLine top={} left={} bottom={} right={}".format(
             self.y1, self.x1, self.y2, self.x2)
 
-class DrawRRect(DisplayItem):
+class DrawRRect(DrawCommand):
     def __init__(self, rect, radius, color):
         super().__init__(rect)
         self.rrect = skia.RRect.MakeRectXY(rect, radius, radius)
         self.color = color
-
-    def is_paint_command(self):
-        return True
 
     def execute(self, canvas):
         sk_color = parse_color(self.color)
@@ -155,7 +146,7 @@ class DrawRRect(DisplayItem):
         return "DrawRRect(rect={}, color={})".format(
             str(self.rrect), self.color)
 
-class DrawText(DisplayItem):
+class DrawText(DrawCommand):
     def __init__(self, x1, y1, text, font, color):
         self.left = x1
         self.top = y1
@@ -167,9 +158,6 @@ class DrawText(DisplayItem):
         super().__init__(skia.Rect.MakeLTRB(x1, y1,
             self.right, self.bottom))
 
-    def is_paint_command(self):
-        return True
-
     def execute(self, canvas):
         paint = skia.Paint(AntiAlias=True, Color=parse_color(self.color))
         baseline = self.top - self.font.getMetrics().fAscent
@@ -179,7 +167,7 @@ class DrawText(DisplayItem):
     def __repr__(self):
         return "DrawText(text={})".format(self.text)
 
-class DrawRect(DisplayItem):
+class DrawRect(DrawCommand):
     def __init__(self, x1, y1, x2, y2, color):
         super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
         self.top = y1
@@ -187,9 +175,6 @@ class DrawRect(DisplayItem):
         self.bottom = y2
         self.right = x2
         self.color = color
-
-    def is_paint_command(self):
-        return True
 
     def execute(self, canvas):
         paint = skia.Paint()
@@ -202,14 +187,11 @@ class DrawRect(DisplayItem):
             self.top, self.left, self.bottom,
             self.right, self.color)
 
-class DrawOutline(DisplayItem):
+class DrawOutline(DrawCommand):
     def __init__(self, x1, y1, x2, y2, color, thickness):
         super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
         self.color = color
         self.thickness = thickness
-
-    def is_paint_command(self):
-        return True
 
     def execute(self, canvas):
         paint = skia.Paint()
@@ -228,7 +210,7 @@ class DrawOutline(DisplayItem):
             self.thickness)
 
 
-class ClipRRect(DisplayItem):
+class ClipRRect(VisualEffect):
     def __init__(self, rect, radius, children, should_clip=True):
         super().__init__(rect, children)
         self.should_clip = should_clip
@@ -244,6 +226,11 @@ class ClipRRect(DisplayItem):
         if self.should_clip:
             canvas.restore()
 
+    def map(self, rect):
+        bounds = self.rrect.rect()
+        bounds.intersect(rect)
+        return bounds
+
     def clone(self, children):
         return ClipRRect(self.rect, self.radius, children, \
             self.should_clip)
@@ -254,7 +241,7 @@ class ClipRRect(DisplayItem):
         else:
             return "ClipRRect(<no-op>)"
 
-class SaveLayer(DisplayItem):
+class SaveLayer(VisualEffect):
     def __init__(self, sk_paint, node, children, should_save=True):
         super().__init__(skia.Rect.MakeEmpty(), children, node)
         self.should_save = should_save
@@ -271,6 +258,9 @@ class SaveLayer(DisplayItem):
         if self.should_save:
             canvas.restore()
 
+    def map(self, rect):
+        return rect
+
     def clone(self, children):
         return SaveLayer(self.sk_paint, self.node, children, \
             self.should_save)
@@ -281,7 +271,7 @@ class SaveLayer(DisplayItem):
         else:
             return "SaveLayer(<no-op>)"
 
-class DrawCompositedLayer(DisplayItem):
+class DrawCompositedLayer(DrawCommand):
     def __init__(self, composited_layer):
         self.composited_layer = composited_layer
         super().__init__(
@@ -295,7 +285,6 @@ class DrawCompositedLayer(DisplayItem):
 
     def __repr__(self):
         return "DrawCompositedLayer()"
-
 
 def parse_transform(transform_str):
     if transform_str.find('translate(') < 0:
@@ -1000,12 +989,10 @@ def absolute_bounds_for_obj(obj):
     return rect
 
 def absolute_bounds(display_item):
-    rect = skia.Rect.MakeEmpty()
-    display_item.add_composited_bounds(rect)
-    effect = display_item.parent
-    while effect:
-        rect = effect.map(rect)
-        effect = effect.parent
+    rect = display_item.rect
+    while display_item.parent:
+        rect = display_item.parent.map(rect)
+        display_item = display_item.parent
     return rect
 
 class CompositedLayer:
@@ -1026,7 +1013,7 @@ class CompositedLayer:
     def composited_bounds(self):
         rect = skia.Rect.MakeEmpty()
         for item in self.display_items:
-            item.add_composited_bounds(rect)
+            rect.join(item.rect)
         return rect
 
     def absolute_bounds(self):
@@ -1065,14 +1052,9 @@ class CompositedLayer:
             DrawOutline(0, 0, irect.width() - 1, irect.height() - 1, "red", 1).execute(canvas)
 
     def __repr__(self):
-        composited_bounds = skia.Rect.MakeEmpty()
-        self.add_composited_bounds(composited_bounds)
-        absolute_bounds = skia.Rect.MakeEmpty()
-        self.add_absolute_bounds(absolute_bounds)
-
         return ("layer: composited_bounds={} " +
             "absolute_bounds={} first_chunk={}").format(
-            composited_bounds, absolute_bounds,
+            self.composited_bounds(), self.absolute_bounds(),
             self.display_items if len(self.display_items) > 0 else 'None')
 
 def raster(display_list, canvas):
@@ -1463,9 +1445,8 @@ class Browser:
                 tree_to_list(cmd, all_commands)
         non_composited_commands = [cmd
             for cmd in all_commands
-            if not cmd.needs_compositing and \
-                (not cmd.parent or \
-                 cmd.parent.needs_compositing)
+            if isinstance(cmd, DrawCommand) or not cmd.needs_compositing
+            if not cmd.parent or cmd.parent.needs_compositing
         ]
         for cmd in non_composited_commands:
             did_break = False

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -41,9 +41,9 @@ from lab13 import JSContext, diff_styles, clamp_scroll, add_parent_pointers
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
-from lab13 import CompositedLayer, paint_visual_effects
-from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer, DrawOutline
-from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, add_main_args
+from lab13 import CompositedLayer, paint_visual_effects, add_main_args
+from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
+from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 
 @wbetools.patch(Element)
 class Element:
@@ -1409,9 +1409,8 @@ class Browser:
                 tree_to_list(cmd, all_commands)
         non_composited_commands = [cmd
             for cmd in all_commands
-            if not cmd.needs_compositing and \
-                (not cmd.parent or \
-                 cmd.parent.needs_compositing)
+            if isinstance(cmd, DrawCommand) or not cmd.needs_compositing
+            if not cmd.parent or cmd.parent.needs_compositing
         ]
         for cmd in non_composited_commands:
             for layer in reversed(self.composited_layers):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -36,9 +36,9 @@ from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointe
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
-from lab13 import CompositedLayer, paint_visual_effects
-from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
-from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, add_main_args
+from lab13 import CompositedLayer, paint_visual_effects, add_main_args
+from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
+from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 from lab14 import parse_color, DrawRRect, \
     is_focused, parse_outline, paint_outline, has_outline, \
     device_px, cascade_priority, style, \
@@ -108,7 +108,7 @@ class URL:
         s.close()
         return headers, body
 
-class DrawImage(DisplayItem):
+class DrawImage(DrawCommand):
     def __init__(self, image, rect, quality):
         super().__init__(rect)
         self.image = image
@@ -1787,9 +1787,8 @@ class Browser:
 
         non_composited_commands = [cmd
             for cmd in all_commands
-            if not cmd.needs_compositing and \
-                (not cmd.parent or \
-                 cmd.parent.needs_compositing)
+            if isinstance(cmd, DrawCommand) or not cmd.needs_compositing
+            if not cmd.parent or cmd.parent.needs_compositing
         ]
         for cmd in non_composited_commands:
             for layer in reversed(self.composited_layers):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -32,10 +32,9 @@ from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointe
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
-from lab13 import CompositedLayer, paint_visual_effects
-from lab13 import DisplayItem, DrawText, DrawCompositedLayer, SaveLayer
-from lab13 import ClipRRect, Transform, DrawLine, DrawRRect, \
-    add_main_args
+from lab13 import CompositedLayer, paint_visual_effects, add_main_args
+from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
+from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 from lab14 import parse_color, parse_outline, DrawRRect, \
     is_focused, paint_outline, has_outline, \
     device_px, cascade_priority, \


### PR DESCRIPTION
This PR splits the old `DisplayItem` superclass for display items into two: `DrawCommand` for paint commands and `VisualEffect` for visual effects. This has a few benefits:

- We no longer need to introduce `is_paint_command` initially. (Along the way, this fixes bugs like `DrawImage` technically claiming not to be a paint command.)
- We also do not need to pretend that drawing commands offer methods like `clone` and `map`
- Also drawing commands no longer need (dummy) fields like `node` and `needs_compositing`.

Also I changed how "composited bounds" work in this PR. Basically, the `rect` field always contains the union of all child `rect`s. This passes the tests and per my careful checks but equivalent to the existing source code. That said, I don't actually think it's correct with its handling of `Transform`s, I just don't think the existing code is, either.