### PR TITLE
Refactor the `clamp_scroll` method

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1289,8 +1289,19 @@ class Frame:
         return max(0, min(scroll, maxscroll))
 ```
 
-Make sure to use the new `clamp_scroll` in place of the old one,
-everywhere in `Frame`:
+For browser-thread scrolling we'll have a similar function that uses
+the active tab height:
+
+``` {.python}
+class Browser:
+    def clamp_scroll(self, scroll):
+        height = self.active_tab_height
+        maxscroll = height - (HEIGHT - CHROME_PX)
+        return max(0, min(scroll, maxscroll))
+```
+
+Make sure to use the new `clamp_scroll` methods in place of the old
+ones everywhere. For example, in `scroll_to`:
 
 ``` {.python}
 class Frame:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -32,7 +32,7 @@ from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, linespace, parse_blend_mode
 from lab12 import MeasureTime, REFRESH_RATE_SEC
 from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
-from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointers
+from lab13 import diff_styles, parse_transition, add_parent_pointers
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
@@ -1938,16 +1938,19 @@ class Browser:
                 self.animation_timer.start()
         self.lock.release()
 
+    def clamp_scroll(self, scroll):
+        height = self.active_tab_height
+        maxscroll = height - (HEIGHT - CHROME_PX)
+        return max(0, min(scroll, maxscroll))
+
     def handle_down(self):
         self.lock.acquire(blocking=True)
         if self.root_frame_focused:
             if not self.active_tab_height:
                 self.lock.release()
                 return
-            scroll = clamp_scroll(
-                self.scroll + SCROLL_STEP,
-                self.active_tab_height)
-            self.scroll = scroll
+            self.scroll = \
+                self.clamp_scroll(self.scroll + SCROLL_STEP)
             self.set_needs_draw()
             self.needs_animation_frame = True
             self.lock.release()

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -28,7 +28,7 @@ from lab10 import COOKIE_JAR
 from lab11 import FONTS, get_font, linespace, parse_blend_mode
 from lab12 import MeasureTime, REFRESH_RATE_SEC
 from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
-from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointers
+from lab13 import diff_styles, parse_transition, add_parent_pointers
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES


### PR DESCRIPTION
Up until Chapter 15, there's a `clamp_scroll` function that clamps the scroll position. In Chapter 15, though, we add frames that can have fixed heights, at which point instead of generalizing the one function we add a `clamp_scroll` method on `Frame`s. But we also keep the global function. That seems ugly and disorganized to me, so instead this PR turns that function into a similar method on `Browser`. I think it looks nicer.