### PR TITLE
Major changes to Chapter 7

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -195,14 +195,12 @@ The `Browser` code just delegates to the `Tab`, via a main thread task:
 class Browser:
 	# ...
     def increment_zoom(self, increment):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.zoom_by, increment)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.zoom_by, increment)
+        self.active_tab.task_runner.schedule_task(task)
 
     def reset_zoom(self):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.reset_zoom)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.reset_zoom)
+        self.active_tab.task_runner.schedule_task(task)
 ```
 
 Finally, the `Tab` responds to these commands by adjusting a new
@@ -496,9 +494,8 @@ class Browser:
     # ...
     def toggle_dark_mode(self):
         # ...
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.toggle_dark_mode)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.toggle_dark_mode)
+        self.active_tab.task_runner.schedule_task(task)
 ```
 
 And in `Tab`:
@@ -751,17 +748,24 @@ Here the `focus_addressbar` and `cycle_tabs` methods are new, but
 their contents are just copied from `handle_click`:
 
 ``` {.python}
+class Chrome:
+    def focus_addressbar(self):
+        self.focus = "address bar"
+        self.address_bar = ""
+
 class Browser:
     def focus_addressbar(self):
         self.lock.acquire(blocking=True)
-        self.focus = "address bar"
-        self.address_bar = ""
+        self.chrome.focus_addressbar()
         self.set_needs_raster()
         self.lock.release()
 
     def cycle_tabs(self):
-        new_active_tab = (self.active_tab + 1) % len(self.tabs)
-        self.set_active_tab(new_active_tab)
+        self.lock.acquire(blocking=True)
+        active_ids = self.tabs.index(self.active_tab)
+        new_active_idx = (active_idx + 1) % len(self.tabs)
+        self.set_active_tab(self.tabs[new_active_idx])
+        self.lock.release()
 ```
 
 Now any clicks in the browser chrome can be replaced with keyboard
@@ -798,16 +802,14 @@ backwards in focus order.]
 class Browser:
     def handle_tab(self):
         self.focus = "content"
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.advance_tab)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.advance_tab)
+        self.active_tab.task_runner.schedule_task(task)
 
     def handle_enter(self):
     	# ...
         elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.enter)
-            active_tab.task_runner.schedule_task(task)
+            task = Task(self.active_tab.enter)
+            self.active_tab.task_runner.schedule_task(task)
         # ...
 ```
 

--- a/book/animations.md
+++ b/book/animations.md
@@ -2214,6 +2214,17 @@ whether the time to raster the provided display items is low enough to not
 justify a GPU texture. This will be true for solid colors, but
 probably not complex shapes or text.
 
+*Hit testing*: Right now, when handling clicks, we convert each layout
+object's bounds to absolute coordinates (via
+`absolute_bounds_for_obj`) to compare to the click location. But we
+could instead convert the click location to local coordinates as we
+traverse the layout tree. Implement that instead. It'll probably be
+convenient to define a `hit_test` method on each layout object which
+takes in a click location, adjusts it for transforms, and recursively
+calls child `hit_test` methods.^[In real browsers hit testing is used
+for more than just clicking. The name comes from thinking whether an
+arrow shot at that location would "hit" the object.]
+
 *Atomic effects*: Our browser currently uses a simplistic algorithm for building
 the draw list which doesn't handle nested, composited visual effects
 correctly, especially when there are overlapping elements on the page(this was

--- a/book/animations.md
+++ b/book/animations.md
@@ -1432,7 +1432,7 @@ class Browser:
 
     def commit(self, tab, data):
         # ...
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             # ...
             self.composited_updates = data.composited_updates
             if not self.composited_updates:

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -225,8 +225,7 @@ maximum ascents, maximum descents, and so on comes in. Before we do
 that, let's look at laying out `TextLayout`s.
 
 To lay out text we need font metrics, so let's start by getting the
-relevant font using the same font-construction code as in
-`BlockLayout`:
+relevant font using the same font-construction code as `BlockLayout`:
 
 ``` {.python}
 class TextLayout:
@@ -347,7 +346,7 @@ layout object and its own size and position.
 Actually, text rendering is [*way* more complex][rendering-hates] than
 this. [Letters][morx] can transform and overlap, and the user might
 want to color certain letters---or parts of letters---a different
-color. All of this is possible in HTML, and browsers do implement
+color. All of this is possible in HTML, and real browsers do implement
 support for it.
 :::
 
@@ -483,10 +482,11 @@ new web pages.
 
 ::: {.further}
 On mobile devices, a "click" happens over an area, not just at a
-single point. Since mobile "taps" are often pretty inaccurate, click
-should [use area, not point information][rect-based] for "hit
-testing".\index{hit testing} This can happen even with a [normal mouse
-click][hit-test] when the click is on a rotated or scaled element.
+single point. This is because mobile "taps" are often pretty
+inaccurate, click should [use area, not point information][rect-based]
+for "hit testing".\index{hit testing} This can happen even with a
+[normal mouse click][hit-test] when the click is on a rotated or
+scaled element.
 :::
 
 [rect-based]: http://www.chromium.org/developers/design-documents/views-rect-based-targeting
@@ -611,7 +611,7 @@ great read!
 [netcaptor-ad]: https://web.archive.org/web/20050701001923/http://www.netcaptor.com/
 [booklink]: Some people instead attribute tabbed browsing to Booklink's InternetWorks
     browser, a browser obscure enough that it doesn't have a Wikipedia
-    page though you can see some screenshots [on Twitter][booklink-x].
+    page, though you can see some screenshots [on Twitter][booklink-x].
     However, its tabs were slightly different from the modern
     conception, more like bookmarks than tabs. SimulBrowse instead
     used the modern notion of tabs.
@@ -724,7 +724,7 @@ letter X is typically as wide as the widest number.
 
 To actually draw the UI, we'll first have the browser chrome paint a
 display list, which the `Browser` will then draw to the screen. Let's
-first paint the new-tab button:
+start by first painting the new-tab button:
 
 ``` {.python}
 class Chrome:
@@ -929,9 +929,10 @@ class Browser:
 ```
 
 Note that we need to subtract out the the chrome size when clicking on
-tab contents. Inside `Chrome`, we need to figure out what the user
-clicked on. To make that easier, let's add a quick method to test
-whether a point intersects a rectangle:
+tab contents. As for clicks on the browser chrome, inside `Chrome` we
+need to figure out what the user clicked on. To make that easier,
+let's add a quick method to test whether a point intersects a
+rectangle:
 
 ``` {.python}
 def intersects(x, y, rect):
@@ -1236,7 +1237,7 @@ keys or function keys). For now let's have the `Browser` send all key
 presses to `Chrome` and then call `draw()` so that the new letters
 actually show up.
 
-The `Chrome` can then check `focus` and add on to `address_bar`:
+Then `Chrome` can check `focus` and add on to `address_bar`:
 
 ``` {.python}
 class Chrome:

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -834,7 +834,7 @@ class Tab:
         if self.needs_accessibility:
             # ...
 
-        if self.pending_hover:
+        if self.needs_paint:
             # ...
 
         # ...
@@ -1258,9 +1258,8 @@ class Browser:
         self.lock.acquire(blocking=True)
         if self.root_frame_focused:
             # ...
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.scrolldown)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.scrolldown)
+        self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 ```
 
@@ -1346,7 +1345,7 @@ in the browser thread, which has limited information:
 
 We'll make a subclass of `AccessibilityNode` to store this information:
 
-``` {.python}
+``` {.python dropline=pass}
 class FrameAccessibilityNode(AccessibilityNode):
     pass
 ```

--- a/book/forms.md
+++ b/book/forms.md
@@ -1151,3 +1151,22 @@ be contained inside button instead of spilling out---this can make a
 button really tall. Think about edge cases, like a button that
 contains another button, an input area, or a link, and test real
 browsers to see what they do.
+
+*HTML chrome*: Browser chrome is quite complicated in real browsers,
+with tricky details such as font sizes, padding, outlines, shadows,
+icons and so on. This makes it tempting to try to reuse our layout
+engine for it. Implement this, using `<button>` elements for the new
+tab and back buttons, an `<input>` element for the address bar, and
+`<a>` elements for the tab names. It won't look exactly the same as
+the current chrome---outline will have to wait for [Chapter
+14](accessibility.md), for example---but if you adjust the default CSS
+you should be able to make it look passable.[^real-browser-reuse]
+
+[^real-browser-reuse]: Real browsers have in fact gone down this
+implementation path multiple times, building layout engines for the
+browser chrome that are heavily inspired by or reuse pieces of the
+main web layout engine. [Firefox had
+one](https://en.wikipedia.org/wiki/XUL), and [Chrome has
+one](https://www.chromium.org/developers/webui/). However, because
+it's so important for the browser chrome to be very fast and
+responsive to draw, such approaches have had mixed success.

--- a/book/forms.md
+++ b/book/forms.md
@@ -219,9 +219,9 @@ class BlockLayout:
         if self.cursor_x + w > self.width:
             self.new_line()
         line = self.children[-1]
-        input = InputLayout(node, line, self.previous_word)
+        previous_word = line.children[-1] if line.children else None
+        input = InputLayout(node, line, previous_word)
         line.children.append(input)
-        self.previous_word = input
         font = self.get_font(node)
         self.cursor_x += w + font.measure(" ")
 ```
@@ -415,7 +415,7 @@ page, not the browser interface:
 class Browser:
     def handle_click(self, e):
         if e.y < self.chrome.bottom:
-            self.focus = None
+            self.focus = "chrome"
             # ...
         else:
             self.focus = "content"
@@ -435,8 +435,11 @@ bar or calls the active tab's `keypress` method:
 class Browser:
     def handle_key(self, e):
         # ...
+        if self.focus == "chrome":
+            self.chrome.keypress(e.char)
+            self.draw()
         elif self.focus == "content":
-            self.tabs[self.active_tab].keypress(e.char)
+            self.active_tab.keypress(e.char)
             self.draw()
 ```
 

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -743,7 +743,7 @@ constructed:
 
 ``` {.python}
 class Browser:
-    def load(self, url):
+    def new_tab(self, url):
         new_tab = Tab(self, HEIGHT - self.chrome.bottom)
         # ...
 ```
@@ -931,7 +931,7 @@ class Tab:
 
 class Browser:
     def set_needs_animation_frame(self, tab):
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.needs_animation_frame = True
 ```
 
@@ -1274,16 +1274,15 @@ example, here is loading:
 ``` {.python}
 class Browser:
     def schedule_load(self, url, body=None):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.load, url, body)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.load, url, body)
+        self.active_tab.task_runner.schedule_task(task)
 
     def handle_enter(self):
         if self.focus == "address bar":
             self.schedule_load(URL(self.address_bar))
             # ...
 
-    def load(self, url):
+    def new_tab(self, url):
         # ...
         self.schedule_load(url)
 ```
@@ -1302,9 +1301,9 @@ class Browser:
              # ...
         else:
             # ...
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.click, e.x, e.y - self.chrome.bottom)
-            active_tab.task_runner.schedule_task(task)
+            tab_y = e.y - self.chrome.bottom
+            task = Task(self.active_tab.click, e.x, tab_y)
+            self.active_tab.task_runner.schedule_task(task)
 ```
 
 The same logic holds for `keypress`:
@@ -1316,9 +1315,8 @@ class Browser:
         if self.focus == "address bar":
             # ...
         elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.keypress, char)
