### PR TITLE
Move `add_main_args` to `wbetools`

### DIFF
--- a/infra/compile.py
+++ b/infra/compile.py
@@ -115,7 +115,7 @@ RENAME_FNS = {
     "AnimationClass": "AnimationClass"
 }
 
-SKIPPED_FNS = ["add_main_args"]
+SKIPPED_FNS = []
 
 # These are filled in as import statements are read
 RT_IMPORTS = []

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1715,34 +1715,13 @@ class Browser:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
-def add_main_args():
-    import argparse
-    parser = argparse.ArgumentParser(description='Toy browser')
-    parser.add_argument("url", type=str, help="URL to load")
-    parser.add_argument('--single_threaded', action="store_true", default=False,
-        help='Whether to run the browser without a browser thread')
-    parser.add_argument('--disable_compositing', action="store_true",
-        default=False, help='Whether to composite some elements')
-    parser.add_argument('--disable_gpu', action='store_true',
-        default=False, help='Whether to disable use of the GPU')
-    parser.add_argument('--show_composited_layer_borders', action="store_true",
-        default=False, help='Whether to visually indicate composited layer borders')
-    args = parser.parse_args()
-
-    wbetools.USE_BROWSER_THREAD = not args.single_threaded
-    wbetools.USE_GPU = not args.disable_gpu
-    wbetools.USE_COMPOSITING = not args.disable_compositing and not args.disable_gpu
-    wbetools.SHOW_COMPOSITED_LAYER_BORDERS = args.show_composited_layer_borders
-    return args
-
 if __name__ == "__main__":
     import sys
-
-    args = add_main_args()
+    wbetools.parse_flags()
 
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
-    browser.load(URL(args.url))
+    browser.load(URL(sys.argv[1]))
 
     event = sdl2.SDL_Event()
     while True:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -4,6 +4,7 @@ up to and including Chapter 13 (Animations and Compositing),
 without exercises.
 """
 
+import sys
 import ctypes
 import dukpy
 import math
@@ -1716,7 +1717,6 @@ class Browser:
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
 if __name__ == "__main__":
-    import sys
     wbetools.parse_flags()
 
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -4,6 +4,7 @@ up to and including Chapter 14 (Making Content Accessible),
 without exercises.
 """
 
+import sys
 import ctypes
 import dukpy
 import math

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -41,7 +41,7 @@ from lab13 import JSContext, diff_styles, clamp_scroll, add_parent_pointers
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
-from lab13 import CompositedLayer, paint_visual_effects, add_main_args
+from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
 from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 
@@ -1832,12 +1832,10 @@ class Browser:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
-def main_func(args):
-    import sys
-
+def main_func(url):
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
-    browser.load(URL(args.url))
+    browser.load(url)
 
     event = sdl2.SDL_Event()
     ctrl_down = False
@@ -1905,6 +1903,6 @@ def main_func(args):
         browser.schedule_animation_frame()
 
 if __name__ == "__main__":
-    args = add_main_args()
-    main_func(args)
+    wbetools.parse_flags()
+    main_func(URL(sys.argv[1]))
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -36,7 +36,7 @@ from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointe
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
-from lab13 import CompositedLayer, paint_visual_effects, add_main_args
+from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
 from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 from lab14 import parse_color, DrawRRect, \
@@ -2228,31 +2228,6 @@ class Browser:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
-def add_main_args():
-    import argparse
-
-    parser = argparse.ArgumentParser(description='Chapter 13 code')
-    parser.add_argument("url", type=str, help="URL to load")
-    parser.add_argument('--single_threaded', action="store_true", default=False,
-        help='Whether to run the browser without a browser thread')
-    parser.add_argument('--disable_compositing', action="store_true",
-        default=False, help='Whether to composite some elements')
-    parser.add_argument('--disable_gpu', action='store_true',
-        default=False, help='Whether to disable use of the GPU')
-    parser.add_argument('--show_composited_layer_borders', action="store_true",
-        default=False, help='Whether to visually indicate composited layer borders')
-    parser.add_argument("--force_cross_origin_iframes", action="store_true",
-        default=False, help="Whether to treat all iframes as cross-origin")
-    args = parser.parse_args()
-
-    wbetools.USE_BROWSER_THREAD = not args.single_threaded
-    wbetools.USE_GPU = not args.disable_gpu
-    wbetools.USE_COMPOSITING = not args.disable_compositing and not args.disable_gpu
-    wbetools.SHOW_COMPOSITED_LAYER_BORDERS = args.show_composited_layer_borders
-    wbetools.FORCE_CROSS_ORIGIN_IFRAMES = args.force_cross_origin_iframes
-
-    return args
-
 if __name__ == "__main__":
