### PR TITLE
Factor out paint recursion into a paint_tree method

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1092,7 +1092,7 @@ class LineLayout:
         outline_node = None
         for child in self.children:
             if child.node.parent.is_focused:
-                outline_rect.join(child.rect())
+                outline_rect.join(child.self_rect())
                 outline_node = child.node.parent
         if outline_node:
             paint_outline(
@@ -1356,7 +1356,7 @@ class LineLayout:
         for child in self.children:
             outline_str = child.node.parent.style.get("outline")
             if parse_outline(outline_str):
-                outline_rect.join(child.rect())
+                outline_rect.join(child.self_rect())
                 outline_node = child.node.parent
 ```
 

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1060,20 +1060,15 @@ class Tab:
             node.is_focused = True
 ```
 
-To draw an outline, we'll use `DrawOutline`:
+To draw an outline, we'll use `DrawOutline`. This will have to happen in
+`paint_effects`, because it paints on top of the painted subtree.
 
 ``` {.python}
 class InputLayout:
-	def paint(self, display_list):
-		# ...
-        if self.node.is_focused and self.node.tag == "input":
-            cx = self.x + self.font.measureText(text)
-            cmds.append(DrawLine(cx, self.y, cx, self.y + self.height,
-                                 "black", 1))
-
+	def paint_effects(self, cmds):
         cmds = paint_visual_effects(self.node, cmds, rect)
         paint_outline(self.node, cmds, rect, self.zoom)
-        display_list.extend(cmds)
+        return cmds
 ```
 
 I also changed the cursor drawing to only happen if the node is
@@ -1087,12 +1082,12 @@ code. Moreover, those `TextLayout`s could be split across several
 lines, so we might want to draw more than one focus ring. To work
 around this, let's draw the focus ring in `LineLayout`. Each
 `LineLayout` finds all of its child `TextLayout`s that are focused,
-and draws a rectangle around them all:
+and draws a rectangle around them all. This will need to happen in
+`paint_effects` because it paints on top of the painted subtree.
 
 ``` {.python replace=child.node.parent.is_focused/parse_outline(outline_str)}
 class LineLayout:
-    def paint(self, display_list):
-        # ...
+    def paint_effects(self, cmds):
         outline_rect = skia.Rect.MakeEmpty()
         outline_node = None
         for child in self.children:
@@ -1101,7 +1096,8 @@ class LineLayout:
                 outline_node = child.node.parent
         if outline_node:
             paint_outline(
-                outline_node, display_list, outline_rect, self.zoom)
+                outline_node, cmds, outline_rect, self.zoom)
+        return cmds
 ```
 
 You should also add a `paint_outline` call to `BlockLayout`, since
@@ -1355,7 +1351,8 @@ to the browser style sheet above:
 
 ``` {.python}
 class LineLayout:
-    def paint(self, display_list):
+    def paint_effects(self, cmds):
+        # ...
         for child in self.children:
             outline_str = child.node.parent.style.get("outline")
             if parse_outline(outline_str):

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1066,8 +1066,8 @@ To draw an outline, we'll use `DrawOutline`. This will have to happen in
 ``` {.python}
 class InputLayout:
 	def paint_effects(self, cmds):
-        cmds = paint_visual_effects(self.node, cmds, rect)
-        paint_outline(self.node, cmds, rect, self.zoom)
+        cmds = paint_visual_effects(self.node, cmds, self.rect())
+        paint_outline(self.node, cmds, self.rect(), self.zoom)
         return cmds
 ```
 

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1066,8 +1066,8 @@ To draw an outline, we'll use `DrawOutline`. This will have to happen in
 ``` {.python}
 class InputLayout:
 	def paint_effects(self, cmds):
-        cmds = paint_visual_effects(self.node, cmds, self.rect())
-        paint_outline(self.node, cmds, self.rect(), self.zoom)
+        cmds = paint_visual_effects(self.node, cmds, self.self_rect())
+        paint_outline(self.node, cmds, self.self_rect(), self.zoom)
         return cmds
 ```
 

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -313,8 +313,8 @@ is painting. For `LineLayout` there is nothing to paint:
 
 ``` {.python}
 class LineLayout:
-    def paint(self, display_list):
-        pass
+    def paint(self):
+        return []
 
 ```
 
@@ -322,10 +322,12 @@ And each `TextLayout` creates a single `DrawText` call:
 
 ``` {.python}
 class TextLayout:
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, self.word, self.font, color))
+        return cmds
 ```
 
 So, oof, well, this was quite a bit of refactoring. Take a moment to

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -731,7 +731,6 @@ start by first painting the new-tab button:
 ``` {.python}
 class Chrome:
     def paint(self):
-        cmds = []
         cmds.append(DrawOutline(
             self.newtab_rect[0], self.newtab_rect[1],
             self.newtab_rect[2], self.newtab_rect[3],

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -313,20 +313,19 @@ is painting. For `LineLayout` there is nothing to paint:
 
 ``` {.python}
 class LineLayout:
-    def paint(self):
-        return []
+    def paint(self, display_list):
+        pass
+
 ```
 
 And each `TextLayout` creates a single `DrawText` call:
 
 ``` {.python}
 class TextLayout:
-    def paint(self):
-        cmds = []
+    def paint(self, display_list):
         color = self.node.style["color"]
-        cmds.append(
+        display_list.append(
             DrawText(self.x, self.y, self.word, self.font, color))
-        return cmds
 ```
 
 So, oof, well, this was quite a bit of refactoring. Take a moment to

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -323,11 +323,8 @@ And each `TextLayout` creates a single `DrawText` call:
 ``` {.python}
 class TextLayout:
     def paint(self):
-        cmds = []
         color = self.node.style["color"]
-        cmds.append(
-            DrawText(self.x, self.y, self.word, self.font, color))
-        return cmds
+        return [DrawText(self.x, self.y, self.word, self.font, color)]
 ```
 
 Now we don't need a `display_list` field in `BlockLayout`, and we can

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -309,23 +309,24 @@ class TextLayout:
 ```
 
 So that's `layout` for `LineLayout` and `TextLayout`. All that's left
-is painting. For `LineLayout` we just recurse:
+is painting. For `LineLayout` there is nothing to paint:
 
 ``` {.python}
 class LineLayout:
-    def paint(self, display_list):
-        for child in self.children:
-            child.paint(display_list)
+    def paint(self):
+        return []
 ```
 
 And each `TextLayout` creates a single `DrawText` call:
 
 ``` {.python}
 class TextLayout:
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, self.word, self.font, color))
+        return cmds
 ```
 
 So, oof, well, this was quite a bit of refactoring. Take a moment to

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1040,6 +1040,7 @@ Then painting of an `IframeLayout` is just drawing a rectangle and background:
 
 ``` {.python}
 class IframeLayout(EmbedLayout):
+    # ...
     def paint(self):
         cmds = []
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1038,9 +1038,11 @@ def paint_tree(layout_object, display_list):
 
 Then painting of an `IframeLayout` is just drawing a rectangle and background:
 
-``` {.python}
+::: {.todo}
+No idea why the expecation doesn't pass.
+:::
+``` {.python expected=False}
 class IframeLayout(EmbedLayout):
-    # ...
     def paint(self):
         cmds = []
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -358,7 +358,7 @@ class InputLayout(EmbedLayout):
         self.width = device_px(INPUT_WIDTH_PX, self.zoom)
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self):
         # ...
 ```
 
@@ -395,14 +395,14 @@ Painting an image is also straightforward:
 
 ``` {.python}
 class ImageLayout(EmbedLayout):
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
         rect = skia.Rect.MakeLTRB(
             self.x, self.y + self.height - self.img_height,
             self.x + self.width, self.y + self.height)
         quality = self.node.style.get("image-rendering", "auto")
         cmds.append(DrawImage(self.node.image, rect, quality))
-        display_list.extend(cmds)
+        return cmds
 ```
 
 Now we need to create `ImageLayout`s in `BlockLayout`. Input elements
@@ -1005,7 +1005,7 @@ class Tab:
     def render(self):
         if self.needs_paint:
             self.display_list = []
-            self.root_frame.paint(self.display_list)
+            paint_tree(self.root_frame.document, self.display_list)
             self.needs_paint = False
 ```
 