-            active_tab.task_runner.schedule_task(task)
+            task = Task(self.active_tab.keypress, char)
+            self.active_tab.task_runner.schedule_task(task)
 ```
 
 Do the same with any other calls from the `Browser` to the `Tab`.
@@ -1420,7 +1418,7 @@ class Browser:
 
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.url = data.url
             self.scroll = data.scroll
             self.active_tab_height = data.height
@@ -1679,8 +1677,8 @@ Move tab switching (in `load` and `handle_click`) to a new method
 
 ``` {.python}
 class Browser:
-    def set_active_tab(self, index):
-        self.active_tab = index
+    def set_active_tab(self, tab):
+        self.active_tab = tab
         self.scroll = 0
         self.url = None
         self.needs_animation_frame = True
@@ -1778,7 +1776,7 @@ The browser thread can ignore the scroll offset in this case:
 ``` {.python}
 class Browser:
     def commit(self, tab, data):
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             # ...
             if data.scroll != None:
                 self.scroll = data.scroll

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1548,8 +1548,7 @@ import math
 
 class Browser:
     def raster_tab(self):
-        active_tab = self.tabs[self.active_tab]
-        tab_height = math.ceil(active_tab.document.height)
+        tab_height = math.ceil(self.active_tab.document.height)
 
         if not self.tab_surface or \
                 tab_height != self.tab_surface.height():
@@ -1575,7 +1574,7 @@ class Browser:
         # ...
         
         tab_rect = skia.Rect.MakeLTRB(0, self.chrome.bottom, WIDTH, HEIGHT)
-        tab_offset = self.chrome.bottom - self.tabs[self.active_tab].scroll
+        tab_offset = self.chrome.bottom - self.active_tab.scroll
         canvas.save()
         canvas.clipRect(tab_rect)
         canvas.translate(0, tab_offset)
@@ -1617,10 +1616,10 @@ class Browser:
             # ...
         else:
             # ...
-            url = self.tabs[self.active_tab].url
-            self.tabs[self.active_tab].click(
-                e.x, e.y - self.chrome.bottom)
-            if self.tabs[self.active_tab] != url:
+            url = self.active_tab.url
+            tab_y = e.y - self.chrome.bottom
+            self.active_tab.click(e.x, tab_y)
+            if self.active_tab.url != url:
                 self.raster_chrome()
             self.raster_tab()
 ```

--- a/src/lab10-tests.md
+++ b/src/lab10-tests.md
@@ -17,7 +17,7 @@ in the cookie jar:
     >>> browser = lab10.Browser()
     >>> url = 'http://test.test/login'
     >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\nSet-Cookie: foo=bar\r\n\r\n")
-    >>> browser.load(lab10.URL(url))
+    >>> browser.new_tab(lab10.URL(url))
     >>> lab10.COOKIE_JAR["test.test"]
     ('foo=bar', {})
     
@@ -26,7 +26,7 @@ requests:
 
     >>> url2 = 'http://test.test/'
     >>> test.socket.respond(url2, b"HTTP/1.0 200 OK\r\n\r\n\r\n")
-    >>> browser.load(lab10.URL(url2))
+    >>> browser.new_tab(lab10.URL(url2))
     >>> test.socket.last_request(url2)
     b'GET / HTTP/1.0\r\nHost: test.test\r\nCookie: foo=bar\r\n\r\n'
 
@@ -34,7 +34,7 @@ Unrelated sites should not be sent the cookie:
 
     >>> url3 = 'http://other.site/'
     >>> test.socket.respond(url3, b"HTTP/1.0 200 OK\r\n\r\n\r\n")
-    >>> browser.load(lab10.URL(url3))
+    >>> browser.new_tab(lab10.URL(url3))
     >>> test.socket.last_request(url3)
     b'GET / HTTP/1.0\r\nHost: other.site\r\n\r\n'
     
@@ -46,7 +46,7 @@ Cookie values can be updated:
     >>> lab10.COOKIE_JAR["test.test"]
     ('foo=bar', {})
     >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\nSet-Cookie: foo=baz\r\n\r\n")
-    >>> browser.load(lab10.URL(url))
+    >>> browser.new_tab(lab10.URL(url))
     >>> lab10.COOKIE_JAR["test.test"]
     ('foo=baz', {})
 
@@ -54,7 +54,7 @@ The trailing slash is also optional:
 
     >>> url_no_slash = 'http://test.test'
     >>> test.socket.respond(url_no_slash + '/', b"HTTP/1.0 200 OK\r\n\r\n\r\n")
-    >>> browser.load(lab10.URL(url_no_slash))
+    >>> browser.new_tab(lab10.URL(url_no_slash))
     >>> test.socket.last_request(url_no_slash + '/')
     b'GET / HTTP/1.0\r\nHost: test.test\r\nCookie: foo=baz\r\n\r\n'
 
@@ -78,7 +78,7 @@ Now let's test a simple same-site request:
     >>> url2 = "http://about.blank/hello"
     >>> test.socket.respond(url2, b"HTTP/1.0 200 OK\r\n\r\nHello!")
     >>> browser = lab10.Browser()
-    >>> browser.load(lab10.URL(url))
+    >>> browser.new_tab(lab10.URL(url))
     >>> tab = browser.tabs[0]
     >>> tab.js.run(xhrjs(url2))
     Hello!
@@ -213,7 +213,7 @@ Now with all of these URLs set up, let's load the page without CSP and
 check that all of these requests were made:
 
     >>> browser = lab10.Browser()
-    >>> browser.load(lab10.URL(url))
+    >>> browser.new_tab(lab10.URL(url))
     >>> [test.socket.made_request(url + "css"),
     ...  test.socket.made_request(url + "js")]
     [True, True]
@@ -232,7 +232,7 @@ Now let's reload the page, but with CSP enabled for `test.test` and
     ... b"Content-Security-Policy: default-src http://test.test http://library.test\r\n\r\n" + \
     ... body.encode("utf8"))
     >>> browser = lab10.Browser()
-    >>> browser.load(lab10.URL(url))
+    >>> browser.new_tab(lab10.URL(url))
     Blocked script http://other.test/js due to CSP
     Blocked style http://other.test/css due to CSP
 
@@ -259,7 +259,7 @@ JavaScript!
     >>> url = "http://weird.test/"
     >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\n" + \
     ... b"Content-Security-Policy: default-src\r\n\r\n")
