### PR TITLE
Address feedback items for chapter 1

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1221,10 +1221,10 @@ checks if that's followed by a colon and a pseudo-class name:
 ``` {.python}
 class CSSParser:
     def simple_selector(self):
-        out = TagSelector(self.word().lower())
+        out = TagSelector(self.word().casefold())
         if self.i < len(self.s) and self.s[self.i] == ":":
             self.literal(":")
-            pseudoclass = self.word().lower()
+            pseudoclass = self.word().casefold()
             out = PseudoclassSelector(pseudoclass, out)
         return out
 ```

--- a/book/forms.md
+++ b/book/forms.md
@@ -855,7 +855,7 @@ def handle_connection(conx):
         line = req.readline().decode('utf8')
         if line == '\r\n': break
         header, value = line.split(":", 1)
-        headers[header.lower()] = value.strip()
+        headers[header.casefold()] = value.strip()
 ```
 
 Finally we read the body, but only when the `Content-Length` header

--- a/book/forms.md
+++ b/book/forms.md
@@ -627,7 +627,7 @@ The new `body` argument to `load` is then passed through to `request`:
 ``` {.python indent=4}
 def load(self, url, body=None):
     # ...
-    headers, body = url.request(body)
+    body = url.request(body)
     # ...
 ```
 

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -591,6 +591,13 @@ window's new width and height can be found in the `width` and `height`
 fields on the event object. Remember that when the window is resized,
 the line breaks must change, so you will need to call `layout` again.
 
+*about:blank:* Currently, a malformed URL causes the browser to crash.
+It would be much better to have error recovery for that, and instead
+show a blank page, so that the user can fix the error. To do this, add
+support for the special `about:blank` URL, which should just render
+a blank page, and cause malformed URLs to automatically render as if they
+were `about:blank`.
+
 [fill-expand]: https://web.archive.org/web/20201111222645id_/http://effbot.org/tkinterbook/pack.htm
 
 [^3]: On older systems, applications drew directly to the screen, and

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -357,7 +357,7 @@ Now `load` just needs to call `layout` followed by `draw`:
 ``` {.python}
 class Browser:
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         text = lex(body)
         self.display_list = layout(text)
         self.draw()

--- a/book/html.md
+++ b/book/html.md
@@ -284,7 +284,7 @@ Try this out on this web page, parsing the HTML source code and then
 calling `print_tree` to visualize it:
 
 ``` {.python expected=False}
-headers, body = URL(sys.argv[1]).request()
+body = URL(sys.argv[1]).request()
 nodes = HTMLParser(body).parse()
 print_tree(nodes)
 ```
@@ -432,7 +432,7 @@ whitespace to get the tag name and the attribute-value pairs:
 class HTMLParser:
     def get_attributes(self, text):
         parts = text.split()
-        tag = parts[0].lower()
+        tag = parts[0].casefold()
         attributes = {}
         for attrpair in parts[1:]:
             # ...
@@ -460,7 +460,7 @@ def get_attributes(self, text):
     for attrpair in parts[1:]:
         if "=" in attrpair:
             key, value = attrpair.split("=", 1)
-            attributes[key.lower()] = value
+            attributes[key.casefold()] = value
     # ...
 ```
 
@@ -471,7 +471,7 @@ case the attribute value defaults to the empty string:
 for attrpair in parts[1:]:
     # ...
     else:
-        attributes[attrpair.lower()] = ""
+        attributes[attrpair.casefold()] = ""
 ```
 
 Finally, the value can be quoted, in which case the quotes have to be