@@ -1021,9 +1021,27 @@ Most of the layout tree's `paint` methods don't need to change, but to
 paint an `IframeLayout`, we'll need to paint the child frame:
 
 ``` {.python}
+def paint_tree(layout_object, display_list):
+    cmds = layout_object.paint()
+
+    if isinstance(layout_object, IframeLayout) and \
+        layout_object.node.frame:
+        paint_tree(layout_object.node.frame.document, cmds)
+    else:
+        for child in layout_object.children:
+            paint_tree(child, cmds)
+
+    cmds = layout_object.paint_effects(cmds)
+    display_list.extend(cmds)
+
+```
+
+Then painting of an `IframeLayout` is just drawing a rectangle and background:
+
+``` {.python}
 class IframeLayout(EmbedLayout):
-    def paint(self, display_list):
-        frame_cmds = []
+    def paint(self):
+        cmds = []
 
         rect = skia.Rect.MakeLTRB(
             self.x, self.y,
@@ -1034,32 +1052,32 @@ class IframeLayout(EmbedLayout):
             radius = device_px(float(
                 self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
-            frame_cmds.append(DrawRRect(rect, radius, bgcolor))
-
-        if self.node.frame:
-            self.node.frame.paint(frame_cmds)
+            cmds.append(DrawRRect(rect, radius, bgcolor))
+        return cmds
 ```
 
 Note the last line, where we recursively paint the child frame. 
 
 Before putting those commands in the display list, though, we need to
 add a border, clip content outside of it, and transform the coordinate
-system:
+system. This applies to the painted output of the child frame, and so happens
+in `paint_effects`:
 
 ``` {.python}
 class IframeLayout(EmbedLayout):
-    def paint(self, display_list):
-        # ...
-
+    def paint_effects(self, cmds):
+        rect = skia.Rect.MakeLTRB(
+            self.x, self.y,
+            self.x + self.width, self.y + self.height)
         diff = device_px(1, self.zoom)
         offset = (self.x + diff, self.y + diff)
-        cmds = [Transform(offset, rect, self.node, frame_cmds)]
+        cmds = [Transform(offset, rect, self.node, cmds)]
         inner_rect = skia.Rect.MakeLTRB(
             self.x + diff, self.y + diff,
             self.x + self.width - diff, self.y + self.height - diff)
         cmds = paint_visual_effects(self.node, cmds, inner_rect)
         paint_outline(self.node, cmds, rect, self.zoom)
-        display_list.extend(cmds)
+        return cmds
 ```
 
 The `Transform` shifts over the child frame contents so that its

--- a/book/forms.md
+++ b/book/forms.md
@@ -341,7 +341,7 @@ class Tab:
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []
-        self.document.paint(self.display_list)
+        paint_tree(self.document, self.display_list)
 ```
 
 For this code to work, you'll also need to change `nodes` and `rules`

--- a/book/forms.md
+++ b/book/forms.md
@@ -174,7 +174,7 @@ case.[^exercises] Finally, we draw that text:
 ``` {.python}
 class InputLayout:
     def paint(self):
-        cmds = []
+        # ...
         color = self.node.style["color"]
         cmds.append(
             DrawText(self.x, self.y, text, self.font, color))
@@ -510,6 +510,7 @@ class InputLayout:
             cx = self.x + self.font.measure(text)
             cmds.append(DrawLine(
                 cx, self.y, cx, self.y + self.height, "black", 1))
+        # ...
 ```
 
 Now you can click on a text entry, type into it, and modify its value.

--- a/book/forms.md
+++ b/book/forms.md
@@ -135,20 +135,22 @@ background:
 
 ``` {.python}
 class InputLayout:
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
         if bgcolor != "transparent":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
+            cmds.append(rect)
+        return cmds
 ```
 
 It then needs to get the input element's text contents:
 
 ``` {.python}
 class InputLayout:
-    def paint(self, display_list):
+    def paint(self):
         # ...
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -159,6 +161,7 @@ class InputLayout:
             else:
                 print("Ignoring HTML contents inside button")
                 text = ""
+        # ...
 ```
 
 Note that `<button>` elements can in principle contain complex HTML,
@@ -171,10 +174,12 @@ Finally, we draw that text:
 
 ``` {.python}
 class InputLayout:
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, text, self.font, color))
+        return cmds
 ```
 
 By this point in the book, you've seen many layout objects, so I'm
@@ -266,7 +271,7 @@ in this case:[^atomic-inline-input]
 ``` {.python}
 class BlockLayout:
     # ...
-    def paint(self, display_list):
+    def paint(self):
         # ...
         is_atomic = not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
@@ -275,7 +280,7 @@ class BlockLayout:
             if bgcolor != "transparent":
                 x2, y2 = self.x + self.width, self.y + self.height
                 rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-                display_list.append(rect)
+                cmds.append(rect)
 
 ```
 
@@ -504,11 +509,11 @@ an `input` element is focused:
 
 ``` {.python}
 class InputLayout:
-    def paint(self, display_list):
+    def paint(self):
         # ...
         if self.node.is_focused:
             cx = self.x + self.font.measure(text)