-    >>> browser.load(lab10.URL(url))
+    >>> browser.new_tab(lab10.URL(url))
     >>> tab = browser.tabs[-1]
     >>> tab.js.run("""
     ... x = new XMLHttpRequest()

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -178,5 +178,5 @@ class Tab:
 
 if __name__ == "__main__":
     import sys
-    Browser().load(URL(sys.argv[1]))
+    Browser().new_tab(URL(sys.argv[1]))
     tkinter.mainloop()

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -23,7 +23,7 @@ Opacity can be applied.
     ... b"<div style=\"opacity:0.5\"><div>Text</div></div>)")
 
     >>> browser = lab11.Browser()
-    >>> browser.load(lab11.URL(size_and_opacity_url))
+    >>> browser.new_tab(lab11.URL(size_and_opacity_url))
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
     saveLayer(color=80000000, alpha=128)
@@ -43,7 +43,7 @@ So can `mix-blend-mode:multiply` and `mix-blend-mode: difference`.
     ... b"<div style=\"mix-blend-mode:difference\"><div>Diff</div></div>)")
 
     >>> browser = lab11.Browser()
-    >>> browser.load(lab11.URL(size_and_mix_blend_mode_url))
+    >>> browser.new_tab(lab11.URL(size_and_mix_blend_mode_url))
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
     saveLayer(color=ff000000, blend_mode=BlendMode.kMultiply)
@@ -72,7 +72,7 @@ div and its children so the clip only applies ot it, and one to
 make a canvas in which to draw the circular clip mask.
 
     >>> browser = lab11.Browser()
-    >>> browser.load(lab11.URL(size_and_rounded_clip_url))
+    >>> browser.new_tab(lab11.URL(size_and_rounded_clip_url))
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
     saveLayer(color=ff000000)
@@ -99,7 +99,7 @@ is implicit/an implementation detail of Skia, and a `clipRRect` call with a
 radius equal to the `20px` radius specified above.
 
     >>> browser = lab11.Browser()
-    >>> browser.load(lab11.URL(size_and_border_radius_url))
+    >>> browser.new_tab(lab11.URL(size_and_border_radius_url))
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
     drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(10, 10), color=ff0000ff)

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -537,7 +537,7 @@ class Browser:
             WIDTH, HEIGHT,
             ct=skia.kRGBA_8888_ColorType,
             at=skia.kUnpremul_AlphaType))
-        self.chrome_surface = skia.Surface(WIDTH, self.chrome.bottom)
+        self.chrome_surface = skia.Surface(WIDTH, math.ceil(self.chrome.bottom))
         self.tab_surface = None
 
         self.tabs = []
@@ -590,6 +590,10 @@ class Browser:
             self.raster_tab()
             self.raster_chrome()
             self.draw()
+
+    def handle_down(self):
+        self.active_tab.scrolldown()
+        self.draw()
 
     def new_tab(self, url):
         new_tab = Tab(HEIGHT - self.chrome.bottom)
@@ -661,7 +665,7 @@ if __name__ == "__main__":
     import sys
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
-    browser.load(URL(sys.argv[1]))
+    browser.new_tab(URL(sys.argv[1]))
 
     event = sdl2.SDL_Event()
     while True:

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -210,9 +210,9 @@ class BlockLayout:
         if self.cursor_x + w > self.width:
             self.new_line()
         line = self.children[-1]
-        text = TextLayout(node, word, line, self.previous_word)
+        previous_word = line.children[-1] if line.children else None
+        text = TextLayout(node, word, line, previous_word)
         line.children.append(text)
-        self.previous_word = text
         self.cursor_x += w + font.measureText(" ")
 
     def input(self, node):
@@ -220,9 +220,9 @@ class BlockLayout:
         if self.cursor_x + w > self.width:
             self.new_line()
         line = self.children[-1]
-        input = InputLayout(node, line, self.previous_word)
+        previous_word = line.children[-1] if line.children else None
+        input = InputLayout(node, line, previous_word)
         line.children.append(input)
-        self.previous_word = input
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         size = float(node.style["font-size"][:-2])
@@ -393,119 +393,136 @@ class Tab:
 class Chrome:
     def __init__(self, browser):
         self.browser = browser
+        self.focus = None
+        self.address_bar = ""
+
         self.font = get_font(20, "normal", "roman")
-        font_height = linespace(self.font)
+        self.font_height = linespace(self.font)
 
         self.padding = 5
-        self.tab_header_bottom = font_height + 2 * self.padding
-        self.addressbar_top = self.tab_header_bottom + self.padding
-        self.bottom = \
-            math.ceil(
-                self.addressbar_top + font_height + 2 * self.padding)
+        self.tabbar_top = 0
+        self.tabbar_bottom = self.font_height + 2*self.padding
 
-    def plus_bounds(self):
-        plus_width = self.font.measureText("+")
-        return (self.padding, self.padding,
-            plus_width + self.padding, self.tab_header_bottom - self.padding)
+        plus_width = self.font.measureText("+") + 2*self.padding
+        self.newtab_rect = (
+           self.padding, self.padding,
+           self.padding + plus_width,
+           self.padding + self.font_height
+        )
 
-    def tab_bounds(self, i):
-        tab_start_x = self.font.measureText("+") + \
-            self.padding + self.padding
+        self.urlbar_top = self.tabbar_bottom
+        self.urlbar_bottom = self.urlbar_top + \
+            self.font_height + 2*self.padding
 
-        tab_width = self.font.measureText("Tab 1") + 2 * self.padding
+        back_width = self.font.measureText("<") + 2*self.padding
+        self.back_rect = (
+            self.padding,
+            self.urlbar_top + self.padding,
+            self.padding + back_width,
+            self.urlbar_bottom - self.padding,
+        )
 
-        return (tab_start_x + tab_width * i, self.padding,
-            tab_start_x + tab_width + tab_width * i, self.tab_header_bottom)
+        self.address_rect = (
+            self.back_rect[2] + self.padding,
+            self.urlbar_top + self.padding,
+            WIDTH - self.padding,
+            self.urlbar_bottom - self.padding,
+        )
 
-    def backbutton_bounds(self):
-        backbutton_width = self.font.measureText("<")
-        return (self.padding, self.addressbar_top,
-            self.padding + backbutton_width, self.bottom - self.padding)
+        self.bottom = self.urlbar_bottom
+
+    def tab_rect(self, i):
+        tabs_start = self.newtab_rect[3] + self.padding
+        tab_width = self.font.measureText("Tab X") + 2*self.padding
+        return (
+            tabs_start + tab_width * i, self.tabbar_top,
+            tabs_start + tab_width * (i + 1), self.tabbar_bottom
+        )
 
     def paint(self):
         cmds = []
-        cmds.append(DrawRect(0, 0, WIDTH, self.bottom, "white"))
+        cmds.append(DrawLine(
+            0, self.bottom, WIDTH,
+            self.bottom, "black", 1))
 
-        (plus_left, plus_top, plus_right, plus_bottom) = self.plus_bounds()
         cmds.append(DrawOutline(
-            plus_left, plus_top, plus_right, plus_bottom, "black", 1))
-        cmds.append(DrawText(
-            plus_left, plus_top, "+", self.font, "black"))
-
-        for i, tab in enumerate(self.browser.tabs):
-            name = "Tab {}".format(i)
-            (tab_left, tab_top, tab_right, tab_bottom) = self.tab_bounds(i)
-
-            cmds.append(DrawLine(
-                tab_left, 0,tab_left, tab_bottom, "black", 1))
-            cmds.append(DrawLine(
-                tab_right, 0, tab_right, tab_bottom, "black", 1))
-            cmds.append(DrawText(
-                tab_left + self.padding, tab_top,
-                name, self.font, "black"))
-            if i == self.browser.active_tab:
-                cmds.append(DrawLine(
-                    0, tab_bottom, tab_left, tab_bottom, "black", 1))
-                cmds.append(DrawLine(
-                    tab_right, tab_bottom, WIDTH, tab_bottom, "black", 1))
-
-        backbutton_width = self.font.measureText("<")
-        (backbutton_left, backbutton_top, backbutton_right, backbutton_bottom) = \
-            self.backbutton_bounds()
-        cmds.append(DrawOutline(
-            backbutton_left, backbutton_top,
-            backbutton_right, backbutton_bottom,
+            self.newtab_rect[0], self.newtab_rect[1],
+            self.newtab_rect[2], self.newtab_rect[3],
             "black", 1))
         cmds.append(DrawText(
-            backbutton_left, backbutton_top + self.padding,
-            "<", self.font, "black"))
+            self.newtab_rect[0] + self.padding,
+            self.newtab_rect[1],
+            "+", self.font, "black"))
 
-        (addressbar_left, addressbar_top, \
-            addressbar_right, addressbar_bottom) = \
-            self.addressbar_bounds()
+        for i, tab in enumerate(self.browser.tabs):
+            bounds = self.tab_rect(i)
+            cmds.append(DrawLine(
+                bounds[0], 0, bounds[0], bounds[3],
+                "black", 1))
+            cmds.append(DrawLine(
+                bounds[2], 0, bounds[2], bounds[3],
+                "black", 1))
+            cmds.append(DrawText(
+                bounds[0] + self.padding, bounds[1] + self.padding,
+                "Tab {}".format(i), self.font, "black"))
+
+            if tab == self.browser.active_tab:
+                cmds.append(DrawLine(
+                    0, bounds[3], bounds[0], bounds[3],
+                    "black", 1))
+                cmds.append(DrawLine(
+                    bounds[2], bounds[3], WIDTH, bounds[3],
+                    "black", 1))
 
         cmds.append(DrawOutline(
-            addressbar_left, addressbar_top, addressbar_right,
-            addressbar_bottom, "black", 1))
-        left_bar = addressbar_left + self.padding
-        top_bar = addressbar_top + self.padding
-        if self.browser.focus == "address bar":
-            cmds.append(DrawText(
-                left_bar, top_bar,
-                self.browser.address_bar, self.font, "black"))
-            w = self.font.measureText(self.browser.address_bar)
-            cmds.append(DrawLine(
-                left_bar + w, top_bar,
-                left_bar + w,
-                self.bottom - self.padding, "red", 1))
-        else:
-            url = str(self.browser.tabs[self.browser.active_tab].url)
-            cmds.append(DrawText(
-                left_bar,
-                top_bar,
-                url, self.font, "black"))
+            self.back_rect[0], self.back_rect[1],
+            self.back_rect[2], self.back_rect[3],
+            "black", 1))
+        cmds.append(DrawText(
+            self.back_rect[0] + self.padding,
+            self.back_rect[1],
+            "<", self.font, "black"))
 
-        cmds.append(DrawLine(
-            0, self.bottom + self.padding, WIDTH,
-            self.bottom + self.padding, "black", 1))
+        cmds.append(DrawOutline(
+            self.address_rect[0], self.address_rect[1],
+            self.address_rect[2], self.address_rect[3],
+            "black", 1))
+        if self.focus == "address bar":
+            cmds.append(DrawText(
+                self.address_rect[0] + self.padding,
+                self.address_rect[1],
+                self.address_bar, self.font, "black"))
+            w = self.font.measureText(self.address_bar)
+            cmds.append(DrawLine(
+                self.address_rect[0] + self.padding + w,
+                self.address_rect[1],
+                self.address_rect[0] + self.padding + w,
+                self.address_rect[3],
+                "red", 1))
+        else:
+            url = str(self.browser.active_tab.url)
+            cmds.append(DrawText(
+                self.address_rect[0] + self.padding,
+                self.address_rect[1],
+                url, self.font, "black"))
 
         return cmds
 
     def click(self, x, y):
-        if intersects(x, y, self.plus_bounds()):
-            self.browser.load(URL("https://browser.engineering/"))
-        elif intersects(x, y, self.backbutton_bounds()):
-            self.browser.tabs[self.browser.active_tab].go_back()
-        elif intersects(x, y, self.addressbar_bounds()):
-            self.browser.focus = "address bar"
-            self.browser.address_bar = ""
+        self.focus = None
+        if intersects(x, y, self.newtab_rect):
+            self.browser.new_tab(URL("https://browser.engineering/"))
+        elif intersects(x, y, self.back_rect):
+            self.browser.active_tab.go_back()
+        elif intersects(x, y, self.address_rect):
+            self.focus = "address bar"
+            self.address_bar = ""
         else:
             for i, tab in enumerate(self.browser.tabs):
-                if intersects(x, y, self.tab_bounds(i)):
-                    self.browser.active_tab = i
+                if intersects(x, y, self.tab_rect(i)):
+                    self.browser.active_tab = tab
                     break
             self.browser.raster_tab()
-
 
 @wbetools.patch(Browser)
 class Browser:
@@ -539,59 +556,52 @@ class Browser:
             self.BLUE_MASK = 0x00ff0000
             self.ALPHA_MASK = 0xff000000
 
-    def handle_down(self):
-        self.tabs[self.active_tab].scrolldown()
-        self.draw()
-
     def handle_click(self, e):
         if e.y < self.chrome.bottom:
-            self.focus = None
+            self.focus = "chrome"
             self.chrome.click(e.x, e.y)
             self.raster_chrome()
         else:
             if self.focus != "content":
                 self.focus = "content"
                 self.raster_chrome()
-            else:
-                self.focus = "content"
-            url = self.tabs[self.active_tab].url
-            self.tabs[self.active_tab].click(
-                e.x, e.y - self.chrome.bottom)
-            if self.tabs[self.active_tab] != url:
+            url = self.active_tab.url
+            tab_y = e.y - self.chrome.bottom
+            self.active_tab.click(e.x, tab_y)
+            if self.active_tab.url != url:
                 self.raster_chrome()
             self.raster_tab()
         self.draw()
 
     def handle_key(self, char):
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "address bar":
-            self.address_bar += char
+        if self.focus == "chrome":
+            self.chrome.keypress(char)
             self.raster_chrome()
             self.draw()
         elif self.focus == "content":
-            self.tabs[self.active_tab].keypress(char)
+            self.active_tab.keypress(char)
             self.raster_tab()
             self.draw()
 
     def handle_enter(self):
-        if self.focus == "address bar":
-            self.tabs[self.active_tab].load(URL(self.address_bar))
-            self.focus = None
+        if self.focus == "chrome":
+            self.chrome.enter()
             self.raster_tab()
+            self.raster_chrome()
             self.draw()
 
-    def load(self, url):
+    def new_tab(self, url):
         new_tab = Tab(HEIGHT - self.chrome.bottom)
         new_tab.load(url)
-        self.active_tab = len(self.tabs)
         self.tabs.append(new_tab)
+        self.active_tab = new_tab
         self.raster_chrome()
         self.raster_tab()
         self.draw()
 
     def raster_tab(self):
-        active_tab = self.tabs[self.active_tab]
-        tab_height = math.ceil(active_tab.document.height)
+        tab_height = math.ceil(self.active_tab.document.height)
 
         if not self.tab_surface or \
                 tab_height != self.tab_surface.height():
@@ -599,7 +609,7 @@ class Browser:
 
         canvas = self.tab_surface.getCanvas()
         canvas.clear(skia.ColorWHITE)
-        active_tab.raster(canvas)
+        self.active_tab.raster(canvas)
 
     def raster_chrome(self):
         canvas = self.chrome_surface.getCanvas()
@@ -613,7 +623,7 @@ class Browser:
         canvas.clear(skia.ColorWHITE)
         
         tab_rect = skia.Rect.MakeLTRB(0, self.chrome.bottom, WIDTH, HEIGHT)
-        tab_offset = self.chrome.bottom - self.tabs[self.active_tab].scroll
+        tab_offset = self.chrome.bottom - self.active_tab.scroll
         canvas.save()
         canvas.clipRect(tab_rect)
         canvas.translate(0, tab_offset)

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -34,7 +34,7 @@ Before load, there is no tab height or display list.
 
 Once the Tab has loaded, the browser should need raster and draw.
 
-    >>> browser.load(lab12.URL(test_url))
+    >>> browser.new_tab(lab12.URL(test_url))
     >>> browser.render()
     >>> browser.needs_raster_and_draw
     True
@@ -65,7 +65,7 @@ After performing raster and draw, the display list should be present.
 
 The initial sroll offset is 0.
 
-    >>> browser.tabs[browser.active_tab].scroll
+    >>> browser.active_tab.scroll
     0
 
 Scrolling down causes a draw but nothing else.
@@ -89,7 +89,7 @@ Testing TabWrapper
 
 	>>> lab12.TaskRunner = test.MockNoOpTaskRunner
     >>> browser = lab12.Browser()
-    >>> browser.load(lab12.URL(test_url))
+    >>> browser.new_tab(lab12.URL(test_url))
 
  The URL is not set until the load has committed.
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -448,7 +448,7 @@ class Browser:
             WIDTH, HEIGHT,
             ct=skia.kRGBA_8888_ColorType,
             at=skia.kUnpremul_AlphaType))
-        self.chrome_surface = skia.Surface(WIDTH, self.chrome.bottom)
+        self.chrome_surface = skia.Surface(WIDTH, math.ceil(self.chrome.bottom))
         self.tab_surface = None
 
         self.tabs = []
@@ -645,7 +645,7 @@ if __name__ == "__main__":
 
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
-    browser.load(URL(args.url))
+    browser.new_tab(URL(args.url))
     event = sdl2.SDL_Event()
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:

--- a/src/lab13-tests.md
+++ b/src/lab13-tests.md
@@ -33,7 +33,7 @@ Testing CSS transtions
     ... b"<div style=\"opacity:0.5\">Text</div>)")
 
     >>> browser = lab13.Browser()
-    >>> browser.load(lab13.URL(transitions_url))
+    >>> browser.new_tab(lab13.URL(transitions_url))
     >>> browser.render()
     >>> browser.composite_raster_and_draw()
 
@@ -59,7 +59,7 @@ Testing CSS transtions
              SaveLayer(<no-op>)
                ClipRRect(<no-op>)
                  DrawCompositedLayer()
-    >>> tab = browser.tabs[browser.active_tab]
+    >>> tab = browser.active_tab
     >>> div = tab.nodes.children[1].children[0]
 
 There is a transition defined for opacity, for a duration of 2 seconds. This is
@@ -109,10 +109,10 @@ Animations work:
     ... b"<div style=\"transform:translate(80px,90px)\">Text</div>)")
 
     >>> browser = lab13.Browser()
-    >>> browser.load(lab13.URL(transitions_url3))
+    >>> browser.new_tab(lab13.URL(transitions_url3))
     >>> browser.render()
     >>> browser.composite_raster_and_draw()
-    >>> tab = browser.tabs[browser.active_tab]
+    >>> tab = browser.active_tab
     >>> div = tab.nodes.children[1].children[0]
     >>> lab13.parse_transition(div.style.get("transition"))
     {'transform': 125.0}
@@ -137,14 +137,14 @@ Here's a page with a button translated via CSS:
     >>> test.socket.respond(success_url, b"HTTP/1.0 200 OK\r\n" +
     ... b"content-type: text/html\r\n\r\n")
     >>> browser = lab13.Browser()
-    >>> browser.load(lab13.URL(transitions_url4))
+    >>> browser.new_tab(lab13.URL(transitions_url4))
     >>> browser.render()
     
 Let's click it at (100, 120). Those numbers are an offset of (80, 90)
 plus an initial position of (13, 21) plus a little bit to make sure
 we're inside the button:
 
-    >>> tab = browser.tabs[browser.active_tab]
+    >>> tab = browser.active_tab
     >>> tab.click(100, 120)
     >>> tab.url
     URL(scheme=http, host=test.test, port=80, path='/success')

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1346,7 +1346,7 @@ class Browser:
 
             self.chrome_surface = skia.Surface.MakeRenderTarget(
                     self.skia_context, skia.Budgeted.kNo,
-                    skia.ImageInfo.MakeN32Premul(WIDTH, self.chrome.bottom))
+                    skia.ImageInfo.MakeN32Premul(WIDTH, math.ceil(self.chrome.bottom)))
             assert self.chrome_surface is not None
         else:
             self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
@@ -1357,7 +1357,7 @@ class Browser:
                 WIDTH, HEIGHT,
                 ct=skia.kRGBA_8888_ColorType,
                 at=skia.kUnpremul_AlphaType))
-            self.chrome_surface = skia.Surface(WIDTH, self.chrome.bottom)
+            self.chrome_surface = skia.Surface(WIDTH, math.ceil(self.chrome.bottom))
             self.skia_context = None
 
         self.tabs = []
@@ -1673,7 +1673,7 @@ if __name__ == "__main__":
 
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
-    browser.load(URL(sys.argv[1]))
+    browser.new_tab(URL(sys.argv[1]))
 
     event = sdl2.SDL_Event()
     while True:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1397,13 +1397,12 @@ class Browser:
 
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
-        tab = self.tabs[self.active_tab]
-        tab.task_runner.run_tasks()
-        tab.run_animation_frame(self.scroll)
+        self.active_tab.task_runner.run_tasks()
+        self.active_tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.url = data.url
             if data.scroll != None:
                 self.scroll = data.scroll
@@ -1421,7 +1420,7 @@ class Browser:
 
     def set_needs_animation_frame(self, tab):
         self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.needs_animation_frame = True
         self.lock.release()
 
@@ -1523,7 +1522,7 @@ class Browser:
         def callback():
             self.lock.acquire(blocking=True)
             scroll = self.scroll
-            active_tab = self.tabs[self.active_tab]
+            active_tab = self.active_tab
             self.needs_animation_frame = False
             self.lock.release()
             task = Task(active_tab.run_animation_frame, scroll)
@@ -1556,8 +1555,8 @@ class Browser:
         self.display_list = []
         self.composited_layers = []
 
-    def set_active_tab(self, index):
-        self.active_tab = index
+    def set_active_tab(self, tab):
+        self.active_tab = tab
         self.clear_data()
         self.needs_animation_frame = True
 
@@ -1571,9 +1570,9 @@ class Browser:
             if self.focus != "content":
                 self.set_needs_raster()
             self.focus = "content"
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.click, e.x, e.y - self.chrome.bottom)
-            active_tab.task_runner.schedule_task(task)
+            tab_y = e.y - self.chrome.bottom
+            task = Task(self.active_tab.click, e.x, tab_y)
+            self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def handle_key(self, char):
@@ -1583,15 +1582,13 @@ class Browser:
             self.address_bar += char
             self.set_needs_raster()
         elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.keypress, char)
-            active_tab.task_runner.schedule_task(task)
+            task = Task(self.active_tab.keypress, char)
+            self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def schedule_load(self, url, body=None):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.load, url, body)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.load, url, body)
+        self.active_tab.task_runner.schedule_task(task)
 
     def handle_enter(self):
         self.lock.acquire(blocking=True)
@@ -1603,14 +1600,14 @@ class Browser:
             self.needs_animation_frame = True
         self.lock.release()
 
-    def load(self, url):
+    def new_tab(self, url):
         self.lock.acquire(blocking=True)
-        self.load_internal(url)
+        self.new_tab_internal(url)
         self.lock.release()
 
-    def load_internal(self, url):
+    def new_tab_internal(self, url):
         new_tab = Tab(self, HEIGHT - self.chrome.bottom)
-        self.set_active_tab(len(self.tabs))
+        self.set_active_tab(new_tab)
         self.tabs.append(new_tab)
         self.schedule_load(url)
 
@@ -1665,7 +1662,7 @@ class Browser:
 
     def handle_quit(self):
         self.measure.finish()
-        self.tabs[self.active_tab].task_runner.set_needs_quit()
+        self.active_tab.task_runner.set_needs_quit()
         if wbetools.USE_GPU:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
@@ -1695,9 +1692,8 @@ if __name__ == "__main__":
                     browser.handle_down()
             elif event.type == sdl2.SDL_TEXTINPUT:
                 browser.handle_key(event.text.text.decode('utf8'))
-        active_tab = browser.tabs[browser.active_tab]
         if not wbetools.USE_BROWSER_THREAD:
-            if active_tab.task_runner.needs_quit:
+            if browser.active_tab.task_runner.needs_quit:
                 break
             if browser.needs_animation_frame:
                 browser.needs_animation_frame = False

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -44,7 +44,7 @@ An outline causes a `DrawOutline` with the given width and color:
     ... b'<div>test</div>')
 
     >>> browser = lab14.Browser()
-    >>> browser.load(lab14.URL(outline_url))
+    >>> browser.new_tab(lab14.URL(outline_url))
     >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
@@ -62,7 +62,7 @@ Focus
     ... b'<input><a href="/dest">Link</a>')
 
     >>> browser = lab14.Browser()
-    >>> browser.load(lab14.URL(focus_url))
+    >>> browser.new_tab(lab14.URL(focus_url))
     >>> browser.render()
 
 On load, nothing is focused:
@@ -104,7 +104,7 @@ Tabindex changes the order:
     ... b'<input tabindex=2><a tabindex=1 href="/dest">Link</a>')
 
     >>> browser = lab14.Browser()
-    >>> browser.load(lab14.URL(focus_url))
+    >>> browser.new_tab(lab14.URL(focus_url))
     >>> browser.render()
 
 This time the `a` element is focused first:
@@ -137,7 +137,7 @@ are:
     ... b'<div>Not focusable</div><div tabindex=1>Is focusable</div>')
 
     >>> browser = lab14.Browser()
-    >>> browser.load(lab14.URL(focus_tabindex_url))
+    >>> browser.new_tab(lab14.URL(focus_tabindex_url))
     >>> browser.render()
 
 The first `div` is not focusable.
@@ -164,7 +164,7 @@ The accessibility tree is automatically created.
     ... b'<input><a href="/dest">Link</a>')
 
     >>> browser = lab14.Browser()
-    >>> browser.load(lab14.URL(focus_url))
+    >>> browser.new_tab(lab14.URL(focus_url))
     >>> browser.toggle_accessibility()
 
 Rendering will read out the accessibility instructions:
@@ -197,7 +197,7 @@ The browser supports light and dark mode rendering.
 The tab contents are light:
 
     >>> browser = lab14.Browser()
-    >>> browser.load(lab14.URL(focus_url))
+    >>> browser.new_tab(lab14.URL(focus_url))
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
      DrawRRect(rect=RRect(13, 21, 213, 37, 1), color=lightblue)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1237,71 +1237,76 @@ class Chrome:
             color = "black"
 
         cmds = []
+        cmds.append(DrawLine(
+            0, self.bottom, WIDTH,
+            self.bottom, color, 1))
 
-        (plus_left, plus_top, plus_right, plus_bottom) = self.plus_bounds()
         cmds.append(DrawOutline(
-            plus_left, plus_top, plus_right, plus_bottom, color, 1))
-        cmds.append(DrawText(
-            plus_left, plus_top, "+", self.font, color))
-
-        for i, tab in enumerate(self.browser.tabs):
-            name = "Tab {}".format(i)
-            (tab_left, tab_top, tab_right, tab_bottom) = self.tab_bounds(i)
-
-            cmds.append(DrawLine(
-                tab_left, 0,tab_left, tab_bottom, color, 1))
-            cmds.append(DrawLine(
-                tab_right, 0, tab_right, tab_bottom, color, 1))
-            cmds.append(DrawText(
-                tab_left + self.padding, tab_top,
-                name, self.font, color))
-            if i == self.browser.active_tab:
-                cmds.append(DrawLine(
-                    0, tab_bottom, tab_left, tab_bottom, color, 1))
-                cmds.append(DrawLine(
-                    tab_right, tab_bottom, WIDTH, tab_bottom, color, 1))
-
-        backbutton_width = self.font.measureText("<")
-        (backbutton_left, backbutton_top, backbutton_right, backbutton_bottom) = \
-            self.backbutton_bounds()
-        cmds.append(DrawOutline(
-            backbutton_left, backbutton_top,
-            backbutton_right, backbutton_bottom,
+            self.newtab_rect[0], self.newtab_rect[1],
+            self.newtab_rect[2], self.newtab_rect[3],
             color, 1))
         cmds.append(DrawText(
-            backbutton_left, backbutton_top + self.padding,
-            "<", self.font, color))
+            self.newtab_rect[0] + self.padding,
+            self.newtab_rect[1],
+            "+", self.font, color))
 
-        (addressbar_left, addressbar_top, \
-            addressbar_right, addressbar_bottom) = \
-            self.addressbar_bounds()
+        for i, tab in enumerate(self.browser.tabs):
+            bounds = self.tab_rect(i)
+            cmds.append(DrawLine(
+                bounds[0], 0, bounds[0], bounds[3],
+                color, 1))
+            cmds.append(DrawLine(
+                bounds[2], 0, bounds[2], bounds[3],
+                color, 1))
+            cmds.append(DrawText(
+                bounds[0] + self.padding, bounds[1] + self.padding,
+                "Tab {}".format(i), self.font, color))
+
+            if tab == self.browser.active_tab:
+                cmds.append(DrawLine(
+                    0, bounds[3], bounds[0], bounds[3],
+                    color, 1))
+                cmds.append(DrawLine(
+                    bounds[2], bounds[3], WIDTH, bounds[3],
+                    color, 1))
 
         cmds.append(DrawOutline(
-            addressbar_left, addressbar_top, addressbar_right,
-            addressbar_bottom, color, 1))
-        left_bar = addressbar_left + self.padding
-        top_bar = addressbar_top + self.padding
-        if self.browser.focus == "address bar":
+            self.back_rect[0], self.back_rect[1],
+            self.back_rect[2], self.back_rect[3],
+            color, 1))
+        cmds.append(DrawText(
+            self.back_rect[0] + self.padding,
+            self.back_rect[1],
+            "<", self.font, color))
+
+        cmds.append(DrawOutline(
+            self.address_rect[0], self.address_rect[1],
+            self.address_rect[2], self.address_rect[3],
+            color, 1))
+        if self.focus == "address bar":
             cmds.append(DrawText(
-                left_bar, top_bar,
-                self.browser.address_bar, self.font, color))
-            w = self.font.measureText(self.browser.address_bar)
+                self.address_rect[0] + self.padding,
+                self.address_rect[1],
+                self.address_bar, self.font, color))
+            w = self.font.measureText(self.address_bar)
             cmds.append(DrawLine(
-                left_bar + w, top_bar,
-                left_bar + w,
-                self.bottom - self.padding, "red", 1))
+                self.address_rect[0] + self.padding + w,
+                self.address_rect[1],
+                self.address_rect[0] + self.padding + w,
+                self.address_rect[3],
+                "red", 1))
         else:
-            url = str(self.browser.tabs[self.browser.active_tab].url)
+            url = str(self.browser.active_tab.url)
             cmds.append(DrawText(
-                left_bar,
-                top_bar,
+                self.address_rect[0] + self.padding,
+                self.address_rect[1],
                 url, self.font, color))
 
-        cmds.append(DrawLine(
-            0, self.bottom + self.padding, WIDTH,
-            self.bottom + self.padding, color, 1))
-
         return cmds
+
+    def focus_addressbar(self):
+        self.focus = "address bar"
+        self.address_bar = ""
 
 class Browser:
     def __init__(self):
@@ -1400,13 +1405,12 @@ class Browser:
 
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
-        tab = self.tabs[self.active_tab]
-        tab.task_runner.run_tasks()
-        tab.run_animation_frame(self.scroll)
+        self.active_tab.task_runner.run_tasks()
+        self.active_tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.url = data.url
             if data.scroll != None:
                 self.scroll = data.scroll
@@ -1428,7 +1432,7 @@ class Browser:
 
     def set_needs_animation_frame(self, tab):
         self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.needs_animation_frame = True
         self.lock.release()
 
@@ -1605,7 +1609,7 @@ class Browser:
         def callback():
             self.lock.acquire(blocking=True)
             scroll = self.scroll
-            active_tab = self.tabs[self.active_tab]
+            active_tab = self.active_tab
             self.needs_animation_frame = False
             self.lock.release()
             task = Task(active_tab.run_animation_frame, scroll)
@@ -1634,14 +1638,13 @@ class Browser:
 
     def handle_tab(self):
         self.focus = "content"
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.advance_tab)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.advance_tab)
+        self.active_tab.task_runner.schedule_task(task)
 
     def focus_addressbar(self):
         self.lock.acquire(blocking=True)
-        self.focus = "address bar"
-        self.address_bar = ""
+        self.focus = "chrome"
+        self.chrome.focus_addressbar()
         text = "Address bar focused"
         if self.accessibility_is_on:
             print(text)
@@ -1657,25 +1660,24 @@ class Browser:
         self.accessibility_tree = None
         self.composited_layers = []
 
-    def set_active_tab(self, index):
-        self.active_tab = index
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.set_needs_paint)
-        active_tab.task_runner.schedule_task(task)
+    def set_active_tab(self, tab):
+        self.active_tab = tab
+        task = Task(self.active_tab.set_needs_paint)
+        self.active_tab.task_runner.schedule_task(task)
 
         self.clear_data()
         self.needs_animation_frame = True
 
     def go_back(self):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.go_back)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.go_back)
+        self.active_tab.task_runner.schedule_task(task)
         self.clear_data()
 
     def cycle_tabs(self):
         self.lock.acquire(blocking=True)
-        new_active_tab = (self.active_tab + 1) % len(self.tabs)
-        self.set_active_tab(new_active_tab)
+        active_ids = self.tabs.index(self.active_tab)
+        new_active_idx = (active_idx + 1) % len(self.tabs)
+        self.set_active_tab(self.tabs[new_active_idx])
         self.lock.release()
 
     def toggle_accessibility(self):
@@ -1721,9 +1723,8 @@ class Browser:
     def toggle_dark_mode(self):
         self.lock.acquire(blocking=True)
         self.dark_mode = not self.dark_mode
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.toggle_dark_mode)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.toggle_dark_mode)
+        self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def handle_click(self, e):
@@ -1736,9 +1737,9 @@ class Browser:
             if self.focus != "content":
                 self.set_needs_raster()
             self.focus = "content"
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.click, e.x, e.y - self.chrome.bottom)
-            active_tab.task_runner.schedule_task(task)
+            tab_y = e.y - self.chrome.bottom
+            task = Task(self.active_tab.click, e.x, tab_y)
+            self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def handle_hover(self, event):
@@ -1751,56 +1752,49 @@ class Browser:
     def handle_key(self, char):
         self.lock.acquire(blocking=True)
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "address bar":
-            self.address_bar += char
+        if self.focus == "chrome":
+            self.chrome.keypress(char)
             self.set_needs_raster()
         elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.keypress, char)
-            active_tab.task_runner.schedule_task(task)
+            task = Task(self.active_tab.keypress, char)
+            self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def schedule_load(self, url, body=None):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.load, url, body)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.load, url, body)
+        self.active_tab.task_runner.schedule_task(task)
 
     def handle_enter(self):
         self.lock.acquire(blocking=True)
-        if self.focus == "address bar":
-            self.schedule_load(URL(self.address_bar))
-            self.url = self.address_bar
-            self.focus = None
+        if self.focus == "chrome":
+            self.chrome.enter()
             self.set_needs_raster()
         elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.enter)
-            active_tab.task_runner.schedule_task(task)
+            task = Task(self.active_tab.enter)
+            self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def increment_zoom(self, increment):
         self.lock.acquire(blocking=True)
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.zoom_by, increment)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.zoom_by, increment)
+        self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
     def reset_zoom(self):
         self.lock.acquire(blocking=True)
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.reset_zoom)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.reset_zoom)
+        self.active_tab.task_runner.schedule_task(task)
         self.lock.release()
 
-    def load(self, url):
+    def new_tab(self, url):
         self.lock.acquire(blocking=True)
-        self.load_internal(url)
+        self.new_tab_internal(url)
         self.lock.release()
 
-    def load_internal(self, url):
+    def new_tab_internal(self, url):
         new_tab = Tab(self, HEIGHT -self.chrome.bottom)
         self.tabs.append(new_tab)
-        self.set_active_tab(len(self.tabs) - 1)
+        self.set_active_tab(new_tab)
         self.schedule_load(url)
 
     def raster_tab(self):
@@ -1861,7 +1855,7 @@ class Browser:
 
     def handle_quit(self):
         self.measure.finish()
-        self.tabs[self.active_tab].task_runner.set_needs_quit()
+        self.active_tab.task_runner.set_needs_quit()
         if wbetools.USE_GPU:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
@@ -1926,9 +1920,8 @@ def main_func(url):
                     ctrl_down = False
             elif event.type == sdl2.SDL_TEXTINPUT and not ctrl_down:
                 browser.handle_key(event.text.text.decode('utf8'))
-        active_tab = browser.tabs[browser.active_tab]
         if not wbetools.USE_BROWSER_THREAD:
-            if active_tab.task_runner.needs_quit:
+            if browser.active_tab.task_runner.needs_quit:
                 break
             if browser.needs_animation_frame:
                 browser.needs_animation_frame = False

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1340,7 +1340,7 @@ class Browser:
 
             self.chrome_surface = skia.Surface.MakeRenderTarget(
                     self.skia_context, skia.Budgeted.kNo,
-                    skia.ImageInfo.MakeN32Premul(WIDTH, self.chrome.bottom))
+                    skia.ImageInfo.MakeN32Premul(WIDTH, math.ceil(self.chrome.bottom)))
             assert self.chrome_surface is not None
         else:
             self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
@@ -1351,7 +1351,7 @@ class Browser:
                 WIDTH, HEIGHT,
                 ct=skia.kRGBA_8888_ColorType,
                 at=skia.kUnpremul_AlphaType))
-            self.chrome_surface = skia.Surface(WIDTH, self.chrome.bottom)
+            self.chrome_surface = skia.Surface(WIDTH, math.ceil(self.chrome.bottom))
             self.skia_context = None
 
         self.tabs = []
@@ -1863,7 +1863,7 @@ class Browser:
 def main_func(url):
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
-    browser.load(url)
+    browser.new_tab(url)
 
     event = sdl2.SDL_Event()
     ctrl_down = False

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -35,7 +35,7 @@ Let's verify that we can request the image:
     ... b'content-type: text/html\r\n\r\n' +
     ... b'<img src="http://test.test/img.png">')
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(url))
+    >>> browser.new_tab(lab15.URL(url))
     >>> browser.render()
     >>> frame = browser.tabs[0].root_frame
     >>> headers, body = lab15.URL(image_url).request(frame.url)
@@ -70,7 +70,7 @@ Now let's test setting a different width and height:
     ... b'<img width=10 height=20 src="http://test.test/img.png">')
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(size_url))
+    >>> browser.new_tab(lab15.URL(size_url))
     >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
@@ -88,7 +88,7 @@ Let's load the original image in an iframe.
     ... b'<iframe src="http://test.test/">')
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(iframe_url))
+    >>> browser.new_tab(lab15.URL(iframe_url))
     >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
@@ -107,7 +107,7 @@ And the sized one:
     ... b'<iframe src="http://test.test/size">')
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(iframe_size_url))
+    >>> browser.new_tab(lab15.URL(iframe_size_url))
     >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
@@ -129,7 +129,7 @@ Iframes can be sized too:
     ... b'<iframe width=50 height=30 src="http://test.test/">')
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(sized_iframe_url))
+    >>> browser.new_tab(lab15.URL(sized_iframe_url))
     >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
@@ -185,7 +185,7 @@ Now let's test scrolling of the root frame:
 Clicking the sub-frame focuses it:
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(sized_iframe_url))
+    >>> browser.new_tab(lab15.URL(sized_iframe_url))
     >>> browser.render()
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
@@ -220,7 +220,7 @@ Let's verify that it still works.
     ... b'<input><a href="/dest">Link</a>')
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(focus_url))
+    >>> browser.new_tab(lab15.URL(focus_url))
     >>> browser.render()
     >>> browser.toggle_accessibility()
 
@@ -237,7 +237,7 @@ Rendering will read out the accessibility instructions:
 It also works for iframes:
 
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(iframe_url))
+    >>> browser.new_tab(lab15.URL(iframe_url))
     >>> browser.render()
     >>> browser.toggle_accessibility()
 
@@ -288,7 +288,7 @@ resizing is dramatic:
     ... <iframe width=50 src=""" + url2 + """ />
     ... """)
     >>> browser = lab15.Browser()
