### PR TITLE
Remove the `has_outline` method

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1089,16 +1089,14 @@ around this, let's draw the focus ring in `LineLayout`. Each
 `LineLayout` finds all of its child `TextLayout`s that are focused,
 and draws a rectangle around them all:
 
-``` {.python}
+``` {.python replace=child.node.parent.is_focused/parse_outline(outline_str)}
 class LineLayout:
     def paint(self, display_list):
         # ...
         outline_rect = skia.Rect.MakeEmpty()
         outline_node = None
         for child in self.children:
-            outline_str = child.node.parent.style.get("outline")
-            outline = parse_outline(outline_str)
-            if outline:
+            if child.node.parent.is_focused:
                 outline_rect.join(child.rect())
                 outline_node = child.node.parent
         if outline_node:
@@ -1360,8 +1358,7 @@ class LineLayout:
     def paint(self, display_list):
         for child in self.children:
             outline_str = child.node.parent.style.get("outline")
-            outline = parse_outline(outline_str)
-            if outline:
+            if parse_outline(outline_str):
                 outline_rect.join(child.rect())
                 outline_node = child.node.parent
 ```

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1038,13 +1038,13 @@ drawing a vertical line in `InputLayout`'s `paint` method. We'll
 add a call to `paint_outline` in that method, to draw a rectangle around the focused
 element:
 
-``` {.python replace=node.is_focused/has_outline(node),%22black%22/color,1/thickness}
+``` {.python replace=node.is_focused/outline,%22black%22/color,1/device_px(thickness%2c%20zoom)}
 def paint_outline(node, cmds, rect, zoom):
-    if node.is_focused:
-        cmds.append(DrawOutline(
-            rect.left(), rect.top(),
-            rect.right(), rect.bottom(),
-            "black", 1))
+    if not node.is_focused: return
+    cmds.append(DrawOutline(
+        rect.left(), rect.top(),
+        rect.right(), rect.bottom(),
+        "black", 1))
 ```
 
 We'll set this flag in a new `focus_element` method that we'll now use
@@ -1094,15 +1094,16 @@ class LineLayout:
     def paint(self, display_list):
         # ...
         outline_rect = skia.Rect.MakeEmpty()
-        focused_node = None
+        outline_node = None
         for child in self.children:
-            node = child.node
-            if has_outline(node.parent):
-                focused_node = node.parent
+            outline_str = child.node.parent.style.get("outline")
+            outline = parse_outline(outline_str)
+            if outline:
                 outline_rect.join(child.rect())
-        if focused_node:
+                outline_node = child.node.parent
+        if outline_node:
             paint_outline(
-                focused_node, display_list, outline_rect, self.zoom)
+                outline_node, display_list, outline_rect, self.zoom)
 ```
 
 You should also add a `paint_outline` call to `BlockLayout`, since
@@ -1305,29 +1306,26 @@ parse that into a thickness and a color, assuming that we only want to
 support `solid` outlines:
 
 ``` {.python}
-def parse_outline(outline_str, zoom):
+def parse_outline(outline_str):
     if not outline_str: return None
     values = outline_str.split(" ")
     if len(values) != 3: return None
     if values[1] != "solid": return None
-    return (device_px(int(values[0][:-2]), zoom), values[2])
+    return int(values[0][:-2]), values[2]
 ```
 
 Now we can use this `parse_outline` method when drawing an outline, in
 `paint_outline`:
 
 ``` {.python}
-def has_outline(node):
-    return parse_outline(node.style.get("outline"), 1)
-
 def paint_outline(node, cmds, rect, zoom):
-    if has_outline(node):
-        thickness, color = \
-            parse_outline(node.style.get("outline"), zoom)
-        cmds.append(DrawOutline(
-            rect.left(), rect.top(),
-            rect.right(), rect.bottom(),
-            color, thickness))
+    outline = parse_outline(node.style.get("outline"))
+    if not outline: return
+    thickness, color = outline
+    cmds.append(DrawOutline(
+        rect.left(), rect.top(),
+        rect.right(), rect.bottom(),
+        color, device_px(thickness, zoom)))
 ```
 
 The default two-pixel black outline can now be moved into the browser
@@ -1361,8 +1359,11 @@ to the browser style sheet above:
 class LineLayout:
     def paint(self, display_list):
         for child in self.children:
-            if has_outline(node.parent):
-                # ...
+            outline_str = child.node.parent.style.get("outline")
+            outline = parse_outline(outline_str)
+            if outline:
+                outline_rect.join(child.rect())
+                outline_node = child.node.parent
 ```
 
 As with dark mode, focus outlines are a case where adding an

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -23,17 +23,12 @@ Outlines
 
 The outline css property can be parsed:
 
-    >>> lab14.parse_outline("12px solid red", 1)
+    >>> lab14.parse_outline("12px solid red")
     (12, 'red')
-
-If zoom is set, it is incorporated:
-
-    >>> lab14.parse_outline("12px solid red", 2)
-    (24, 'red')
 
 Values other than "solid" for the secnod word are ignored:
 
-    >>> lab14.parse_outline("12px dashed red", 1)
+    >>> lab14.parse_outline("12px dashed red")
 
 An outline causes a `DrawOutline` with the given width and color:
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -94,24 +94,21 @@ def parse_color(color):
     else:
         return skia.ColorBLACK
 
-def parse_outline(outline_str, zoom):
+def parse_outline(outline_str):
     if not outline_str: return None
     values = outline_str.split(" ")
     if len(values) != 3: return None
     if values[1] != "solid": return None