-            display_list.append(DrawLine(
+            cmds.append(DrawLine(
                 cx, self.y, cx, self.y + self.height, "black", 1))
 ```
 

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -2402,13 +2402,13 @@ not the layout object has a previous sibling:
 ``` {.python}
 class BlockLayout:
     def __init__(self, node, parent, previous, frame):
-    # ...
-    if self.previous:
-        y_dependencies = [self.previous.y, self.previous.height]
-    else:
-        y_dependencies = [self.parent.y]
-    self.y = ProtectedField(self, "y", self.parent, y_dependencies)
-    # ...
+        # ...
+        if self.previous:
+            y_dependencies = [self.previous.y, self.previous.height]
+        else:
+            y_dependencies = [self.parent.y]
+        self.y = ProtectedField(self, "y", self.parent, y_dependencies)
+        # ...
 ```
 
 We can't freeze `height` for `BlockLayout`, for the same reason as

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -113,7 +113,7 @@ will go. Let's do that in `BlockLayout`:
 
 ``` {.python replace=.width/.width.get()}
 class BlockLayout:
-    def paint(self, display_list):
+    def paint(self):
         # ...
         if self.node.is_focused \
             and "contenteditable" in self.node.attributes:
@@ -141,7 +141,7 @@ We might as well also use this wrapper in `InputLayout`:
 
 ``` {.python replace=self.font/self.font.get()}
 class InputLayout(EmbedLayout):
-    def paint(self, display_list):
+    def paint(self):
         if self.node.is_focused and self.node.tag == "input":
             cmds.append(DrawCursor(self, self.font.measureText(text)))
 ```

--- a/book/layout.md
+++ b/book/layout.md
@@ -553,7 +553,7 @@ list:
 
 ``` {.python}
 def paint_tree(layout_object, display_list):
-    layout_object.paint(display_list)
+    display_list.extend(layout_object.paint())
 
     for child in layout_object.children:
         paint_tree(child, display_list)
@@ -564,8 +564,8 @@ nothing to paint:
 
 ``` {.python}
 class DocumentLayout:
-    def paint(self, display_list):
-        pass
+    def paint(self):
+        return []
 ```
 
 You can now delete the line that computes a `DocumentLayout`'s
@@ -578,8 +578,8 @@ objects.]
 
 ``` {.python expected=False}
 class BlockLayout:
-    def paint(self, display_list):
-        display_list.extend(self.display_list)
+    def paint(self):
+        return self.display_list
 ```
 
 Now the browser can use `paint` to collect its own `display_list`
@@ -653,10 +653,12 @@ commands in one place.
 
 ``` {.python}
 class BlockLayout:
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         if self.layout_mode() == "inline":
             for x, y, word, font in self.display_list:
-                display_list.append(DrawText(x, y, word, font))
+                cmds.append(DrawText(x, y, word, font))
+        return cmds
 ```
 
 But it can also add a `DrawRect` command to draw a background. Let's add
@@ -664,11 +666,12 @@ a gray background to `pre` tags (which are used for code examples):
 
 ``` {.python}
 class BlockLayout:
-    def paint(self, display_list):
+    def paint(self):
+        # ...
         if isinstance(self.node, Element) and self.node.tag == "pre":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, "gray")
-            display_list.append(rect)
+            cmds.append(rect)
         # ...
 ```
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -545,11 +545,9 @@ the way, we can stop copying the display list contents over and over
 again as we go up the layout tree.
 
 I think it's most convenient to do that by adding a `paint`\index{paint}
-function to each layout object, which appends any of its own layout objects to
-the display list. Then there is a separate function, `paint_tree`, that
-recursively calls `paint` on all layout objects.  A neat trick here is to pass
-the list itself as an argument, and have each call to `paint` append to that
-list:
+function to each layout object, whose return value is the display list entries
+for that object. Then there is a separate function, `paint_tree`, that
+recursively calls `paint` on all layout objects:
 
 ``` {.python}
 def paint_tree(layout_object, display_list):
@@ -582,7 +580,7 @@ class BlockLayout:
         return self.display_list
 ```
 
-Now the browser can use `paint` to collect its own `display_list`
+Now the browser can use `paint_tree` to collect its own `display_list`
 variable:
 
 ``` {.python}
@@ -675,10 +673,10 @@ class BlockLayout:
         # ...
 ```
 
-Make sure this code comes *before* the loop that adds `DrawText`
-objects and *before* the recursion into child layout objects: the
-background has to be drawn *below* and therefore *before* any
-contents.
+Make sure this code comes *before* the loop that adds `DrawText` objects: the
+background has to be drawn *below* that text. Note also that `paint_tree`
+calls `paint` before recursing into the subtree, so the subtree also paints
+on top of this background, as desired.
 
 With the display list filled out, we need to `draw`
 each graphics command. Let's add an `execute` method for this. On

--- a/book/styles.md
+++ b/book/styles.md
@@ -242,13 +242,14 @@ element, the browser can consult it for styling information:
 
 ``` {.python}
 class BlockLayout:
-    def paint(self, display_list):
+    def paint(self):
+        # ...
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
         if bgcolor != "transparent":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
+            cmds.append(rect)
         # ...
 ```
 
@@ -916,10 +917,10 @@ def flush(self):
 That `display_list` is converted to drawing commands in `paint`:
 
 ``` {.python indent=4}
-def paint(self, display_list):
+def paint(self):
     # ...
     for x, y, word, font, color in self.display_list:
-        display_list.append(DrawText(self.x + x, self.y + y,
+        cmds.append(DrawText(self.x + x, self.y + y,
                                      word, font, color))
 ```
 

--- a/book/styles.md
+++ b/book/styles.md
@@ -238,7 +238,7 @@ def style(node):
 
 Call `style` in the browser's `load` method, after parsing the HTML
 but before doing layout. With the `style` information stored on each
-element, the browser can consult it for styling information:
+element, the browser can consult it for styling information during paint:
 
 ``` {.python}
 class BlockLayout:

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -409,7 +409,7 @@ example, in the `render` method for a `Tab`, we must do:
 
 ``` {.python}
 class InputLayout:
-    def paint(self, display_list):
+    def paint(self):
         if self.node.is_focused:
             cx = self.x + self.font.measureText(text)
             # ...
@@ -509,14 +509,14 @@ Note that Skia supports `RRect`s, or rounded rectangles, natively, so
 we can just draw one right to a canvas. Now we can draw these rounded
 rectangles for the background:
 
-``` {.python replace=display_list./cmds.}
+``` {.python}
 class BlockLayout:
-    def paint(self, display_list):
+    def paint(self):
         if not is_atomic:
             if bgcolor != "transparent":
                 radius = float(
                     self.node.style.get("border-radius", "0px")[:-2])
-                display_list.append(DrawRRect(rect, radius, bgcolor))
+                cmds.append(DrawRRect(rect, radius, bgcolor))
 ```
 
 Similar changes should be made to `InputLayout`.
@@ -803,39 +803,40 @@ class SaveLayer:
         canvas.restore()
 ```
 
-Now let's look at how we can add this to our existing `paint` method
-for `BlockLayout`s. Right now, this method draws a background and then
-recurses into its children, adding each drawing command straight to
-the global display list. Let's instead add those drawing commands to a
-temporary list first:
+Now let's look at how we can add this to our existing `paint` method for
+`BlockLayout`s. Now, _before_ we add its `cmds` command list to the overall
+display list, we can use `SaveLayer` to add transparency to the whole element.
+I'm going to do this in a new `paint_effects` method, which will wrap `cmds`
+in a `SaveLayer`. The actual `SaveLayer` will be computed in a new
+global `paint_visual_effects` method (because other object types will need it
+also).
 
 ``` {.python}
 class BlockLayout:
-    def paint(self, display_list):
-        cmds = []
-        # ...
-        if bgcolor != "transparent":
-            # ...
-            cmds.append(DrawRRect(rect, radius, bgcolor))
+    def paint_effects(self, cmds):
+        is_atomic = not isinstance(self.node, Text) and \
+            (self.node.tag == "input" or self.node.tag == "button")
 
-        for child in self.children:
-            child.paint(cmds)
-        # ...        
-        display_list.extend(cmds)
+        if not is_atomic:
+            rect = skia.Rect.MakeLTRB(
+                self.x, self.y,
+                self.x + self.width, self.y + self.height)
+            cmds = paint_visual_effects(self.node, cmds, rect)
+        return cmds
 ```
 
-Now, _before_ we add our temporary command list to the overall display
-list, we can use `SaveLayer` to add transparency to the whole element.
-I'm going to do this in a new `paint_visual_effects` method, because
-we'll want to make the same changes to all of our other layout
-objects:
+A change is now needed in `paint_tree` to call this method, but only *after*
+recursing into children. That's because these visual effects apply to the
+entire subtree's display list, not just the current object.
 
 ``` {.python}
-class BlockLayout:
-    def paint(self, display_list):
-        # ...
-        cmds = paint_visual_effects(self.node, cmds, rect)
-        display_list.extend(cmds)
+def paint_tree(layout_object, display_list):
+    cmds = layout_object.paint()
+    for child in layout_object.children:
+        paint_tree(child, cmds)
+
+    cmds = layout_object.paint_effects(cmds)
+    display_list.extend(cmds)
 ```
 
 Inside `paint_visual_effects`, we'll parse the opacity value and

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -509,7 +509,7 @@ Note that Skia supports `RRect`s, or rounded rectangles, natively, so
 we can just draw one right to a canvas. Now we can draw these rounded
 rectangles for the background:
 
-``` {.python replace=is_atomic/self.is_atomic(),rect/self.rect()}
+``` {.python replace=is_atomic/self.is_atomic(),rect/self.self_rect()}
 class BlockLayout:
     def paint(self):
         if not is_atomic:
@@ -809,7 +809,7 @@ display list, we can use `SaveLayer` to add transparency to the whole element.
 I'm going to do this in a new `paint_effects` method, which will wrap `cmds`
 in a `SaveLayer`. The actual `SaveLayer` will be computed in a new
 global `paint_visual_effects` method (because other object types will need it
-also).^[As part of adding this method, I've factored out a `rect` and
+also).^[As part of adding this method, I've factored out a `self_rect` and
 `is_atomic` method from `paint`, you'll need to update that method also to call
 these helpers.]
 
@@ -819,14 +819,14 @@ class BlockLayout:
         return not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y,
             self.x + self.width, self.y + self.height)
 
     def paint_effects(self, cmds):
         if not self.is_atomic():
-            cmds = paint_visual_effects(self.node, cmds, self.rect())
+            cmds = paint_visual_effects(self.node, cmds, self.self_rect())
         return cmds
 ```
 

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -204,7 +204,7 @@ def paint_tree(layout_object, display_list):
     for child in layout_object.children:
         paint_tree(child, cmds)
 
-    cmds = layout_object.paint_effects(cmds)
+#    cmds = layout_object.paint_effects(cmds)
 
     display_list.extend(cmds)
 
@@ -383,7 +383,7 @@ class InputLayout:
 
         return cmds
 
-    def paint_effects(cmds):
+    def paint_effects(self, cmds):
         rect = skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
@@ -429,6 +429,7 @@ class Tab:
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)
+        print(len(self.display_list))
 
     def raster(self, canvas):
         for cmd in self.display_list:
@@ -631,6 +632,7 @@ class Browser:
         self.draw()
 
     def raster_tab(self):
+        print('raster_tab')
         active_tab = self.tabs[self.active_tab]
         tab_height = math.ceil(active_tab.document.height)
 
@@ -640,7 +642,9 @@ class Browser:
 
         canvas = self.tab_surface.getCanvas()
         canvas.clear(skia.ColorWHITE)
+        print('rastering')
         active_tab.raster(canvas)
+        print('raster_tab done')
 
     def raster_chrome(self):
         canvas = self.chrome_surface.getCanvas()

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -299,8 +299,8 @@ class LineLayout:
     def paint(self):
         return []
     
-    def paint_effects(self, display_list):
-        return display_list
+    def paint_effects(self, cmds):
+        return cmds
 
 @wbetools.patch(TextLayout)
 class TextLayout:
@@ -417,8 +417,8 @@ class DocumentLayout:
     def paint(self):
         return []
 
-    def paint_effects(self, display_list):
-        return display_list
+    def paint_effects(self, cmds):
+        return cmds
 
 @wbetools.patch(Tab)
 class Tab:

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -200,12 +200,11 @@ class ClipRRect:
             canvas.restore()
 
 def paint_tree(layout_object, display_list):
-    cmds = layout_object.paint(display_list)
+    cmds = layout_object.paint()
     for child in layout_object.children:
         paint_tree(child, cmds)
 
-#    cmds = layout_object.paint_effects(cmds)
-
+    cmds = layout_object.paint_effects(cmds)
     display_list.extend(cmds)
 
 @wbetools.patch(BlockLayout)
@@ -238,7 +237,7 @@ class BlockLayout:
         font = get_font(size, weight, style)
         self.cursor_x += w + font.measureText(" ")
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -297,8 +296,8 @@ class LineLayout:
                            for word in self.children])
         self.height = 1.25 * (max_ascent + max_descent)
 