-    >>> browser.load(lab15.URL(url1))
+    >>> browser.new_tab(lab15.URL(url1))
     >>> browser.render()
     >>> frame1 = browser.tabs[0].root_frame
     >>> iframe = [

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -44,7 +44,7 @@ from lab14 import parse_color, DrawRRect, \
     parse_outline, paint_outline, \
     device_px, cascade_priority, style, \
     is_focusable, get_tabindex, speak_text, \
-    CSSParser, DrawOutline, main_func, Browser, Chrome
+    CSSParser, DrawOutline, main_func, Browser, Chrome, Tab
 
 @wbetools.patch(URL)
 class URL:
@@ -1283,10 +1283,8 @@ class Frame:
         if self.needs_layout:
             self.document = DocumentLayout(self.nodes, self)
             self.document.layout(self.frame_width, self.tab.zoom)
-            if self.tab.accessibility_is_on:
-                self.tab.needs_accessibility = True
-            else:
-                self.needs_paint = True
+            self.tab.needs_accessibility = True
+            self.needs_paint = True
             self.needs_layout = False
 
         clamped_scroll = self.clamp_scroll(self.scroll)
@@ -1436,7 +1434,7 @@ class CommitData:
         self.accessibility_tree = accessibility_tree
         self.focus = focus
 
-
+@wbetools.patch(Tab)
 class Tab:
     def __init__(self, browser, tab_height):
         self.url = ""
@@ -1615,10 +1613,6 @@ class Tab:
             back = self.history.pop()
             self.load(back)
 
-    def toggle_accessibility(self):
-        self.accessibility_is_on = not self.accessibility_is_on
-        self.set_needs_accessibility()
-
     def toggle_dark_mode(self):
         self.dark_mode = not self.dark_mode
         self.set_needs_render_all_frames()
@@ -1627,100 +1621,6 @@ class Tab:
         frame = self.window_id_to_frame[target_window_id]
         frame.js.dispatch_post_message(
             message, target_window_id)
-
-@wbetools.patch(Chrome)
-class Chrome:
-    def paint(self):
-        if self.browser.dark_mode:
-            color = "white"
-        else:
-            color = "black"
-
-        cmds = []
-
-        (plus_left, plus_top, plus_right, plus_bottom) = self.plus_bounds()
-        cmds.append(DrawOutline(
-            plus_left, plus_top, plus_right, plus_bottom, color, 1))
-        cmds.append(DrawText(
-            plus_left, plus_top, "+", self.font, color))
-
-        for i, tab in enumerate(self.browser.tabs):
-            name = "Tab {}".format(i)
-            (tab_left, tab_top, tab_right, tab_bottom) = self.tab_bounds(i)
-
-            cmds.append(DrawLine(
-                tab_left, 0,tab_left, tab_bottom, color, 1))
-            cmds.append(DrawLine(
-                tab_right, 0, tab_right, tab_bottom, color, 1))
-            cmds.append(DrawText(
-                tab_left + self.padding, tab_top,
-                name, self.font, color))
-            if i == self.browser.active_tab:
-                cmds.append(DrawLine(
-                    0, tab_bottom, tab_left, tab_bottom, color, 1))
-                cmds.append(DrawLine(
-                    tab_right, tab_bottom, WIDTH, tab_bottom, color, 1))
-
-        backbutton_width = self.font.measureText("<")
-        (backbutton_left, backbutton_top, backbutton_right, backbutton_bottom) = \
-            self.backbutton_bounds()
-        cmds.append(DrawOutline(
-            backbutton_left, backbutton_top,
-            backbutton_right, backbutton_bottom,
-            color, 1))
-        cmds.append(DrawText(
-            backbutton_left, backbutton_top + self.padding,
-            "<", self.font, color))
-
-        (addressbar_left, addressbar_top, \
-            addressbar_right, addressbar_bottom) = \
-            self.addressbar_bounds()
-
-        cmds.append(DrawOutline(
-            addressbar_left, addressbar_top, addressbar_right,
-            addressbar_bottom, color, 1))
-        left_bar = addressbar_left + self.padding
-        top_bar = addressbar_top + self.padding
-        if self.browser.focus == "address bar":
-            cmds.append(DrawText(
-                left_bar, top_bar,
-                self.browser.address_bar, self.font, color))
-            w = self.font.measureText(self.browser.address_bar)
-            cmds.append(DrawLine(
-                left_bar + w, top_bar,
-                left_bar + w,
-                self.bottom - self.padding, "red", 1))
-        else:
-            url = ""
-            if self.browser.tabs[self.browser.active_tab].root_frame:
-                url = str(self.browser.tabs[
-                    self.browser.active_tab].root_frame.url)
-            cmds.append(DrawText(
-                left_bar,
-                top_bar,
-                url, self.font, color))
-
-        cmds.append(DrawLine(
-            0, self.bottom + self.padding, WIDTH,
-            self.bottom + self.padding, color, 1))
-
-        return cmds
-
-    def click(self, x, y):
-        if intersects(x, y, self.plus_bounds()):
-            self.browser.load_internal(URL("https://browser.engineering/"))
-        elif intersects(x, y, self.backbutton_bounds()):
-            active_tab = self.browser.tabs[self.browser.active_tab]
-            task = Task(active_tab.go_back)
-            active_tab.task_runner.schedule_task(task)
-        elif intersects(x, y, self.addressbar_bounds()):
-            self.browser.focus = "address bar"
-            self.browser.address_bar = ""
-        else:
-            for i in range(0, len(self.browser.tabs)):
-                if intersects(x, y, self.tab_bounds(i)):
-                    self.browser.set_active_tab(i)
-                    break
 
 @wbetools.patch(Browser)
 class Browser:
@@ -1755,7 +1655,7 @@ class Browser:
 
             self.chrome_surface = skia.Surface.MakeRenderTarget(
                     self.skia_context, skia.Budgeted.kNo,
-                    skia.ImageInfo.MakeN32Premul(WIDTH, self.chrome.bottom))
+                    skia.ImageInfo.MakeN32Premul(WIDTH, math.ceil(self.chrome.bottom)))
             assert self.chrome_surface is not None
         else:
             self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
