### PR TITLE
Require crossOriginIsolated for lab9+-browser.html

### DIFF
--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -411,8 +411,7 @@ class math {
 
 class JSInterpreterError extends ExpectedError {
     constructor() {
-        super("This widget cannot execute JavaScript due to sandboxing, " +
-             "but the book's Python code should work correctly.");
+        super("This widget cannot work unless crossOriginIsolated is true.");
         this.name = "JSEnvironmentError."
     }
 }


### PR DESCRIPTION
The JS error thrown when crossOriginIsolated is false causes a JS error in the browser that breaks the whole thing, and it's not worth trying to recover from it.