@@ -589,7 +589,7 @@ the node tree, like this:
 ``` {.python}
 class Browser:
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         self.nodes = HTMLParser(body).parse()
         self.display_list = Layout(self.nodes).display_list
         self.draw()

--- a/book/http.md
+++ b/book/http.md
@@ -109,7 +109,7 @@ Berners-Lee---no surprise there! The second author is Roy Fielding, a
 key contributor to the design HTTP and also well-known for describing
 the "REST" architecture of the web in his [PhD thesis][rest-thesis],
 which explains how REST allowed the web to grow in a decentralized
-way. Today, many services provide "REST APIs" that also follow these
+way. Today, many services provide "RESTful APIs" that also follow these
 principles, though there does seem to be [some
 confusion][what-is-rest] about it.
 :::
@@ -264,7 +264,7 @@ much traction, even though many people (including me!) think they are
 a good idea.
 :::
 
-[header]: https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+[headers]: https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
 
 [codes]: https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
 
@@ -517,17 +517,13 @@ endings.
 
 
 Let's now split the response into pieces. The first line is the
-status line:^[A status code other than 200 indicates various forms of
-action needed by the browser, such as a [redirect] code like 301, or
-action needed by the user, such as the famous [404]. I could have asserted
+status line:^[I could have asserted
 that 200 is required, since that's the only code our browser supports,
 but it's better to just let the browser render the returned body, because
 servers will generally output a helpful and user-readable HTML error page
 even for these codes. This is another way in which the web is easy to
 implement incrementally.]
 
-[redirect]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
-[404]: https://en.wikipedia.org/wiki/HTTP_404
 
 ``` {.python}
 class URL:
@@ -635,6 +631,9 @@ is enclosed in a pair of tags: `<title>` and `</title>`. Each tag, inside
 the angle brackets, has a tag name\index{tag name} (like `title` here),
 and then optionally a space followed by *attributes*, and its pair has a `/`
 followed by the tag name (and no attributes). 
+
+[^content-tag]: That said, some tags, like `img`, are content, not information
+    about it.
 
 So, to create our very, very simple web browser, let's take the page
 HTML and print all the text, but not the tags, in it.[^python2] I'll do
@@ -842,7 +841,7 @@ Summary
 This chapter went from an empty file to a rudimentary web browser that
 can:
 
--   Parse a URL into a scheme, host, port and path.
+-   Parse a URL into a scheme, host, port and path
 -   Connect to that host using the `sockets` and `ssl` libraries
 -   Send an HTTP request to that host, including a `Host` header
 -   Split the HTTP response into a status line, headers, and a body

--- a/book/http.md
+++ b/book/http.md
@@ -554,19 +554,23 @@ class URL:
             line = response.readline()
             if line == "\r\n": break
             header, value = line.split(":", 1)
-            response_headers[header.lower()] = value.strip()
+            response_headers[header.casefold()] = value.strip()
 ```
 
-For the headers, I split each line at the first colon and fill in a
-map of header names to header values. Headers are case-insensitive, so
-I normalize them to lower case. Also, white-space is insignificant in
-HTTP header values, so I strip off extra whitespace at the beginning
-and end.
+For the headers, I split each line at the first colon and fill in a map of
+header names to header values. Headers are case-insensitive, so I normalize
+them to lower case.[^casefold] Also, white-space is insignificant in HTTP
+header values, so I strip off extra whitespace at the beginning and end.
+
+[^casefold]: I used [`casefold`][casefold] instead of `lower`, because it works
+better for more languages.
+
+[casefold]: https://docs.python.org/3/library/stdtypes.html#str.casefold
 
 Headers can describe all sorts of information, but a couple of headers
 are especially important because they tell us that the data we're
 trying to access is being sent in an unusual way. Let's make sure none
-of those are present:[^if-te]
+of those are present.[^if-te]
 
 [^if-te]: The "compression" exercise at the end of this chapter
     describes how your browser should handle these headers if they are
@@ -590,14 +594,13 @@ class URL:
         s.close()
 ```
 
-It's that body that we're going to display, so let's return that.
-Let's also return the headers, in case they are useful to someone:
+It's that body that we're going to display, so let's return that:
 
 ``` {.python}
 class URL:
     def request(self):
         # ...
-        return response_headers, body
+        return body
 ```
 
 Now let's actually display the text in the response body.