@@ -1766,7 +1666,7 @@ class Browser:
                 WIDTH, HEIGHT,
                 ct=skia.kRGBA_8888_ColorType,
                 at=skia.kUnpremul_AlphaType))
-            self.chrome_surface = skia.Surface(WIDTH, self.chrome.bottom)
+            self.chrome_surface = skia.Surface(WIDTH, math.ceil(self.chrome.bottom))
             self.skia_context = None
 
         self.tabs = []
@@ -1819,15 +1719,9 @@ class Browser:
         self.active_alerts = []
         self.spoken_alerts = []
 
-    def render(self):
-        assert not wbetools.USE_BROWSER_THREAD
-        tab = self.tabs[self.active_tab]
-        tab.task_runner.run_tasks()
-        tab.run_animation_frame(self.scroll)
-
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
+        if tab == self.active_tab:
             self.url = data.url
             if data.scroll != None:
                 self.scroll = data.scroll
@@ -1847,191 +1741,6 @@ class Browser:
                 self.set_needs_draw()
         self.lock.release()
 
-    def set_needs_animation_frame(self, tab):
-        self.lock.acquire(blocking=True)
-        if tab == self.tabs[self.active_tab]:
-            self.needs_animation_frame = True
-        self.lock.release()
-
-    def set_needs_raster(self):
-        self.needs_raster = True
-        self.needs_draw = True
-
-    def set_needs_composite(self):
-        self.needs_composite = True
-        self.needs_raster = True
-        self.needs_draw = True
-
-    def set_needs_accessibility(self):
-        if not self.accessibility_is_on:
-            return
-        self.needs_accessibility = True
-        self.needs_draw = True
-
-    def set_needs_draw(self):
-        self.needs_draw = True
-
-    def composite(self):
-        self.composited_layers = []
-        add_parent_pointers(self.active_tab_display_list)
-        all_commands = []
-        for cmd in self.active_tab_display_list:
-            all_commands = \
-                tree_to_list(cmd, all_commands)
-
-        non_composited_commands = [cmd
-            for cmd in all_commands
-            if isinstance(cmd, DrawCommand) or not cmd.needs_compositing
-            if not cmd.parent or cmd.parent.needs_compositing
-        ]
-        for cmd in non_composited_commands:
-            for layer in reversed(self.composited_layers):
-                if layer.can_merge(cmd):
-                    layer.add(cmd)
-                    break
-                elif skia.Rect.Intersects(
-                    layer.absolute_bounds(),
-                    absolute_bounds(cmd)):
-                    layer = CompositedLayer(self.skia_context, cmd)
-                    self.composited_layers.append(layer)
-                    break
-            else:
-                layer = CompositedLayer(self.skia_context, cmd)
-                self.composited_layers.append(layer)
-
-        self.active_tab_height = 0
-        for layer in self.composited_layers:
-            self.active_tab_height = \
-                max(self.active_tab_height,
-                    layer.absolute_bounds().bottom())
-
-    def clone_latest(self, visual_effect, current_effect):
-        node = visual_effect.node
-        if not node in self.composited_updates:
-            return visual_effect.clone(current_effect)
-        save_layer = self.composited_updates[node]
-        if type(visual_effect) is SaveLayer:
-            return save_layer.clone(current_effect)
-        return visual_effect.clone(current_effect)
-
-    def paint_draw_list(self):
-        self.draw_list = []
-        for composited_layer in self.composited_layers:
-            current_effect = \
-                DrawCompositedLayer(composited_layer)
-            if not composited_layer.display_items: continue
-            parent = composited_layer.display_items[0].parent
-            while parent:
-                current_effect = \
-                    self.clone_latest(parent, [current_effect])
-                parent = parent.parent
-            self.draw_list.append(current_effect)
-
-        if self.pending_hover:
-            (x, y) = self.pending_hover
-            y += self.scroll
-            a11y_node = self.accessibility_tree.hit_test(x, y)
-            if a11y_node:
-                if not self.hovered_a11y_node or \
-                    a11y_node.node != self.hovered_a11y_node.node:
-                    self.needs_speak_hovered_node = True
-                self.hovered_a11y_node = a11y_node
-        self.pending_hover = None
-
-        if self.hovered_a11y_node:
-            self.draw_list.append(DrawOutline(
-                self.hovered_a11y_node.absolute_bounds(),
-                "white" if self.dark_mode else "black", 2))
-
-    def update_accessibility(self):
-        if not self.accessibility_tree: return
-
-        if not self.has_spoken_document:
-            self.speak_document()
-            self.has_spoken_document = True
-
-        self.active_alerts = [
-            node for node in tree_to_list(self.accessibility_tree, [])
-            if node.role == "alert"
-        ]
-
-        for alert in self.active_alerts:
-            if alert not in self.spoken_alerts:
-                self.speak_node(alert, "New alert")
-                self.spoken_alerts.append(alert)
-
-        new_spoken_alerts = []
-        for old_node in self.spoken_alerts:
-            new_nodes = [
-                node for node in \
-                    tree_to_list(self.accessibility_tree, [])
-                if node.node == old_node.node
-                and node.role == "alert"
-            ]
-            if new_nodes:
-                new_spoken_alerts.append(new_nodes[0])
-        self.spoken_alerts = new_spoken_alerts
-
-        if self.tab_focus and \
-            self.tab_focus != self.last_tab_focus:
-            nodes = [node for node in \
-                tree_to_list(self.accessibility_tree, [])
-                        if node.node == self.tab_focus]
-            if nodes:
-                self.focus_a11y_node = nodes[0]
-                self.speak_node(
-                    self.focus_a11y_node, "element focused ")
-            self.last_tab_focus = self.tab_focus
-
-        if self.needs_speak_hovered_node:
-            self.speak_node(self.hovered_a11y_node, "Hit test ")
-        self.needs_speak_hovered_node = False
-
-    def composite_raster_and_draw(self):
-        self.lock.acquire(blocking=True)
-        if not self.needs_composite and \
-            len(self.composited_updates) == 0 \
-            and not self.needs_raster and not self.needs_draw:
-            self.lock.release()
-            return
-        self.measure.time('raster/draw')
-        start_time = time.time()
-        if self.needs_composite:
-            self.composite()
-        if self.needs_raster:
-            self.raster_chrome()
-            self.raster_tab()
-        if self.needs_draw:
-            self.paint_draw_list()
-            self.draw()
-
-        self.measure.stop('raster/draw')
-
-        if self.needs_accessibility:
-            self.update_accessibility()
-
-        self.needs_composite = False
-        self.needs_raster = False
-        self.needs_draw = False
-        self.lock.release()
-
-    def schedule_animation_frame(self):
-        def callback():
-            self.lock.acquire(blocking=True)
-            scroll = self.scroll
-            active_tab = self.tabs[self.active_tab]
-            self.needs_animation_frame = False
-            self.lock.release()
-            task = Task(active_tab.run_animation_frame, scroll)
-            active_tab.task_runner.schedule_task(task)
-        self.lock.acquire(blocking=True)
-        if self.needs_animation_frame and not self.animation_timer:
-            if wbetools.USE_BROWSER_THREAD:
-                self.animation_timer = \
-                    threading.Timer(REFRESH_RATE_SEC, callback)
-                self.animation_timer.start()
-        self.lock.release()
-
     def clamp_scroll(self, scroll):
         height = self.active_tab_height
         maxscroll = height - (HEIGHT - self.chrome.bottom)
