### PR TITLE
Add OUP styles if present

### DIFF
--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -491,6 +491,8 @@ $if(logo)$
 $endif$
 $endif$
 
+\IfFileExists{oupstylefixff.sty}{\usepackage{oupstylefix}}{}
+
 \begin{document}
 \begin{CJK}{UTF8}{gbsn}
 $if(has-frontmatter)$


### PR DESCRIPTION
I did not add the OUP style file directly as it's copyrighted.

Note: there is one error when compiling this (complaining that "Command \titlepage already defined."). I'm not sure why, I can't find where it would be multiply define elsewhere.