-    def paint(self, display_list):
-        return display_list
+    def paint(self):
+        return []
     
     def paint_effects(self, display_list):
         return display_list
@@ -322,7 +321,7 @@ class TextLayout:
 
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
         color = self.node.style["color"]
         cmds.append(
@@ -349,7 +348,7 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -415,8 +414,8 @@ def paint_visual_effects(node, cmds, rect):
 
 @wbetools.patch(DocumentLayout)
 class DocumentLayout:
-    def paint(self, display_list):
-        return display_list
+    def paint(self):
+        return []
 
     def paint_effects(self, display_list):
         return display_list
@@ -631,7 +630,6 @@ class Browser:
         self.draw()
 
     def raster_tab(self):
-        print('raster_tab')
         active_tab = self.tabs[self.active_tab]
         tab_height = math.ceil(active_tab.document.height)
 
@@ -641,9 +639,7 @@ class Browser:
 
         canvas = self.tab_surface.getCanvas()
         canvas.clear(skia.ColorWHITE)
-        print('rastering')
         active_tab.raster(canvas)
-        print('raster_tab done')
 
     def raster_chrome(self):
         canvas = self.chrome_surface.getCanvas()

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -241,7 +241,7 @@ class BlockLayout:
         return not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y,
             self.x + self.width, self.y + self.height)
@@ -256,13 +256,13 @@ class BlockLayout:
             if bgcolor != "transparent":
                 radius = float(
                     self.node.style.get("border-radius", "0px")[:-2])
-                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+                cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         return cmds
 
     def paint_effects(self, cmds):
         if not self.is_atomic():
-            cmds = paint_visual_effects(self.node, cmds, self.rect())
+            cmds = paint_visual_effects(self.node, cmds, self.self_rect())
         return cmds
 
 @wbetools.patch(LineLayout)
@@ -344,7 +344,7 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def rect(self):
+    def self_rect(self):
         rect = skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
@@ -356,7 +356,7 @@ class InputLayout:
                                  "transparent")
         if bgcolor != "transparent":
             radius = float(self.node.style.get("border-radius", "0px")[:-2])
-            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+            cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -380,7 +380,7 @@ class InputLayout:
         return cmds
 
     def paint_effects(self, cmds):
-        return paint_visual_effects(self.node, cmds, self.rect())
+        return paint_visual_effects(self.node, cmds, self.self_rect())
 
 def paint_visual_effects(node, cmds, rect):
     opacity = float(node.style.get("opacity", "1.0"))

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -429,7 +429,6 @@ class Tab:
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)
-        print(len(self.display_list))
 
     def raster(self, canvas):
         for cmd in self.display_list:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -28,7 +28,7 @@ from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, JSContext, URL
 from lab11 import get_font, FONTS, DrawLine, DrawRect, DrawOutline, linespace, DrawText, SaveLayer, ClipRRect
 from lab11 import BlockLayout, LineLayout, TextLayout, InputLayout, Chrome
-from lab11 import paint_visual_effects, parse_blend_mode, parse_color, Tab, Browser
+from lab11 import Tab, Browser, paint_tree
 
 class MeasureTime:
 
@@ -277,7 +277,7 @@ class Tab:
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []
-        self.document.paint(self.display_list)
+        paint_tree(self.document, self.display_list)
         self.needs_render = False
         self.browser.measure.stop('render')
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -496,6 +496,15 @@ class BlockLayout:
         font = get_font(size, weight, size)
         self.cursor_x += w + font.measureText(" ")
 
+    def is_atomic(self):
+        return not isinstance(self.node, Text) and \
+            (self.node.tag == "input" or self.node.tag == "button")
+
+    def rect(self):
+        return skia.Rect.MakeLTRB(
+            self.x, self.y,
+            self.x + self.width, self.y + self.height)
+
     def paint(self):
         cmds = []
 
@@ -506,26 +515,17 @@ class BlockLayout:
         bgcolor = self.node.style.get("background-color",
                                  "transparent")
         
-        is_atomic = not isinstance(self.node, Text) and \
-            (self.node.tag == "input" or self.node.tag == "button")
-
-        if not is_atomic:
+        if not self.is_atomic():
             if bgcolor != "transparent":
                 radius = float(
                     self.node.style.get("border-radius", "0px")[:-2])
-                cmds.append(DrawRRect(rect, radius, bgcolor))
+                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
 
         return cmds
 
     def paint_effects(self, cmds):
-        is_atomic = not isinstance(self.node, Text) and \
-            (self.node.tag == "input" or self.node.tag == "button")
-
-        if not is_atomic:
-            rect = skia.Rect.MakeLTRB(
-                self.x, self.y,
-                self.x + self.width, self.y + self.height)
-            cmds = paint_visual_effects(self.node, cmds, rect)
+        if not self.is_atomic():
+            cmds = paint_visual_effects(self.node, cmds, self.rect())
         return cmds
 
     def __repr__(self):
@@ -676,18 +676,19 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def paint(self):
-        cmds = []
-
-        rect = skia.Rect.MakeLTRB(
+    def rect(self):
+        return skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
+
+    def paint(self):
+        cmds = []
 
         bgcolor = self.node.style.get("background-color",
                                  "transparent")
         if bgcolor != "transparent":
             radius = float(self.node.style.get("border-radius", "0px")[:-2])
-            cmds.append(DrawRRect(rect, radius, bgcolor))
+            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -711,11 +712,7 @@ class InputLayout:
         return cmds
 
     def paint_effects(self, cmds):
-        rect = skia.Rect.MakeLTRB(
-            self.x, self.y, self.x + self.width,
-            self.y + self.height)
-
-        return paint_visual_effects(self.node, cmds, rect)
+        return paint_visual_effects(self.node, cmds, self.rect())
 
     def __repr__(self):
         if self.node.tag == "input":

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -500,7 +500,7 @@ class BlockLayout:
         return not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y,
             self.x + self.width, self.y + self.height)
@@ -519,13 +519,13 @@ class BlockLayout:
             if bgcolor != "transparent":
                 radius = float(
                     self.node.style.get("border-radius", "0px")[:-2])
-                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+                cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         return cmds
 
     def paint_effects(self, cmds):
         if not self.is_atomic():