-    args = add_main_args()
-    main_func(args)
+    wbetools.parse_flags()
+    main_func(URL(sys.argv[1]))

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -4,6 +4,7 @@ up to and including Chapter 15 (Supporting Embedded Content),
 without exercises.
 """
 
+import sys
 import ctypes
 import dukpy
 import gtts

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -32,7 +32,7 @@ from lab13 import diff_styles, parse_transition, clamp_scroll, add_parent_pointe
 from lab13 import absolute_bounds, absolute_bounds_for_obj
 from lab13 import NumericAnimation, TranslateAnimation
 from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
-from lab13 import CompositedLayer, paint_visual_effects, add_main_args
+from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
 from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 from lab14 import parse_color, parse_outline, DrawRRect, \
@@ -1292,39 +1292,6 @@ class Tab:
 
         self.browser.commit(self, commit_data)
 
-def add_main_args():
-    import argparse
-
-    parser = argparse.ArgumentParser(description='Chapter 13 code')
-    parser.add_argument("url", type=str, help="URL to load")
-    parser.add_argument('--single_threaded', action="store_true", default=False,
-        help='Whether to run the browser without a browser thread')
-    parser.add_argument('--disable_compositing', action="store_true",
-        default=False, help='Whether to composite some elements')
-    parser.add_argument('--disable_gpu', action='store_true',
-        default=False, help='Whether to disable use of the GPU')
-    parser.add_argument('--show_composited_layer_borders', action="store_true",
-        default=False, help='Whether to visually indicate composited layer borders')
-    parser.add_argument("--force_cross_origin_iframes", action="store_true",
-        default=False, help="Whether to treat all iframes as cross-origin")
-    parser.add_argument("--assert_layout_clean", action="store_true",
-        default=False, help="Assert layout is clean once complete")
-    parser.add_argument("--print_invalidation_dependencies", action="store_true",
-        default=False, help="Whether to print out all invalidation dependencies")
-    args = parser.parse_args()
-
-    wbetools.USE_BROWSER_THREAD = not args.single_threaded
-    wbetools.USE_GPU = not args.disable_gpu
-    wbetools.USE_COMPOSITING = not args.disable_compositing and not args.disable_gpu
-    wbetools.SHOW_COMPOSITED_LAYER_BORDERS = args.show_composited_layer_borders
-    wbetools.FORCE_CROSS_ORIGIN_IFRAMES = args.force_cross_origin_iframes
-    wbetools.ASSERT_LAYOUT_CLEAN = args.assert_layout_clean
-    wbetools.PRINT_INVALIDATION_DEPENDENCIES = \
-        args.print_invalidation_dependencies
-
-    return args
-    
-
 if __name__ == "__main__":
-    args = add_main_args()
-    main_func(args)
+    wbetools.parse_flags()
+    main_func(URL(sys.argv[1]))

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -4,6 +4,7 @@ up to and including Chapter 16 (Reusing Previous Computations),
 without exercises.
 """
 
+import sys
 import sdl2
 import skia
 import ctypes

--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -63,4 +63,38 @@ USE_BROWSER_THREAD = True
 FORCE_CROSS_ORIGIN_IFRAMES = False
 ASSERT_LAYOUT_CLEAN = False
 PRINT_INVALIDATION_DEPENDENCIES = False
-WINDOW_COUNT = 0
+
+def parse_flags():
+    import argparse, sys
+    global SHOW_COMPOSITED_LAYER_BORDERS, \
+        USE_COMPOSITING, USE_GPU, USE_BROWSER_THREAD, \
+        FORCE_CROSS_ORIGIN_IFRAMES, ASSERT_LAYOUT_CLEAN, \
+        PRINT_INVALIDATION_DEPENDENCIES
+
+    parser = argparse.ArgumentParser(description='Chapter 13 code')
+    parser.add_argument("url", type=str, help="URL to load")
+    parser.add_argument('--single_threaded', action="store_true", default=False,
+        help='Whether to run the browser without a browser thread')
+    parser.add_argument('--disable_compositing', action="store_true",
+        default=False, help='Whether to composite some elements')
+    parser.add_argument('--disable_gpu', action='store_true',
+        default=False, help='Whether to disable use of the GPU')
+    parser.add_argument('--show_composited_layer_borders', action="store_true",
+        default=False, help='Whether to visually indicate composited layer borders')
+    parser.add_argument("--force_cross_origin_iframes", action="store_true",
+        default=False, help="Whether to treat all iframes as cross-origin")
+    parser.add_argument("--assert_layout_clean", action="store_true",
+        default=False, help="Assert layout is clean once complete")
+    parser.add_argument("--print_invalidation_dependencies", action="store_true",
+        default=False, help="Whether to print out all invalidation dependencies")
+    args = parser.parse_args()
+
+    USE_BROWSER_THREAD = not args.single_threaded
+    USE_GPU = not args.disable_gpu
+    USE_COMPOSITING = not args.disable_compositing and not args.disable_gpu
+    SHOW_COMPOSITED_LAYER_BORDERS = args.show_composited_layer_borders
+    FORCE_CROSS_ORIGIN_IFRAMES = args.force_cross_origin_iframes
+    ASSERT_LAYOUT_CLEAN = args.assert_layout_clean
+    PRINT_INVALIDATION_DEPENDENCIES = args.print_invalidation_dependencies
+
+    sys.argv = [sys.argv[0], args.url]


### PR DESCRIPTION
This PR moves this function to the `wbetools` helper module. The reasoning is twofold:

- The actual flags live there, so this makes things more self-contained
- I don't think it's strictly necessary for different versions of the browser to accept different flags, seeing as we only ever add flags (and could probably stick to this even if we changed flags)
- This way it won't show up on outlines as a function we never explained

Also to keep things a bit more self-contained, the new `wbetools.parse_flags` method doesn't return anything, it just parses the flags and restores the command-line arguments as if the flags weren't there.