@@ -668,7 +671,7 @@ We can now load a web page just by stringing together `request` and
 
 ``` {.python}
 def load(url):
-    headers, body = url.request()
+    body = url.request()
     show(body)
 ```
 
@@ -754,8 +757,7 @@ detect which scheme is being used:
 class URL:
     def __init__(self, url):
         self.scheme, url = url.split("://", 1)
-        assert self.scheme in ["http", "https"], \
-            "Unknown scheme {}".format(self.scheme)
+        assert self.scheme in ["http", "https"]
         # ...
 ```
 

--- a/book/security.md
+++ b/book/security.md
@@ -792,9 +792,9 @@ def request(self, payload=None):
         params = {}
         if ";" in cookie:
             cookie, rest = cookie.split(";", 1)
-            for param_pair in rest.split(";"):
+        for param_pair in rest.split(";"):
                 name, value = param_pair.strip().split("=", 1)
-                params[name.lower()] = value.lower()
+                params[name.casefold()] = value.casefold()
         COOKIE_JAR[self.host] = (cookie, params)
 ```
 

--- a/book/security.md
+++ b/book/security.md
@@ -792,7 +792,7 @@ def request(self, payload=None):
         params = {}
         if ";" in cookie:
             cookie, rest = cookie.split(";", 1)
-        for param_pair in rest.split(";"):
+            for param_pair in rest.split(";"):
                 name, value = param_pair.strip().split("=", 1)
                 params[name.casefold()] = value.casefold()
         COOKIE_JAR[self.host] = (cookie, params)

--- a/book/styles.md
+++ b/book/styles.md
@@ -111,7 +111,7 @@ def pair(self):
     self.literal(":")
     self.whitespace()
     val = self.word()
-    return prop.lower(), val
+    return prop.casefold(), val
 ```
 
 We can parse sequences by calling parsing functions in a loop. For
@@ -122,7 +122,7 @@ def body(self):
     pairs = {}
     while self.i < len(self.s):
         prop, val = self.pair()
-        pairs[prop.lower()] = val
+        pairs[prop.casefold()] = val
         self.whitespace()
         self.literal(";")
         self.whitespace()
@@ -378,11 +378,11 @@ elements with those tags.
 
 ``` {.python indent=4}
 def selector(self):
-    out = TagSelector(self.word().lower())
+    out = TagSelector(self.word().casefold())
     self.whitespace()
     while self.i < len(self.s) and self.s[self.i] != "{":
         tag = self.word()
-        descendant = TagSelector(tag.lower())
+        descendant = TagSelector(tag.casefold())
         out = DescendantSelector(out, descendant)
         self.whitespace()
     return out
@@ -635,7 +635,7 @@ def load(self, url):
     # ...
     for link in links:
         try:
-            header, body = url.resolve(link).request()
+            body = url.resolve(link).request()
         except:
             continue
         rules.extend(CSSParser(body).parse())