-    return (device_px(int(values[0][:-2]), zoom), values[2])
-
-def has_outline(node):
-    return parse_outline(node.style.get("outline"), 1)
+    return int(values[0][:-2]), values[2]
 
 def paint_outline(node, cmds, rect, zoom):
-    if has_outline(node):
-        thickness, color = \
-            parse_outline(node.style.get("outline"), zoom)
+    outline = parse_outline(node.style.get("outline"))
+    if outline:
+        thickness, color = outline
         cmds.append(DrawOutline(
             rect.left(), rect.top(),
             rect.right(), rect.bottom(),
-            color, thickness))
+            color, device_px(thickness, zoom)))
 
 class BlockLayout:
     def __init__(self, node, parent, previous):
@@ -291,7 +288,7 @@ class LineLayout:
         focused_node = None
         for child in self.children:
             node = child.node
-            if has_outline(node.parent):
+            if parse_outline(node.parent.style.get("outline")):
                 focused_node = node.parent
                 outline_rect.join(child.rect())
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -284,7 +284,6 @@ class LineLayout:
             child.paint(display_list)
 
         outline_rect = skia.Rect.MakeEmpty()
-        focused_node = None
         outline = None
         for child in self.children:
             child_outline = parse_outline(child.node.parent.style.get("outline"))

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -101,7 +101,8 @@ def parse_outline(outline_str):
     if values[1] != "solid": return None
     return int(values[0][:-2]), values[2]
 
-def paint_outline(outline, rect, cmds, zoom):
+def paint_outline(node, cmds, rect, zoom):
+    outline = parse_outline(node.style.get("outline"))
     if not outline: return
     thickness, color = outline
     cmds.append(DrawOutline(
@@ -284,14 +285,17 @@ class LineLayout:
             child.paint(display_list)
 
         outline_rect = skia.Rect.MakeEmpty()
-        outline = None
+        outline_node = None
         for child in self.children:
-            child_outline = parse_outline(child.node.parent.style.get("outline"))
-            if child_outline:
+            outline_str = child.node.parent.style.get("outline")
+            outline = parse_outline(outline_str)
+            if outline:
                 outline_rect.join(child.rect())
-                outline = child_outline
+                outline_node = child.node.parent
 
-        paint_outline(outline, outline_rect, display_list, self.zoom)
+        if outline_node:
+            paint_outline(
+                outline_node, display_list, outline_rect, self.zoom)
 
     def role(self):
         return "none"
@@ -488,8 +492,7 @@ class InputLayout:
                                  "black", 1))
 
         cmds = paint_visual_effects(self.node, cmds, rect)
-        outline = parse_outline(self.node.style.get("outline"))
-        paint_outline(outline, rect, cmds, self.zoom)
+        paint_outline(self.node, cmds, rect, self.zoom)
         display_list.extend(cmds)
 
     def __repr__(self):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -288,8 +288,7 @@ class LineLayout:
         outline_node = None
         for child in self.children:
             outline_str = child.node.parent.style.get("outline")
-            outline = parse_outline(outline_str)
-            if outline:
+            if parse_outline(outline_str):
                 outline_rect.join(child.rect())
                 outline_node = child.node.parent
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -390,8 +390,7 @@ class InputLayout(EmbedLayout):
             cmds.append(DrawLine(cx, self.y, cx, self.y + self.height, color, 1))
 
         cmds = paint_visual_effects(self.node, cmds, rect)
-        outline = parse_outline(self.node.style.get("outline"))
-        paint_outline(outline, rect, cmds, self.zoom)
+        paint_outline(self.node, cmds, rect, self.zoom)
         display_list.extend(cmds)
 
     def __repr__(self):
@@ -440,14 +439,15 @@ class LineLayout:
             child.paint(display_list)
 
         outline_rect = skia.Rect.MakeEmpty()
-        outline = None
+        outline_node = None
         for child in self.children:
             child_outline = parse_outline(child.node.parent.style.get("outline"))
             if child_outline:
                 outline_rect.join(child.rect())
-                outline = child_outline
+                outline_node = child.node.parent
 
-        paint_outline(outline, outline_rect, display_list, self.zoom)
+        if outline_node:
+            paint_outline(outline_node, display_list, outline_rect, self.zoom)
 
     def role(self):
         return "none"
@@ -609,8 +609,7 @@ class IframeLayout(EmbedLayout):
             self.x + diff, self.y + diff,
             self.x + self.width - diff, self.y + self.height - diff)
         cmds = paint_visual_effects(self.node, cmds, inner_rect)
-        outline = parse_outline(self.node.style.get("outline"))
-        paint_outline(outline, rect, cmds, self.zoom)
+        paint_outline(self.node, cmds, rect, self.zoom)
         display_list.extend(cmds)
 
     def __repr__(self):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -441,8 +441,8 @@ class LineLayout:
         outline_rect = skia.Rect.MakeEmpty()
         outline_node = None
         for child in self.children:
-            child_outline = parse_outline(child.node.parent.style.get("outline"))
-            if child_outline:
+            outline_str = child.node.parent.style.get("outline")
+            if parse_outline(outline_str):
                 outline_rect.join(child.rect())
                 outline_node = child.node.parent
 


### PR DESCRIPTION
This PR reduces our trio of outline helper functions (`has_outline`, `parse_outline`, `paint_outline`) to two. The basic insight is that `has_outline` just directly calls `parse_outline` so should be inlined, but that to make that palatable we need to make `parse_outline` not take a zoom parameter so it's easier to call.

Along the way I deduplicated a few double-calls to `parse_outline`.