@@ -2049,234 +1758,10 @@ class Browser:
             self.needs_animation_frame = True
             self.lock.release()
             return
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.scrolldown)
-        active_tab.task_runner.schedule_task(task)
+        task = Task(self.active_tab.scrolldown)
+        self.active_tab.task_runner.schedule_task(task)
         self.needs_animation_frame = True
         self.lock.release()        
-
-    def handle_tab(self):
-        self.focus = "content"
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.advance_tab)
-        active_tab.task_runner.schedule_task(task)
-        pass
-
-    def focus_addressbar(self):
-        self.lock.acquire(blocking=True)
-        self.focus = "address bar"
-        self.address_bar = ""
-        text = "Address bar focused"
-        if self.accessibility_is_on:
-            print(text)
-            if not self.muted:
-                speak_text(text)
-        self.set_needs_raster()
-        self.lock.release()
-
-    def clear_data(self):
-        self.scroll = 0
-        self.url = None
-        self.display_list = []
-        self.composited_layers = []
-
-    def set_active_tab(self, index):
-        self.active_tab = index
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.set_needs_paint)
-        active_tab.task_runner.schedule_task(task)
-
-        self.clear_data()
-        self.needs_animation_frame = True
-
-    def go_back(self):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.go_back)
-        active_tab.task_runner.schedule_task(task)
-        self.clear_data()
-
-    def cycle_tabs(self):
-        new_active_tab = (self.active_tab + 1) % len(self.tabs)
-        self.set_active_tab(new_active_tab)
-
-    def toggle_accessibility(self):
-        self.accessibility_is_on = not self.accessibility_is_on
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.toggle_accessibility)
-        active_tab.task_runner.schedule_task(task)
-
-    def speak_node(self, node, text):
-        text += node.text
-        if text and node.children and \
-            node.children[0].role == "StaticText":
-            text += " " + \
-            node.children[0].text
-
-        if text:
-            if not self.is_muted():
-                speak_text(text)
-            else:
-                print(text)
-
-    def speak_document(self):
-        text = "Here are the document contents: "
-        tree_list = tree_to_list(self.accessibility_tree, [])
-        for accessibility_node in tree_list:
-            new_text = accessibility_node.text
-            if new_text:
-                text += "\n"  + new_text
-
-        if not self.is_muted():
-            speak_text(text)
-        else:
-            print(text)
-
-    def toggle_mute(self):
-        self.muted = not self.muted
-
-    def is_muted(self):
-        muted = self.muted
-        return muted
-
-    def toggle_dark_mode(self):
-        self.dark_mode = not self.dark_mode
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.toggle_dark_mode)
-        active_tab.task_runner.schedule_task(task)
-
-    def handle_click(self, e):
-        self.lock.acquire(blocking=True)
-        if e.y < self.chrome.bottom:
-            self.focus = None
-            self.chrome.click(e.x, e.y)
-            self.set_needs_raster()
-        else:
-            self.focus = "content"
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.click, e.x, e.y - self.chrome.bottom)
-            active_tab.task_runner.schedule_task(task)
-        self.lock.release()
-
-    def handle_hover(self, event):
-        if not self.accessibility_is_on or \
-            not self.accessibility_tree:
-            return
-        self.pending_hover = (event.x, event.y - self.chrome.bottom)
-        self.set_needs_accessibility()
-
-    def handle_key(self, char):
-        self.lock.acquire(blocking=True)
-        if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "address bar":
-            self.address_bar += char
-            self.set_needs_raster()
-        elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.keypress, char)
-            active_tab.task_runner.schedule_task(task)
-        self.lock.release()
-
-    def schedule_load(self, url, body=None):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.load, url, body)
-        active_tab.task_runner.schedule_task(task)
-
-    def handle_enter(self):
-        self.lock.acquire(blocking=True)
-        if self.focus == "address bar":
-            self.schedule_load(URL(self.address_bar))
-            self.url = self.address_bar
-            self.focus = None
-            self.set_needs_raster()
-        elif self.focus == "content":
-            active_tab = self.tabs[self.active_tab]
-            task = Task(active_tab.enter)
-            active_tab.task_runner.schedule_task(task)
-        self.lock.release()
-
-    def increment_zoom(self, increment):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.zoom_by, increment)
-        active_tab.task_runner.schedule_task(task)
-
-    def reset_zoom(self):
-        active_tab = self.tabs[self.active_tab]
-        task = Task(active_tab.reset_zoom)
-        active_tab.task_runner.schedule_task(task)
-
-    def load(self, url):
-        self.lock.acquire(blocking=True)
-        self.load_internal(url)
-        self.lock.release()
-
-    def load_internal(self, url):
-        new_tab = Tab(self, HEIGHT - self.chrome.bottom)
-        self.tabs.append(new_tab)
-        self.set_active_tab(len(self.tabs) - 1)
-        self.schedule_load(url)
-
-    def raster_tab(self):
-        for composited_layer in self.composited_layers:
-            composited_layer.raster()
-
-    def raster_chrome(self):
-        canvas = self.chrome_surface.getCanvas()
-        if self.dark_mode:
-            background_color = skia.ColorBLACK
-        else:
-            background_color = skia.ColorWHITE
-        canvas.clear(background_color)
-    
-        for cmd in self.chrome.paint():
-            cmd.execute(canvas)
-
-    def draw(self):
-        canvas = self.root_surface.getCanvas()
-        if self.dark_mode:
-            canvas.clear(skia.ColorBLACK)
-        else:
-            canvas.clear(skia.ColorWHITE)
-
-        canvas.save()
-        canvas.translate(0, self.chrome.bottom - self.scroll)
-        for item in self.draw_list:
-            item.execute(canvas)
-        canvas.restore()
-
-        chrome_rect = skia.Rect.MakeLTRB(0, 0, WIDTH, self.chrome.bottom)
-        canvas.save()
-        canvas.clipRect(chrome_rect)
-        self.chrome_surface.draw(canvas, 0, 0)
-        canvas.restore()
-
-        if wbetools.USE_GPU:
-            self.root_surface.flushAndSubmit()
-            sdl2.SDL_GL_SwapWindow(self.sdl_window)
-        else:
-            # This makes an image interface to the Skia surface, but
-            # doesn't actually copy anything yet.
-            skia_image = self.root_surface.makeImageSnapshot()
-            skia_bytes = skia_image.tobytes()
-
-            depth = 32 # Bits per pixel
-            pitch = 4 * WIDTH # Bytes per row
-            sdl_surface = sdl2.SDL_CreateRGBSurfaceFrom(
-                skia_bytes, WIDTH, HEIGHT, depth, pitch,
-                self.RED_MASK, self.GREEN_MASK,
-                self.BLUE_MASK, self.ALPHA_MASK)
-
-            rect = sdl2.SDL_Rect(0, 0, WIDTH, HEIGHT)
-            window_surface = sdl2.SDL_GetWindowSurface(self.sdl_window)
-            # SDL_BlitSurface is what actually does the copy.
-            sdl2.SDL_BlitSurface(sdl_surface, rect, window_surface, rect)
-            sdl2.SDL_UpdateWindowSurface(self.sdl_window)
-
-    def handle_quit(self):
-        self.measure.finish()
-        self.tabs[self.active_tab].task_runner.set_needs_quit()
-        if wbetools.USE_GPU:
-            sdl2.SDL_GL_DeleteContext(self.gl_context)
-        sdl2.SDL_DestroyWindow(self.sdl_window)
 
 if __name__ == "__main__":
     wbetools.parse_flags()