--- a/book/text.md
+++ b/book/text.md
@@ -511,7 +511,7 @@ function, it can be replaced with calls into `Layout`:
 ``` {.python}
 class Browser:
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         tokens = lex(body)
         self.display_list = Layout(tokens).display_list
         self.draw()

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -97,7 +97,7 @@ def check_args(args, ctx):
     return out
 
 RENAME_METHODS = {
-    "lower": "toLowerCase",
+    "casefold": "toLowerCase",
     "upper": "toUpperCase",
     "strip": "trim",
     "append": "push",

--- a/infra/compiler.md
+++ b/infra/compiler.md
@@ -65,7 +65,7 @@ Note that keyword arguments become dictionary arguments at the end.
 
 Some library methods need to be renamed:
 
-    >>> Test.expr("header.lower()")
+    >>> Test.expr("header.casefold()")
     (header.toLowerCase())
     >>> Test.expr("value.strip()")
     (value.trim())

--- a/src/lab1-tests.md
+++ b/src/lab1-tests.md
@@ -68,7 +68,7 @@ To test it, we use the `test.socket` object, which mocks the HTTP server:
 
 Then we request the URL and test both request and response:
 
-    >>> headers, body = lab1.URL(url).request()
+    >>> body = lab1.URL(url).request()
     >>> test.socket.last_request(url)
     b'GET /example1 HTTP/1.0\r\nHost: test.test\r\n\r\n'
     >>> body
@@ -106,7 +106,7 @@ Here we're making sure that SSL support is enabled.
 
     >>> url = 'https://test.test/example2'
     >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\n\r\n")
-    >>> header, body = lab1.URL(url).request()
+    >>> body = lab1.URL(url).request()
     >>> body
     ''
 
@@ -114,7 +114,7 @@ SSL support also means some support for ports:
 
     >>> url = 'https://test.test:400/example3'
     >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\n\r\nHi")
-    >>> header, body = lab1.URL(url).request()
+    >>> body = lab1.URL(url).request()
     >>> body
     'Hi'
 

--- a/src/lab1-tests.md
+++ b/src/lab1-tests.md
@@ -73,8 +73,6 @@ Then we request the URL and test both request and response:
     b'GET /example1 HTTP/1.0\r\nHost: test.test\r\n\r\n'
     >>> body
     'Body text'
-    >>> headers
-    {'header1': 'Value1'}
 
 With an unusual `Transfer-Encoding` the request should fail:
 

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -11,8 +11,7 @@ import wbetools
 class URL:
     def __init__(self, url):
         self.scheme, url = url.split("://", 1)
-        assert self.scheme in ["http", "https"], \
-            "Unknown scheme {}".format(self.scheme)
+        assert self.scheme in ["http", "https"]
 
         if "/" not in url:
             url = url + "/"
@@ -47,7 +46,6 @@ class URL:
     
         statusline = response.readline()
         version, status, explanation = statusline.split(" ", 2)
-        assert status == "200", "{}: {}".format(status, explanation)
     
         response_headers = {}
         while True:

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -52,7 +52,7 @@ class URL:
             line = response.readline()
             if line == "\r\n": break
             header, value = line.split(":", 1)
-            response_headers[header.lower()] = value.strip()
+            response_headers[header.casefold()] = value.strip()
     
         assert "transfer-encoding" not in response_headers
         assert "content-encoding" not in response_headers
@@ -60,7 +60,7 @@ class URL:
         body = response.read()
         s.close()
     
-        return response_headers, body
+        return body
 
     @wbetools.js_hide
     def __repr__(self):
@@ -78,7 +78,7 @@ def show(body):
             print(c, end="")
 
 def load(url):
-    headers, body = url.request()
+    body = url.request()
     show(body)
 
 if __name__ == "__main__":

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -63,7 +63,7 @@ class URL:
             line = response.readline()
             if line == "\r\n": break
             header, value = line.split(":", 1)
-            response_headers[header.lower()] = value.strip()
+            response_headers[header.casefold()] = value.strip()
     
         if "set-cookie" in response_headers:
             cookie = response_headers["set-cookie"]
@@ -73,7 +73,7 @@ class URL:
                 for param_pair in rest.split(";"):
                     if '=' in param_pair:
                         name, value = param_pair.strip().split("=", 1)
-                        params[name.lower()] = value.lower()
+                        params[name.casefold()] = value.casefold()
             COOKIE_JAR[self.host] = (cookie, params)
     
         assert "transfer-encoding" not in response_headers

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -57,7 +57,6 @@ class URL:
     
         statusline = response.readline()
         version, status, explanation = statusline.split(" ", 2)
-        assert status == "200", "{}: {}".format(status, explanation)
     
         response_headers = {}
         while True:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -341,7 +341,7 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.until_semicolon()
-        return prop.lower(), val
+        return prop.casefold(), val
 
     def ignore_until(self, chars):
         while self.i < len(self.s):
@@ -355,7 +355,7 @@ class CSSParser:
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
                 prop, val = self.pair()
-                pairs[prop.lower()] = val
+                pairs[prop.casefold()] = val
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()
@@ -369,11 +369,11 @@ class CSSParser:
         return pairs
 
     def selector(self):
-        out = TagSelector(self.word().lower())
+        out = TagSelector(self.word().casefold())
         self.whitespace()
         while self.i < len(self.s) and self.s[self.i] != "{":
             tag = self.word()
-            descendant = TagSelector(tag.lower())
+            descendant = TagSelector(tag.casefold())
             out = DescendantSelector(out, descendant)
             self.whitespace()
         return out

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -668,7 +668,7 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.until_char(until)
-        return prop.lower(), val
+        return prop.casefold(), val
 
     def ignore_until(self, chars):
         while self.i < len(self.s):
@@ -682,7 +682,7 @@ class CSSParser:
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
                 prop, val = self.pair([";", "}"])
-                pairs[prop.lower()] = val
+                pairs[prop.casefold()] = val
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()
@@ -696,10 +696,10 @@ class CSSParser:
         return pairs
 
     def simple_selector(self):
-        out = TagSelector(self.word().lower())
+        out = TagSelector(self.word().casefold())
         if self.i < len(self.s) and self.s[self.i] == ":":
             self.literal(":")
-            pseudoclass = self.word().lower()
+            pseudoclass = self.word().casefold()
             out = PseudoclassSelector(pseudoclass, out)
         return out
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -81,7 +81,6 @@ class URL:
     
         statusline = response.readline().decode("utf8")
         version, status, explanation = statusline.split(" ", 2)
-        assert status == "200", "{}: {}".format(status, explanation)
     
         response_headers = {}
         while True:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -87,7 +87,7 @@ class URL:
             line = response.readline().decode("utf8")
             if line == "\r\n": break
             header, value = line.split(":", 1)
-            response_headers[header.lower()] = value.strip()
+            response_headers[header.casefold()] = value.strip()
     
         if "set-cookie" in response_headers:
             cookie = response_headers["set-cookie"]
@@ -97,7 +97,7 @@ class URL:
                 for param_pair in rest.split(";"):
                     if '=' in param_pair:
                         name, value = param_pair.strip().split("=", 1)
-                        params[name.lower()] = value.lower()
+                        params[name.casefold()] = value.casefold()
             COOKIE_JAR[self.host] = (cookie, params)
     
         assert "transfer-encoding" not in response_headers
@@ -661,9 +661,9 @@ class AttributeParser:
             key = self.word()
             if self.literal("="):
                 value = self.word(allow_quotes=True) 
-                attributes[key.lower()] = value
+                attributes[key.casefold()] = value
             else:
-                attributes[key.lower()] = ""
+                attributes[key.casefold()] = ""
         return (tag, attributes)
 
 class HTMLParser:

--- a/src/lab2.py
+++ b/src/lab2.py
@@ -55,7 +55,7 @@ class Browser:
         self.window.bind("<Down>", self.scrolldown)
 
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         text = lex(body)
         self.display_list = layout(text)
         self.draw()

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -141,7 +141,7 @@ class Browser:
         self.display_list = []
 
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         tokens = lex(body)
         self.display_list = Layout(tokens).display_list
         self.draw()

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -66,16 +66,16 @@ class HTMLParser:
 
     def get_attributes(self, text):
         parts = text.split()
-        tag = parts[0].lower()
+        tag = parts[0].casefold()
         attributes = {}
         for attrpair in parts[1:]:
             if "=" in attrpair:
                 key, value = attrpair.split("=", 1)
                 if len(value) > 2 and value[0] in ["'", "\""]:
                     value = value[1:-1]
-                attributes[key.lower()] = value
+                attributes[key.casefold()] = value
             else:
-                attributes[attrpair.lower()] = ""
+                attributes[attrpair.casefold()] = ""
         return tag, attributes
 
     def add_text(self, text):
@@ -193,7 +193,7 @@ class Layout:
 @wbetools.patch(Browser)
 class Browser:
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         self.nodes = HTMLParser(body).parse()
         self.display_list = Layout(self.nodes).display_list
         self.draw()

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -198,7 +198,7 @@ class DrawRect:
 @wbetools.patch(Browser)
 class Browser:
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         self.nodes = HTMLParser(body).parse()
         self.document = DocumentLayout(self.nodes)
         self.document.layout()

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -68,7 +68,7 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.word()
-        return prop.lower(), val
+        return prop.casefold(), val
 
     def ignore_until(self, chars):
         while self.i < len(self.s):
@@ -82,7 +82,7 @@ class CSSParser:
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
                 prop, val = self.pair()
-                pairs[prop.lower()] = val
+                pairs[prop.casefold()] = val
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()
@@ -96,11 +96,11 @@ class CSSParser:
         return pairs
 
     def selector(self):
-        out = TagSelector(self.word().lower())
+        out = TagSelector(self.word().casefold())
         self.whitespace()
         while self.i < len(self.s) and self.s[self.i] != "{":
             tag = self.word()
-            descendant = TagSelector(tag.lower())
+            descendant = TagSelector(tag.casefold())
             out = DescendantSelector(out, descendant)
             self.whitespace()
         return out
@@ -294,7 +294,7 @@ class Browser:
             self.default_style_sheet = CSSParser(f.read()).parse()
 
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         self.nodes = HTMLParser(body).parse()
 
         rules = self.default_style_sheet.copy()
@@ -306,7 +306,7 @@ class Browser:
                  and node.attributes.get("rel") == "stylesheet"]
         for link in links:
             try:
-                header, body = url.resolve(link).request()
+                body = url.resolve(link).request()
             except:
                 continue
             rules.extend(CSSParser(body).parse())

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -241,7 +241,7 @@ class Tab:
             self.default_style_sheet = CSSParser(f.read()).parse()
 
     def load(self, url):
-        headers, body = url.request()
+        body = url.request()
         self.scroll = 0
         self.url = url
         self.history.append(url)
@@ -256,7 +256,7 @@ class Tab:
                  and node.attributes.get("rel") == "stylesheet"]
         for link in links:
             try:
-                header, body = url.resolve(link).request()
+                body = url.resolve(link).request()
             except:
                 continue
             rules.extend(CSSParser(body).parse())

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -22,7 +22,7 @@ one.
     >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\n" +
     ... b"Header1: Value1\r\n\r\n" +
     ... b"<div>Form submitted</div>", method="POST", body=request_body)
-    >>> headers, body = lab8.URL(url).request(request_body)
+    >>> body = lab8.URL(url).request(request_body)
     >>> test.socket.last_request(url)
     b'POST /submit HTTP/1.0\r\nContent-Length: 20\r\nHost: test\r\n\r\nname=1&comment=2%3D3'
 

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -72,14 +72,14 @@ class URL:
             line = response.readline()
             if line == "\r\n": break
             header, value = line.split(":", 1)
-            response_headers[header.lower()] = value.strip()
+            response_headers[header.casefold()] = value.strip()
     
         assert "transfer-encoding" not in response_headers
         assert "content-encoding" not in response_headers
     
         body = response.read()
         s.close()
-        return response_headers, body
+        return body
 
 INPUT_WIDTH_PX = 200
 

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -66,7 +66,6 @@ class URL:
     
         statusline = response.readline()
         version, status, explanation = statusline.split(" ", 2)
-        assert status == "200", "{}: {}".format(status, explanation)
     
         response_headers = {}
         while True:

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -222,7 +222,7 @@ class Tab:
         self.scroll = 0
         self.url = url
         self.history.append(url)
-        headers, body = url.request(body)
+        body = url.request(body)
         self.nodes = HTMLParser(body).parse()
 
         self.rules = self.default_style_sheet.copy()
@@ -234,7 +234,7 @@ class Tab:
                  and node.attributes.get("rel") == "stylesheet"]
         for link in links:
             try:
-                header, body = url.resolve(link).request()
+                body = url.resolve(link).request()
             except:
                 continue
             self.rules.extend(CSSParser(body).parse())

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -86,7 +86,7 @@ class Tab:
         self.scroll = 0
         self.url = url
         self.history.append(url)
-        headers, body = url.request(body)
+        body = url.request(body)
         self.nodes = HTMLParser(body).parse()
 
         self.js = JSContext(self)
@@ -96,7 +96,7 @@ class Tab:
                    and node.tag == "script"
                    and "src" in node.attributes]
         for script in scripts:
-            header, body = url.resolve(script).request()
+            body = url.resolve(script).request()
             try:
                 self.js.run(body)
             except dukpy.JSRuntimeError as e:
@@ -111,7 +111,7 @@ class Tab:
                  and node.attributes.get("rel") == "stylesheet"]
         for link in links:
             try:
-                header, body = url.resolve(link).request()
+                body = url.resolve(link).request()
             except:
                 continue
             self.rules.extend(CSSParser(body).parse())

--- a/src/server10.py
+++ b/src/server10.py
@@ -15,7 +15,7 @@ def handle_connection(conx):
         line = req.readline().decode('utf8')
         if line == '\r\n': break
         header, value = line.split(":", 1)
-        headers[header.lower()] = value.strip()
+        headers[header.casefold()] = value.strip()
     if 'content-length' in headers:
         length = int(headers['content-length'])
         body = req.read(length).decode('utf8')

--- a/src/server12.py
+++ b/src/server12.py
@@ -16,7 +16,7 @@ def handle_connection(conx):
         line = req.readline().decode('utf8')
         if line == '\r\n': break
         header, value = line.split(":", 1)
-        headers[header.lower()] = value.strip()
+        headers[header.casefold()] = value.strip()
     if 'content-length' in headers:
         length = int(headers['content-length'])
         body = req.read(length).decode('utf8')

--- a/src/server8.py
+++ b/src/server8.py
@@ -11,7 +11,7 @@ def handle_connection(conx):
         line = req.readline().decode('utf8')
         if line == '\r\n': break
         header, value = line.split(":", 1)
-        headers[header.lower()] = value.strip()
+        headers[header.casefold()] = value.strip()
     if 'content-length' in headers:
         length = int(headers['content-length'])
         body = req.read(length).decode('utf8')

--- a/src/server9.py
+++ b/src/server9.py
@@ -11,7 +11,7 @@ def handle_connection(conx):
         line = req.readline().decode('utf8')
         if line == '\r\n': break
         header, value = line.split(":", 1)
-        headers[header.lower()] = value.strip()
+        headers[header.casefold()] = value.strip()
     if 'content-length' in headers:
         length = int(headers['content-length'])
         body = req.read(length).decode('utf8')

--- a/src/test.py
+++ b/src/test.py
@@ -34,9 +34,9 @@ class socket:
         if self.method == "POST":
             beginning, self.body = self.request.decode("latin1").split("\r\n\r\n")
             headers = [item.split(": ") for item in beginning.split("\r\n")[1:]]
-            assert any(name.lower() == "content-length" for name, value in headers)
+            assert any(name.casefold() == "content-length" for name, value in headers)
             assert all(int(value) == len(self.body) for name, value in headers
-                       if name.lower() == "content-length")
+                       if name.casefold() == "content-length")
 
     def makefile(self, mode, encoding=None, newline=None):
         assert self.connected and self.host and self.port


### PR DESCRIPTION
* Exercise added to chapter 2 for about:blank
* Drop assert error messages
* Removed extra commentary about HTML syntax
* Get rid of 200 assert (I really like this change!)
* Use casefold throughout all chapters
* Don't return headers from `request` until chapter 10

Also:
* Changed numbered footnotes into named ones, and put them inline