-            cmds = paint_visual_effects(self.node, cmds, self.rect())
+            cmds = paint_visual_effects(self.node, cmds, self.self_rect())
         return cmds
 
     def __repr__(self):
@@ -676,7 +676,7 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
@@ -688,7 +688,7 @@ class InputLayout:
                                  "transparent")
         if bgcolor != "transparent":
             radius = float(self.node.style.get("border-radius", "0px")[:-2])
-            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+            cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -712,7 +712,7 @@ class InputLayout:
         return cmds
 
     def paint_effects(self, cmds):
-        return paint_visual_effects(self.node, cmds, self.rect())
+        return paint_visual_effects(self.node, cmds, self.self_rect())
 
     def __repr__(self):
         if self.node.tag == "input":

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -28,7 +28,7 @@ from lab8 import Text, Element, INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, parse_color, parse_blend_mode, linespace
-from lab11 import paint_tree, paint_visual_effects
+from lab11 import paint_tree
 from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
 from lab12 import Task, REFRESH_RATE_SEC, clamp_scroll, Chrome
 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -508,6 +508,9 @@ class InputLayout:
         return cmds
 
     def paint_effects(self, cmds):
+        rect = skia.Rect.MakeLTRB(
+            self.x, self.y, self.x + self.width,
+            self.y + self.height)
         cmds = paint_visual_effects(self.node, cmds, rect)
         paint_outline(self.node, cmds, rect, self.zoom)
         return cmds 

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -213,35 +213,34 @@ class BlockLayout:
         font = get_font(size, weight, size)
         self.cursor_x += w + font.measureText(" ")
 
+    def is_atomic(self):
+        return not isinstance(self.node, Text) and \
+            (self.node.tag == "input" or self.node.tag == "button")
+
+    def rect(self):
+        return skia.Rect.MakeLTRB(
+            self.x, self.y,
+            self.x + self.width, self.y + self.height)
+
     def paint(self):
         cmds = []
-
-        rect = skia.Rect.MakeLTRB(
-            self.x, self.y, self.x + self.width,
-            self.y + self.height)
 
         is_atomic = not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
 
-        if not is_atomic:
+        if not self.is_atomic():
             bgcolor = self.node.style.get("background-color",
                                      "transparent")
             if bgcolor != "transparent":
                 radius = device_px(
                     float(self.node.style.get("border-radius", "0px")[:-2]),
                         self.zoom)
-                cmds.append(DrawRRect(rect, radius, bgcolor))
+                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
         return cmds
 
     def paint_effects(self, cmds):
-        is_atomic = not isinstance(self.node, Text) and \
-            (self.node.tag == "input" or self.node.tag == "button")
-
-        if not is_atomic:
-            rect = skia.Rect.MakeLTRB(
-                self.x, self.y, self.x + self.width,
-                self.y + self.height)
-            cmds = paint_visual_effects(self.node, cmds, rect)
+        if not self.is_atomic():
+            cmds = paint_visual_effects(self.node, cmds, self.rect())
 
         return cmds
 
@@ -472,20 +471,20 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def paint(self):
-        cmds = []
-
-        rect = skia.Rect.MakeLTRB(
+    def rect(self):
+        return skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
 
+    def paint(self):
+        cmds = []
         bgcolor = self.node.style.get("background-color",
                                  "transparent")
         if bgcolor != "transparent":
             radius = device_px(
                 float(self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
-            cmds.append(DrawRRect(rect, radius, bgcolor))
+            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -508,11 +507,8 @@ class InputLayout:
         return cmds
 
     def paint_effects(self, cmds):
-        rect = skia.Rect.MakeLTRB(
-            self.x, self.y, self.x + self.width,
-            self.y + self.height)
-        cmds = paint_visual_effects(self.node, cmds, rect)
-        paint_outline(self.node, cmds, rect, self.zoom)
+        cmds = paint_visual_effects(self.node, cmds, self.rect())
+        paint_outline(self.node, cmds, self.rect(), self.zoom)
         return cmds 
 
     def __repr__(self):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -217,7 +217,7 @@ class BlockLayout:
         return not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y,
             self.x + self.width, self.y + self.height)
@@ -235,12 +235,12 @@ class BlockLayout:
                 radius = device_px(
                     float(self.node.style.get("border-radius", "0px")[:-2]),
                         self.zoom)
-                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+                cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
         return cmds
 
     def paint_effects(self, cmds):
         if not self.is_atomic():
-            cmds = paint_visual_effects(self.node, cmds, self.rect())
+            cmds = paint_visual_effects(self.node, cmds, self.self_rect())
 
         return cmds
 
@@ -431,11 +431,6 @@ class TextLayout:
 
     def paint_effects(self, cmds):
         return cmds
-
-    def rect(self):
-        return skia.Rect.MakeLTRB(
-            self.x, self.y, self.x + self.width,
-            self.y + self.height)
     
     def __repr__(self):
         return ("TextLayout(x={}, y={}, width={}, height={}, " +
@@ -471,7 +466,7 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
@@ -484,7 +479,7 @@ class InputLayout:
             radius = device_px(
                 float(self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
-            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+            cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -507,8 +502,8 @@ class InputLayout:
         return cmds
 
     def paint_effects(self, cmds):
-        cmds = paint_visual_effects(self.node, cmds, self.rect())
-        paint_outline(self.node, cmds, self.rect(), self.zoom)
+        cmds = paint_visual_effects(self.node, cmds, self.self_rect())
+        paint_outline(self.node, cmds, self.self_rect(), self.zoom)
         return cmds 
 
     def __repr__(self):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -35,7 +35,7 @@ from lab7 import intersects
 from lab8 import INPUT_WIDTH_PX
 from lab9 import EVENT_DISPATCH_CODE
 from lab10 import COOKIE_JAR, URL
-from lab11 import FONTS, get_font, parse_blend_mode, linespace
+from lab11 import FONTS, get_font, parse_blend_mode, linespace, paint_tree
 from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
 from lab12 import Task, REFRESH_RATE_SEC
 from lab13 import JSContext, diff_styles, clamp_scroll, add_parent_pointers
@@ -213,7 +213,7 @@ class BlockLayout:
         font = get_font(size, weight, size)
         self.cursor_x += w + font.measureText(" ")
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -231,14 +231,19 @@ class BlockLayout:
                     float(self.node.style.get("border-radius", "0px")[:-2]),
                         self.zoom)
                 cmds.append(DrawRRect(rect, radius, bgcolor))
- 
-        for child in self.children:
-            child.paint(cmds)
+        return cmds
+
+    def paint_effects(self, cmds):
+        is_atomic = not isinstance(self.node, Text) and \
+            (self.node.tag == "input" or self.node.tag == "button")
 
         if not is_atomic:
+            rect = skia.Rect.MakeLTRB(
+                self.x, self.y, self.x + self.width,
+                self.y + self.height)
             cmds = paint_visual_effects(self.node, cmds, rect)
 
-        display_list.extend(cmds)
+        return cmds
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
@@ -281,10 +286,10 @@ class LineLayout:
                            for word in self.children])
         self.height = 1.25 * (max_ascent + max_descent)
 
-    def paint(self, display_list):
-        for child in self.children:
-            child.paint(display_list)
+    def paint(self):
+        return []
 
+    def paint_effects(self, cmds):
         outline_rect = skia.Rect.MakeEmpty()
         outline_node = None
         for child in self.children:
@@ -295,7 +300,9 @@ class LineLayout:
 
         if outline_node:
             paint_outline(
-                outline_node, display_list, outline_rect, self.zoom)
+                outline_node, cmds, outline_rect, self.zoom)
+
+        return cmds
 
     def role(self):
         return "none"
@@ -376,8 +383,11 @@ class DocumentLayout:
         child.layout()
         self.height = child.height
 
-    def paint(self, display_list):
-        self.children[0].paint(display_list)
+    def paint(self):
+        return []
+
+    def paint_effects(self, cmds):
+        return cmds
 
     def __repr__(self):
         return "DocumentLayout()"
@@ -413,10 +423,15 @@ class TextLayout:
 
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, self.word, self.font, color))
+        return cmds
+
+    def paint_effects(self, cmds):
+        return cmds
 
     def rect(self):
         return skia.Rect.MakeLTRB(
@@ -1080,7 +1095,7 @@ class Tab:
 
         if self.needs_paint:
             self.display_list = []
-            self.document.paint(self.display_list)
+            paint_tree(self.document, self.display_list)
             self.needs_paint = False
 
         self.browser.measure.stop('render')

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -422,6 +422,11 @@ class TextLayout:
 
         self.height = linespace(self.font)
 
+    def self_rect(self):
+        return skia.Rect.MakeLTRB(
+            self.x, self.y, self.x + self.width,
+            self.y + self.height)
+
     def paint(self):
         cmds = []
         color = self.node.style["color"]

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -294,7 +294,7 @@ class LineLayout:
         for child in self.children:
             outline_str = child.node.parent.style.get("outline")
             if parse_outline(outline_str):
-                outline_rect.join(child.rect())
+                outline_rect.join(child.self_rect())
                 outline_node = child.node.parent
 
         if outline_node:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -472,7 +472,7 @@ class InputLayout:
         else:
             self.x = self.parent.x
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -505,10 +505,12 @@ class InputLayout:
             cx = self.x + self.font.measureText(text)
             cmds.append(DrawLine(cx, self.y, cx, self.y + self.height,
                                  "black", 1))
+        return cmds
 
+    def paint_effects(self, cmds):
         cmds = paint_visual_effects(self.node, cmds, rect)
         paint_outline(self.node, cmds, rect, self.zoom)
-        display_list.extend(cmds)
+        return cmds 
 
     def __repr__(self):
         return "InputLayout(x={}, y={}, width={}, height={})".format(

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -133,7 +133,7 @@ def paint_tree(layout_object, display_list):
         layout_object.node.frame:
         paint_tree(layout_object.node.frame.document, cmds)
     else:
-        for child in layout_object.children.get():
+        for child in layout_object.children:
             paint_tree(child, cmds)
 
     cmds = layout_object.paint_effects(cmds)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -126,6 +126,18 @@ class DrawImage(DrawCommand):
         return "DrawImage(rect={})".format(
             self.rect)
 
+def paint_tree(layout_object, display_list):
+    cmds = layout_object.paint()
+
+    if layout_object.node.frame:
+        paint_tree(layout_object.node.frame.document)
+    else:
+        for child in layout_object.children:
+            paint_tree(child, cmds)
+
+    cmds = layout_object.paint_effects(cmds)
+    display_list.extend(cmds)
+
 class DocumentLayout:
     def __init__(self, node, frame):
         self.node = node
@@ -146,16 +158,16 @@ class DocumentLayout:
         child.layout()
         self.height = child.height
 
-    def paint(self, display_list, dark_mode, scroll):
-        cmds = []
-        self.children[0].paint(cmds)
-        if scroll != None and scroll != 0:
+    def paint(self):
+        return []
+
+    def paint_effects(self, cmds):
+        if self.frame != self.tab.root_frame and self.frame.scroll != 0:
             rect = skia.Rect.MakeLTRB(
                 self.x, self.y,
                 self.x + self.width, self.y + self.height)
-            cmds = [Transform((0, -scroll), rect, self.node, cmds)]
-
-        display_list.extend(cmds)
+            cmds = [Transform((0, - self.frame.scroll), rect, self.node, cmds)]
+        return cmds
 
     def __repr__(self):
         return "DocumentLayout()"
@@ -284,7 +296,7 @@ class BlockLayout:
             w = IFRAME_WIDTH_PX + device_px(2, self.zoom)
         self.add_inline_child(node, w, IframeLayout, self.frame)
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -303,13 +315,12 @@ class BlockLayout:
                         "border-radius", "0px")[:-2]),
                     self.zoom)
                 cmds.append(DrawRRect(rect, radius, bgcolor))