--- a/src/lab16-tests.md
+++ b/src/lab16-tests.md
@@ -28,7 +28,7 @@ Here's a simple editable web page:
     ... <p contenteditable>Here is some content.</p>
     ... """))
     >>> browser = lab16.Browser()
-    >>> browser.load(url)
+    >>> browser.new_tab(url)
     >>> browser.render()
     >>> lab16.print_tree(browser.tabs[0].root_frame.nodes)
      <html>
@@ -79,7 +79,7 @@ Here's a simple test web page:
 First of all, we can load and render it:
 
     >>> browser = lab16.Browser()
-    >>> browser.load(url)
+    >>> browser.new_tab(url)
     >>> browser.render()
     >>> frame = browser.tabs[0].root_frame
     >>> lab16.print_tree(frame.document) # doctest: +ELLIPSIS
@@ -165,7 +165,7 @@ resizing is dramatic:
     ... <iframe width=50 src=""" + str(url2) + """ />
     ... """))
     >>> browser = lab16.Browser()
-    >>> browser.load(url1)
+    >>> browser.new_tab(url1)
     >>> browser.render()
     >>> frame1 = browser.tabs[0].root_frame
     >>> iframe = [

--- a/src/lab7-tests.md
+++ b/src/lab7-tests.md
@@ -16,7 +16,7 @@ Testing LineLayout and TextLayout
     ...   "<div>This is a test<br>Also a test<br>And this too</div>"))
 
     >>> browser = lab7.Browser()
