### PR TITLE
Fix widgets to align with recent code

### DIFF
--- a/infra/compile.py
+++ b/infra/compile.py
@@ -977,7 +977,7 @@ def compile_module(tree, patches):
 
     imports_str = "import {{ {} }} from \"./{}.js\";"
 
-    rt_imports_arr = [ 'breakpoint', 'comparator', 'filesystem', 'asyncfilter', 'pysplit', 'pyrsplit', 'truthy', 'patch_class' ]
+    rt_imports_arr = [ 'breakpoint', 'comparator', 'asyncfilter', 'pysplit', 'pyrsplit', 'truthy', 'patch_class' ]
     rt_imports_arr += set([ mod.split(".")[0] for mod in RT_IMPORTS])
     rt_imports = imports_str.format(", ".join(sorted(rt_imports_arr)), "rt")
 
@@ -1010,13 +1010,19 @@ if __name__ == "__main__":
     tree = asttools.parse(args.python.read(), args.python.name)
     load_outline(asttools.inline(tree))
     tree, patches = asttools.resolve_patches_and_return_them(tree)
-    js = compile_module(tree, patches)
+    module_js = compile_module(tree, patches)
+
+    js = 'import { filesystem } from "./rt.js";\n'
 
     for fn in FILES:
         path = os.path.join(os.path.dirname(args.python.name), fn)
         with open(path) as f:
-            js += "\nfilesystem.register(" + repr(fn) + ", " + json.dumps(f.read()) + ");\n"
-            
+            js += "\nfilesystem.register(" + repr(fn) + ", " + \
+            json.dumps(f.read()) + ");\n"
+    js += "\n"
+
+    js += module_js
+
     args.javascript.write(js)
 
     issues = 0

--- a/www/widgets/lab10-browser.html
+++ b/www/widgets/lab10-browser.html
@@ -24,7 +24,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://localhost:8000/";
     let b = await (new Browser()).init();
-    await b.load(await (new URL().init(url)));
+    await b.new_tab(await (new URL().init(url)));
 });
 widget.next();
 </script>

--- a/www/widgets/lab11-browser.html
+++ b/www/widgets/lab11-browser.html
@@ -39,7 +39,7 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
         let url = "https://localhost:8000/";
         let b = await (new Browser()).init();
         init_window(b);
-        await b.load(await (new URL().init(url)));
+        await b.new_tab(await (new URL().init(url)));
     });
     widget.next();
   });

--- a/www/widgets/lab12-browser.html
+++ b/www/widgets/lab12-browser.html
@@ -41,7 +41,7 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
         let url = "https://localhost:8000/";
         let b = await (new Browser()).init();
         init_window(b);
-        await b.load(await (new URL().init(url)));
+        await b.new_tab(await (new URL().init(url)));
         await b.render();
         interval = setInterval(async function() {
           await b.render();

--- a/www/widgets/lab13-browser.html
+++ b/www/widgets/lab13-browser.html
@@ -41,7 +41,7 @@ Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
         let url = "https://localhost:8000";
         let b = await (new Browser()).init();
         init_window(b);
-        await b.load(await (new URL().init(url)));
+        await b.new_tab(await (new URL().init(url)));
         await b.render();
         interval = setInterval(async function() {
           await b.render();

--- a/www/widgets/lab7-browser.html
+++ b/www/widgets/lab7-browser.html
@@ -21,7 +21,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://browser.engineering/chrome.html";
     let b = await (new Browser()).init();
-    await b.load(await (new URL().init(url)))
+    await b.new_tab(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab8-browser.html
+++ b/www/widgets/lab8-browser.html
@@ -23,7 +23,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://localhost:8000/";
     let b = await (new Browser()).init();
-    await b.load(await (new URL().init(url)))
+    await b.new_tab(await (new URL().init(url)))
 });
 widget.next();
 </script>

--- a/www/widgets/lab9-browser.html
+++ b/www/widgets/lab9-browser.html
@@ -24,7 +24,7 @@ widget.run(async function() {
     constants.WIDTH = window.innerWidth;
     let url = "https://localhost:8000/";
     let b = await (new Browser()).init();
-    await b.load(await (new URL().init(url)))
+    await b.new_tab(await (new URL().init(url)))
 });
 widget.next();
 </script>


### PR DESCRIPTION
* Move fileystem import to the top so it's before static initializers for imported stylesheet and JS files
* Rename load to new_tab