+        return cmds
  
-        for child in self.children:
-            child.paint(cmds)
-
+    def paint_effects(self, cmds):
         if not is_atomic:
             cmds = paint_visual_effects(self.node, cmds, rect)
-        display_list.extend(cmds)
+        return cmds
 
     def __repr__(self):
         return "BlockLayout(x={}, y={}, width={}, height={}, node={})".format(
@@ -355,7 +366,7 @@ class InputLayout(EmbedLayout):
         self.width = device_px(INPUT_WIDTH_PX, self.zoom)
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
 
         rect = skia.Rect.MakeLTRB(
@@ -388,9 +399,12 @@ class InputLayout(EmbedLayout):
             cx = self.x + self.font.measureText(text)
             cmds.append(DrawLine(cx, self.y, cx, self.y + self.height, color, 1))
 
+        return cmds
+
+    def paint_effects(self, cmds):
         cmds = paint_visual_effects(self.node, cmds, rect)
         paint_outline(self.node, cmds, rect, self.zoom)
-        display_list.extend(cmds)
+        return cmds
 
     def __repr__(self):
         return "InputLayout(x={}, y={}, width={}, height={})".format(
@@ -433,10 +447,10 @@ class LineLayout:
                            for child in self.children])
         self.height = max_ascent + max_descent
 
-    def paint(self, display_list):
-        for child in self.children:
-            child.paint(display_list)
+    def paint(self):
+        return []
 
+    def paint_effects(self, cmds):
         outline_rect = skia.Rect.MakeEmpty()
         outline_node = None
         for child in self.children:
@@ -446,7 +460,8 @@ class LineLayout:
                 outline_node = child.node.parent
 
         if outline_node:
-            paint_outline(outline_node, display_list, outline_rect, self.zoom)
+            paint_outline(outline_node, cmds, outline_rect, self.zoom)
+        return cmds
 
     def role(self):
         return "none"
@@ -489,10 +504,15 @@ class TextLayout:
 
         self.height = linespace(self.font)
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, self.word, self.font, color))
+        return cmds
+
+    def paint_effects(self, cmds):
+        return cmds
 
     def rect(self):
         return skia.Rect.MakeLTRB(
@@ -541,14 +561,17 @@ class ImageLayout(EmbedLayout):
 
         self.height = max(self.img_height, linespace(self.font))
 
-    def paint(self, display_list):
+    def paint(self):
         cmds = []
         rect = skia.Rect.MakeLTRB(
             self.x, self.y + self.height - self.img_height,
             self.x + self.width, self.y + self.height)
         quality = self.node.style.get("image-rendering", "auto")
         cmds.append(DrawImage(self.node.image, rect, quality))
-        display_list.extend(cmds)
+        return cmds
+
+    def paint_effects(self, cmds):
+        return cmds
 
     def __repr__(self):
         return ("ImageLayout(src={}, x={}, y={}, width={}," +
@@ -584,8 +607,8 @@ class IframeLayout(EmbedLayout):
             self.node.frame.frame_width = \
                 self.width - device_px(2, self.zoom)
 
-    def paint(self, display_list):
-        frame_cmds = []
+    def paint(self):
+        cmds = []
 
         rect = skia.Rect.MakeLTRB(
             self.x, self.y,
@@ -596,20 +619,19 @@ class IframeLayout(EmbedLayout):
             radius = device_px(float(
                 self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
-            frame_cmds.append(DrawRRect(rect, radius, bgcolor))
+            cmds.append(DrawRRect(rect, radius, bgcolor))
+        return cmds
 
-        if self.node.frame:
-            self.node.frame.paint(frame_cmds)
-
+    def paint_effects(self, cmds):
         diff = device_px(1, self.zoom)
         offset = (self.x + diff, self.y + diff)
-        cmds = [Transform(offset, rect, self.node, frame_cmds)]
+        cmds = [Transform(offset, rect, self.node, cmds)]
         inner_rect = skia.Rect.MakeLTRB(
             self.x + diff, self.y + diff,
             self.x + self.width - diff, self.y + self.height - diff)
         cmds = paint_visual_effects(self.node, cmds, inner_rect)
         paint_outline(self.node, cmds, rect, self.zoom)
-        display_list.extend(cmds)
+        return cmds
 
     def __repr__(self):
         return "IframeLayout(src={}, x={}, y={}, width={}, height={})".format(
@@ -1294,10 +1316,6 @@ class Frame:
             self.scroll_changed_in_frame = True
         self.scroll = clamped_scroll
 
-    def paint(self, display_list):
-        self.document.paint(display_list, self.tab.dark_mode,
-            self.scroll if self != self.tab.root_frame else None)
-
     def advance_tab(self):
         focusable_nodes = [node
             for node in tree_to_list(self.nodes, [])
@@ -1569,7 +1587,7 @@ class Tab:
 
         if self.needs_paint:
             self.display_list = []
-            self.root_frame.paint(self.display_list)
+            paint_tree(self.root_frame.document, self.display_list)
             self.needs_paint = False
 
         self.browser.measure.stop('render')

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -133,7 +133,7 @@ def paint_tree(layout_object, display_list):
         layout_object.node.frame:
         paint_tree(layout_object.node.frame.document, cmds)
     else:
-        for child in layout_object.children:
+        for child in layout_object.children.get():
             paint_tree(child, cmds)
 
     cmds = layout_object.paint_effects(cmds)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -301,7 +301,7 @@ class BlockLayout:
         return not isinstance(self.node, Text) and \
             (self.node.tag == "input" or self.node.tag == "button")
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y,
             self.x + self.width, self.y + self.height)
@@ -316,12 +316,12 @@ class BlockLayout:
                     float(self.node.style.get(
                         "border-radius", "0px")[:-2]),
                     self.zoom)
-                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+                cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
         return cmds
 
     def paint_effects(self, cmds):
         if not self.is_atomic():
-            cmds = paint_visual_effects(self.node, cmds, self.rect())
+            cmds = paint_visual_effects(self.node, cmds, self.self_rect())
         return cmds
 
     def __repr__(self):
@@ -368,7 +368,7 @@ class InputLayout(EmbedLayout):
         self.width = device_px(INPUT_WIDTH_PX, self.zoom)
         self.height = linespace(self.font)
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
@@ -382,7 +382,7 @@ class InputLayout(EmbedLayout):
             radius = device_px(
                 float(self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
-            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+            cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -405,8 +405,8 @@ class InputLayout(EmbedLayout):
         return cmds
 
     def paint_effects(self, cmds):
-        cmds = paint_visual_effects(self.node, cmds, self.rect())
-        paint_outline(self.node, cmds, self.rect(), self.zoom)
+        cmds = paint_visual_effects(self.node, cmds, self.self_rect())
+        paint_outline(self.node, cmds, self.self_rect(), self.zoom)
         return cmds
 
     def __repr__(self):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -505,7 +505,7 @@ class BlockLayout:
                 cmds.append(DrawCursor(self, 0))
 
         if not self.is_atomic():
-            cmds = paint_visual_effects(self.node, cmds, self.rect())
+            cmds = paint_visual_effects(self.node, cmds, self.self_rect())
         return cmds
 
 def DrawCursor(elt, offset):
@@ -612,7 +612,7 @@ class LineLayout:
         for child in self.children:
             child_outline = parse_outline(child.node.parent.style["outline"].get())
             if child_outline:
-                outline_rect.join(child.rect())
+                outline_rect.join(child.self_rect())
                 outline_node = child.node.parent
 
         if outline_node:
@@ -710,7 +710,7 @@ class TextLayout:
     def paint_effects(self, cmds):
         return cmds
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
@@ -796,7 +796,7 @@ class InputLayout(EmbedLayout):
         self.height.set(linespace(font))
         self.layout_after()
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
@@ -809,7 +809,7 @@ class InputLayout(EmbedLayout):
             radius = device_px(
                 float(self.node.style["border-radius"].get()[:-2]),
                 self.zoom.get())
-            cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+            cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -831,8 +831,8 @@ class InputLayout(EmbedLayout):
         return cmds
 
     def paint_effects(self, cmds):
-        cmds = paint_visual_effects(self.node, cmds, self.rect())
-        paint_outline(self.node, cmds, self.rect(), self.zoom.get())
+        cmds = paint_visual_effects(self.node, cmds, self.self_rect())
+        paint_outline(self.node, cmds, self.self_rect(), self.zoom.get())
         return cmds
 
 @wbetools.patch(ImageLayout)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -119,8 +119,12 @@ def paint_visual_effects(node, cmds, rect):
     else:
         clip_radius = 0
     needs_clip = node.style['overflow'].get() == 'clip'
-    needs_blend_isolation = blend_mode != skia.BlendMode.kSrcOver or needs_clip or opacity != 1.0
-    save_layer = SaveLayer(skia.Paint(BlendMode=blend_mode, Alphaf=opacity), node, [ClipRRect(rect, clip_radius, cmds, should_clip=needs_clip)], should_save=needs_blend_isolation)
+    needs_blend_isolation = blend_mode != skia.BlendMode.kSrcOver or \
+        needs_clip or opacity != 1.0
+    save_layer = SaveLayer(
+        skia.Paint(BlendMode=blend_mode, Alphaf=opacity),
+        node, [ClipRRect(rect, clip_radius, cmds, should_clip=needs_clip)],
+        should_save=needs_blend_isolation)
     transform = Transform(translation, rect, node, [save_layer])
     node.save_layer = save_layer
     return [transform]
@@ -467,7 +471,7 @@ class BlockLayout:
         self.cursor_x += w + font(self.children, node.style, zoom).measureText(' ')
 
     def rect(self):
-        rect = skia.Rect.MakeLTRB(
+        return skia.Rect.MakeLTRB(
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
 
@@ -500,7 +504,7 @@ class BlockLayout:
             else:
                 cmds.append(DrawCursor(self, 0))
 
-        if not self.is_atomic();
+        if not self.is_atomic():
             cmds = paint_visual_effects(self.node, cmds, self.rect())
         return cmds
 

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -470,7 +470,7 @@ class BlockLayout:
         zoom = self.zoom.read(notify=self.children)
         self.cursor_x += w + font(self.children, node.style, zoom).measureText(' ')
 
-    def rect(self):
+    def self_rect(self):
         return skia.Rect.MakeLTRB(
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
@@ -488,7 +488,7 @@ class BlockLayout:
                 radius = device_px(
                     float(self.node.style["border-radius"].get()[:-2]),
                     self.zoom.get())
-                cmds.append(DrawRRect(self.rect(), radius, bgcolor))
+                cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
         return cmds
  
     def paint_effects(self, cmds):

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -38,8 +38,9 @@ class Element:
 
 def print_tree(node, indent=0):
     print(" " * indent, node)
-    for child in node.children:
-        print_tree(child, indent + 2)
+    if hasattr(node, "children"):
+        for child in node.children:
+            print_tree(child, indent + 2)
 
 class HTMLParser:
     def __init__(self, body):

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -38,9 +38,8 @@ class Element:
 
 def print_tree(node, indent=0):
     print(" " * indent, node)
-    if hasattr(node, "children"):
-        for child in node.children:
-            print_tree(child, indent + 2)
+    for child in node.children:
+        print_tree(child, indent + 2)
 
 class HTMLParser:
     def __init__(self, body):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -120,9 +120,6 @@ class BlockLayout:
             for x, y, word, font in self.display_list:
                 display_list.append(DrawText(x, y, word, font))
 
-        for child in self.children:
-            child.paint(display_list)
-
     @wbetools.js_hide
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
@@ -148,7 +145,7 @@ class DocumentLayout:
         wbetools.record("layout_post", self)
 
     def paint(self, display_list):
-        self.children[0].paint(display_list)
+        pass
 
     def __repr__(self):
         return "DocumentLayout()"
@@ -194,6 +191,12 @@ class DrawRect:
         return "DrawRect(top={} left={} bottom={} right={} color={})".format(
             self.top, self.left, self.bottom, self.right, self.color)
 
+def paint_tree(layout_object, display_list):
+    layout_object.paint(display_list)
+
+    for child in layout_object.children:
+        paint_tree(child, display_list)
+
 @wbetools.patch(Browser)
 class Browser:
     def load(self, url):
@@ -202,7 +205,7 @@ class Browser:
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []
-        self.document.paint(self.display_list)
+        paint_tree(self.document, self.display_list)
         self.draw()
 
     def draw(self):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -110,15 +110,17 @@ class BlockLayout:
         max_descent = max([metric["descent"] for metric in metrics])
         self.cursor_y = baseline + 1.25 * max_descent
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         if isinstance(self.node, Element) and self.node.tag == "pre":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, "gray")
-            display_list.append(rect)
+            cmds.append(rect)
 
         if self.layout_mode() == "inline":
             for x, y, word, font in self.display_list:
-                display_list.append(DrawText(x, y, word, font))
+                cmds.append(DrawText(x, y, word, font))
+        return cmds
 
     @wbetools.js_hide
     def __repr__(self):
@@ -144,8 +146,8 @@ class DocumentLayout:
         self.height = child.height
         wbetools.record("layout_post", self)
 
-    def paint(self, display_list):
-        pass
+    def paint(self):
+        return []
 
     def __repr__(self):
         return "DocumentLayout()"
@@ -192,7 +194,7 @@ class DrawRect:
             self.top, self.left, self.bottom, self.right, self.color)
 
 def paint_tree(layout_object, display_list):
-    layout_object.paint(display_list)
+    display_list.extend(layout_object.paint())
 
     for child in layout_object.children:
         paint_tree(child, display_list)

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -233,17 +233,19 @@ class BlockLayout:
         max_descent = max([metric["descent"] for metric in metrics])
         self.cursor_y = baseline + 1.25 * max_descent
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
         if bgcolor != "transparent":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
+            cmds.append(rect)
 
         for x, y, word, font, color in self.display_list:
-            display_list.append(DrawText(self.x + x, self.y + y,
+            cmds.append(DrawText(self.x + x, self.y + y,
                                          word, font, color))
+        return cmds
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -13,7 +13,7 @@ from lab1 import URL
 from lab2 import WIDTH, HEIGHT
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect, DrawText
+from lab5 import BLOCK_ELEMENTS, DrawRect, DrawText, paint_tree
 from lab5 import BlockLayout, DocumentLayout, Browser
 import wbetools
 
@@ -245,9 +245,6 @@ class BlockLayout:
             display_list.append(DrawText(self.x + x, self.y + y,
                                          word, font, color))
 
-        for child in self.children:
-            child.paint(display_list)
-
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(
             self.layout_mode(), self.x, self.y, self.width, self.height)
@@ -315,7 +312,7 @@ class Browser:
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []
-        self.document.paint(self.display_list)
+        paint_tree(self.document, self.display_list)
         self.draw()
 
 if __name__ == "__main__":

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -12,7 +12,7 @@ import tkinter.font
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout, paint_tree
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, URL, tree_to_list, BlockLayout
@@ -65,8 +65,7 @@ class LineLayout:
         self.height = 1.25 * (max_ascent + max_descent)
 
     def paint(self, display_list):
-        for child in self.children:
-            child.paint(display_list)
+        pass
 
     def __repr__(self):
         return "LineLayout(x={}, y={}, width={}, height={})".format(
@@ -181,9 +180,6 @@ class BlockLayout:
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
             display_list.append(rect)
 
-        for child in self.children:
-            child.paint(display_list)
-
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(
             self.layout_mode(), self.x, self.y, self.width, self.height)
@@ -265,7 +261,7 @@ class Tab:
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []
-        self.document.paint(self.display_list)
+        paint_tree(self.document, self.display_list)
 
     def draw(self, canvas, offset):
         for cmd in self.display_list:

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -103,11 +103,8 @@ class TextLayout:
         self.height = self.font.metrics("linespace")
 
     def paint(self):
-        cmds = []
         color = self.node.style["color"]
-        cmds.append(
-            DrawText(self.x, self.y, self.word, self.font, color))
-        return cmds
+        return [DrawText(self.x, self.y, self.word, self.font, color)]
     
     @wbetools.js_hide
     def __repr__(self):

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -64,8 +64,8 @@ class LineLayout:
                            for word in self.children])
         self.height = 1.25 * (max_ascent + max_descent)
 
-    def paint(self, display_list):
-        pass
+    def paint(self):
+        return []
 
     def __repr__(self):
         return "LineLayout(x={}, y={}, width={}, height={})".format(
@@ -102,10 +102,12 @@ class TextLayout:
 
         self.height = self.font.metrics("linespace")
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, self.word, self.font, color))
+        return cmds
     
     @wbetools.js_hide
     def __repr__(self):
@@ -172,13 +174,15 @@ class BlockLayout:
         self.previous_word = text
         self.cursor_x += w + font.measure(" ")
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
         if bgcolor != "transparent":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
+            cmds.append(rect)
+        return cmds
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={})".format(

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -73,13 +73,9 @@ of a text input should be its `value` attribute:
     >>> form = browser.tabs[0].document.children[0].children[0].children[0]
     >>> text_input = form.children[0].children[0].children[1]
     >>> button = form.children[2].children[0].children[0]
-    >>> display_list = []
-    >>> text_input.paint(display_list)
-    >>> display_list
+    >>> text_input.paint()
     [DrawRect(top=20.25 left=85 bottom=32.25 right=285 color=lightblue), DrawText(text=1)]
-    >>> display_list = []
-    >>> button.paint(display_list)
-    >>> display_list
+    >>> button.paint()
     [DrawRect(top=50.25 left=13 bottom=62.25 right=213 color=orange), DrawText(text=Submit!)]
 
 Testing form submission

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -112,13 +112,14 @@ class InputLayout:
 
         self.height = self.font.metrics("linespace")
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
         if bgcolor != "transparent":
             x2, y2 = self.x + self.width, self.y + self.height
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-            display_list.append(rect)
+            cmds.append(rect)
 
         if self.node.tag == "input":
             text = self.node.attributes.get("value", "")
@@ -131,13 +132,14 @@ class InputLayout:
                 text = ""
 
         color = self.node.style["color"]
-        display_list.append(
+        cmds.append(
             DrawText(self.x, self.y, text, self.font, color))
 
         if self.node.is_focused:
             cx = self.x + self.font.measure(text)
-            display_list.append(DrawLine(
+            cmds.append(DrawLine(
                 cx, self.y, cx, self.y + self.height, "black", 1))
+        return cmds
 
     def __repr__(self):
         if self.node.tag == "input":
@@ -187,7 +189,8 @@ class BlockLayout:
         font = self.get_font(node)
         self.cursor_x += w + font.measure(" ")
 
-    def paint(self, display_list):
+    def paint(self):
+        cmds = []
         bgcolor = self.node.style.get("background-color",
                                       "transparent")
 
@@ -198,7 +201,8 @@ class BlockLayout:
             if bgcolor != "transparent":
                 x2, y2 = self.x + self.width, self.y + self.height
                 rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
-                display_list.append(rect)
+                cmds.append(rect)
+        return cmds
 
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -13,7 +13,7 @@ import urllib.parse
 from lab2 import WIDTH, HEIGHT, HSTEP, VSTEP, SCROLL_STEP
 from lab3 import FONTS, get_font
 from lab4 import Text, Element, print_tree, HTMLParser
-from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout
+from lab5 import BLOCK_ELEMENTS, DrawRect, DocumentLayout, paint_tree
 from lab6 import CSSParser, TagSelector, DescendantSelector
 from lab6 import INHERITED_PROPERTIES, style, cascade_priority
 from lab6 import DrawText, URL, tree_to_list
@@ -200,9 +200,6 @@ class BlockLayout:
                 rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
                 display_list.append(rect)
 
-        for child in self.children:
-            child.paint(display_list)
-
     def __repr__(self):
         return "BlockLayout[{}](x={}, y={}, width={}, height={}, node={})".format(
             self.layout_mode(), self.x, self.y, self.width, self.height, self.node)
@@ -245,7 +242,7 @@ class Tab:
         self.document = DocumentLayout(self.nodes)
         self.document.layout()
         self.display_list = []
-        self.document.paint(self.display_list)
+        paint_tree(self.document, self.display_list)
 
     def draw(self, canvas, offset):
         for cmd in self.display_list:


### PR DESCRIPTION
It is a *lot* of changes through various chapters, but I hope things are clearer to the reader. Certainly there is less code
duplication, and likely the `paint_tree` method is easier for readers because it focuses on the recursion, while the
`paint` methods focus only on self-paint and self-paint-effect.