-    >>> browser.load(url)
+    >>> browser.new_tab(url)
     >>> browser.tabs
     [Tab(history=[URL(scheme=http, host=test, port=80, path='/0')])]
     >>> lab7.print_tree(browser.tabs[0].document.node)
@@ -60,7 +60,7 @@ Testing Tab
 
 The browser can have multiple tabs:
 
-    >>> browser.load(url2)
+    >>> browser.new_tab(url2)
     >>> browser.tabs #doctest: +NORMALIZE_WHITESPACE
     [Tab(history=[URL(scheme=http, host=test, port=80, path='/0')]),
      Tab(history=[URL(scheme=http, host=test, port=80, path='/1')])]
@@ -123,20 +123,20 @@ Testing Browser
 Clicking on a browser tab focuses it:
 
     >>> browser.active_tab
-    1
-    >>> (l, t, r, b) = browser.chrome.tab_bounds(0)
+    Tab(history=[URL(scheme=http, host=test, port=80, path='/1')])
+    >>> (l, t, r, b) = browser.chrome.tab_rect(0)
     >>> browser.handle_click(test.Event(l + 1, t + 1))
     >>> browser.active_tab
-    0
-    >>> (l, t, r, b) = browser.chrome.tab_bounds(1)
+    Tab(history=[URL(scheme=http, host=test, port=80, path='/0')])
+    >>> (l, t, r, b) = browser.chrome.tab_rect(1)
     >>> browser.handle_click(test.Event(l + 1, t + 1))
     >>> browser.active_tab
-    1
+    Tab(history=[URL(scheme=http, host=test, port=80, path='/1')])
 
 Clicking on the address bar focuses it:
 
     >>> browser.handle_click(test.Event(50, 51))
-    >>> browser.focus
+    >>> browser.chrome.focus
     'address bar'
 
 The back button works:
@@ -147,7 +147,7 @@ The back button works:
     >>> browser.tabs[1].history #doctest: +NORMALIZE_WHITESPACE
     [URL(scheme=http, host=test, port=80, path='/1'),
      URL(scheme=http, host=test, port=80, path='/0')]
-    >>> (l, t, r, b) = browser.chrome.backbutton_bounds()
+    >>> (l, t, r, b) = browser.chrome.back_rect
     >>> browser.handle_click(test.Event(l + 1, t + 1))
     >>> browser.tabs[1].history
     [URL(scheme=http, host=test, port=80, path='/1')]
@@ -155,9 +155,9 @@ The back button works:
 Pressing enter with text in the address bar works:
 
     >>> browser.handle_click(test.Event(50, 51))
-    >>> browser.focus
+    >>> browser.chrome.focus
     'address bar'
-    >>> browser.address_bar = "http://test/0"
+    >>> browser.chrome.address_bar = "http://test/0"
     >>> browser.handle_enter(test.Event(0, 0))
     >>> browser.tabs[1].history #doctest: +NORMALIZE_WHITESPACE
     [URL(scheme=http, host=test, port=80, path='/1'),

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -424,7 +424,7 @@ class Chrome:
 
     def click(self, x, y):
         if intersects(x, y, self.plus_bounds()):
-            self.browser.load(URL("https://browser.engineering/"))
+            self.browser.new_tab(URL("https://browser.engineering/"))
         elif intersects(x, y, self.backbutton_bounds()):
             self.browser.active_tab.go_back()
         elif intersects(x, y, self.addressbar_bounds()):
@@ -499,5 +499,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    Browser().load(URL(sys.argv[1]))
+    Browser().new_tab(URL(sys.argv[1]))
     tkinter.mainloop()

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -36,7 +36,7 @@ Testing InputLayout
     ... b"  <p><button>Submit!</button></p>" +
     ... b"</form>"))
     >>> browser = lab8.Browser()
-    >>> browser.load(url2)
+    >>> browser.new_tab(url2)
     >>> lab8.print_tree(browser.tabs[0].document.node)
      <html>
        <body>
@@ -128,7 +128,7 @@ Testing layout_mode
     ... b"<input>" +
     ... b"<div></div>"))
     >>> browser = lab8.Browser()
-    >>> browser.load(block_inline_url)
+    >>> browser.new_tab(block_inline_url)
     >>> lab8.print_tree(browser.tabs[0].document.node)
      <html>
        <body>
@@ -160,7 +160,7 @@ If a `<button>` contains rich markup inside of it, it should print nothing:
     ... b"<button><b>Rich markup</b></button>" +
     ... b"</form>"))
     >>> browser = lab8.Browser()
-    >>> browser.load(url3)
+    >>> browser.new_tab(url3)
     Ignoring HTML contents inside button
     >>> browser.tabs[0].display_list
     [DrawRect(top=20.25 left=13 bottom=32.25 right=213 color=orange), DrawText(text=)]

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -181,9 +181,9 @@ class BlockLayout:
         if self.cursor_x + w > self.width:
             self.new_line()
         line = self.children[-1]
-        input = InputLayout(node, line, self.previous_word)
+        previous_word = line.children[-1] if line.children else None
+        input = InputLayout(node, line, previous_word)
         line.children.append(input)
-        self.previous_word = input
         font = self.get_font(node)
         self.cursor_x += w + font.measure(" ")
 
@@ -329,21 +329,22 @@ class Browser:
 
     def handle_click(self, e):
         if e.y < self.chrome.bottom:
-            self.focus = None
+            self.focus = "chrome"
             self.chrome.click(e.x, e.y)
         else:
             self.focus = "content"
-            self.tabs[self.active_tab].click(e.x, e.y - self.chrome.bottom)
+            tab_y = e.y - self.chrome.bottom
+            self.active_tab.click(e.x, tab_y)
         self.draw()
 
     def handle_key(self, e):
         if len(e.char) == 0: return
         if not (0x20 <= ord(e.char) < 0x7f): return
-        if self.focus == "address bar":
-            self.address_bar += e.char
+        if self.focus == "chrome":
+            self.chrome.keypress(e.char)
             self.draw()
         elif self.focus == "content":
-            self.tabs[self.active_tab].keypress(e.char)
+            self.active_tab.keypress(e.char)
             self.draw()
 
 if __name__ == "__main__":

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -349,5 +349,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    Browser().load(URL(sys.argv[1]))
+    Browser().new_tab(URL(sys.argv[1]))
     tkinter.mainloop()

--- a/src/lab9-tests.md
+++ b/src/lab9-tests.md
@@ -19,19 +19,19 @@ The browser should download JavaScript code mentioned in a `<script>` tag:
 
     >>> url2 = lab9.URL(test.socket.serve(""))
     >>> url = lab9.URL(test.socket.serve("<script src=" + str(url2) + "></script>"))
-    >>> lab9.Browser().load(url)
+    >>> lab9.Browser().new_tab(url)
     >>> test.socket.last_request(str(url2))
     b'GET /0 HTTP/1.0\r\nHost: test\r\n\r\n'
 
 If the script succeeds, the browser prints nothing:
 
     >>> test.socket.respond(str(url2), b"HTTP/1.0 200 OK\r\n\r\nvar x = 2; x + x")
-    >>> lab9.Browser().load(url)
+    >>> lab9.Browser().new_tab(url)
 
 If instead the script crashes, the browser prints an error message:
 
     >>> test.socket.respond(str(url2), b"HTTP/1.0 200 OK\r\n\r\nthrow Error('Oops');")
-    >>> lab9.Browser().load(url) #doctest: +ELLIPSIS
+    >>> lab9.Browser().new_tab(url) #doctest: +ELLIPSIS
     Script http://test/0 crashed Error: Oops
     ...
 
@@ -45,21 +45,21 @@ For the rest of these tests we're going to use `console.log` for most testing:
 
     >>> script = "console.log('Hello, world!')"
     >>> test.socket.respond(str(url2), b"HTTP/1.0 200 OK\r\n\r\n" + script.encode("utf8"))
-    >>> lab9.Browser().load(url)
+    >>> lab9.Browser().new_tab(url)
     Hello, world!
 
 Note that you can print other data structures as well:
 
     >>> script = "console.log([2, 3, 4])"
     >>> test.socket.respond(str(url2), b"HTTP/1.0 200 OK\r\n\r\n" + script.encode("utf8"))
-    >>> lab9.Browser().load(url)
+    >>> lab9.Browser().new_tab(url)
     [2, 3, 4]
 
 Let's test that variables work:
 
     >>> script = "var x = 'Hello!'; console.log(x)"
     >>> test.socket.respond(str(url2), b"HTTP/1.0 200 OK\r\n\r\n" + script.encode("utf8"))
-    >>> lab9.Browser().load(url)
+    >>> lab9.Browser().new_tab(url)
     Hello!
     
 Next let's try to do two scripts:
@@ -70,7 +70,7 @@ Next let's try to do two scripts:
     >>> test.socket.respond(str(url), b"HTTP/1.0 200 OK\r\n\r\n" + html_page.encode("utf8"))
     >>> test.socket.respond(str(url2), b"HTTP/1.0 200 OK\r\n\r\nvar x = 'Testing, testing';")
     >>> test.socket.respond(str(url3), b"HTTP/1.0 200 OK\r\n\r\nconsole.log(x);")
-    >>> lab9.Browser().load(url)
+    >>> lab9.Browser().new_tab(url)
     Testing, testing
 
 Testing querySelectorAll
@@ -86,7 +86,7 @@ matching nodes:
     ... </div>"""
     >>> test.socket.respond(str(url), b"HTTP/1.0 200 OK\r\n\r\n" + page.encode("utf8"))
     >>> b = lab9.Browser()
-    >>> b.load(url)
+    >>> b.new_tab(url)
     >>> js = b.tabs[0].js
     >>> js.run("document.querySelectorAll('div').length")
     1
@@ -214,7 +214,7 @@ link, a button, and an input area:
     ...   <button>Submit</button>
     ... </form>"""
     >>> test.socket.respond(str(url), b"HTTP/1.0 200 OK\r\n\r\n" + page.encode("utf8"))
-    >>> b.load(url)
+    >>> b.new_tab(url)
     >>> js = b.tabs[1].js
 
 Now we're going test five event handlers: clicking on the link, clicking on the

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -175,5 +175,5 @@ class Tab:
 
 if __name__ == "__main__":
     import sys
-    Browser().load(URL(sys.argv[1]))
+    Browser().new_tab(URL(sys.argv[1]))
     tkinter.mainloop()


### PR DESCRIPTION
Here's the scope of the changes:

- Reordered both browser chrome sections quite dramatically. Do note that I used a lot of `newtab_rect[3]` and `back_rect[2]` but the intention is to turn those into `Rect` fields in a later PR.
- Reorder `LineLayout` and `TextLayout`'s `layout` methods so they flow a bit better.
- Explicitly bring up the "reverse pipeline" analogy for click handling
- Make `Browser.active_tab` a `Tab`, not an index. Both are a little dangerous but this is way shorter.
- Moved the layout tree hit testing exercise to a later chapter, where it will do more good.
- Move the HTML chrome exercise to the chapter on inputs and buttons, where it's at least hypothetically possible.
- Renamed `Browser.load` to `Browser.new_tab`, I think the old name was more confusing
- Don't store `previous_word` in `BlockLayout`, just compute it when needed

The tests don't pass yet and I need to do the forward pass through later chapters to make sympathetic changes, but it should be ready for a review of the chapter itself.