### PR TITLE
Make consistent use of "our browser" and "your browser"

### DIFF
--- a/book/chrome.md
+++ b/book/chrome.md
@@ -5,7 +5,7 @@ prev: styles
 next: forms
 ...
 
-Our toy browser is still missing the key insight of
+Our browser is still missing the key insight of
 *hypertext*\index{hypertext}: documents linked together by
 hyperlinks\index{hyperlink}. It lets us watch the
 waves, but not surf the web. So in this chapter, we'll implement
@@ -497,7 +497,7 @@ Multiple pages
 If you're anything like me, the next thing you tried after clicking on
 links is middle-clicking them to open in a new tab. Every browser now
 has tabbed browsing, and honestly it's a little embarrassing that our
-little toy browser doesn't.[^ffx]
+browser doesn't.[^ffx]
 
 [^ffx]: Back in the day, browser tabs were the feature that would
     convince friends and relatives to switch from IE 6 to Firefox.

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -5,7 +5,7 @@ prev: accessibility
 next: invalidation
 ...
 
-While our toy browser can render complex styles, visual effects, and
+While our browser can render complex styles, visual effects, and
 animations, all of those apply basically just to text. Yet web pages
 contain a variety of non-text *embedded content*, from images to other
 web pages. Support for embedded content has powerful implications for
@@ -664,7 +664,7 @@ handling three significant differences:
 * Iframes can *share a rendering event loop*.[^iframe-event-loop] In
   real browsers, [cross-origin] iframes are often "site isolated",
   meaning that the iframe has its own CPU process for [security
-  reasons][site-isolation]. In our toy browser we'll just make all
+  reasons][site-isolation]. In our browser we'll just make all
   iframes (even nested ones---yes, iframes can include iframes!) use
   the same rendering event loop.
 
@@ -1986,8 +1986,6 @@ popular [browser extensions][extensions] are probably ad blockers.
 [extensions]: https://en.wikipedia.org/wiki/Browser_extension
 [io]: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
 
-
-
 Isolation and timing
 ====================
 
@@ -2212,7 +2210,7 @@ parameter to [`postMessage`][postmessage]. This parameter is a string
 which indicates the frame origins that are allowed to receive the
 message.
 
-*Multi-frame focus*: in our toy browser, pressing `Tab` cycles through
+*Multi-frame focus*: in our browser, pressing `Tab` cycles through
 the elements in the focused frame. But means it's impossible to access
 focusable elements in other frames via the keyboard alone. Fix it to move
 between frames after iterating through all focusable elements in one

--- a/book/forms.md
+++ b/book/forms.md
@@ -61,7 +61,7 @@ does everything it normally does.
 Implementing forms requires extending many parts of the browser, from
 implementing HTTP `POST` through new layout objects that draw `input`
 elements to handling buttons clicks. That makes it a great starting
-point for transforming our toy browser into an application platform,
+point for transforming our browser into an application platform,
 our goal for these next few chapters. Let's get started implementing
 it all!
 
@@ -940,8 +940,8 @@ your browser to `http://localhost:8000/`, where `localhost` is what
 your computer calls itself and `8000` is the port we chose earlier.
 You should see one guest book entry.
 
-By the way, while you're debugging this toy web server, it's probably
-better to use a real web browser, instead of this book's toy browser,
+By the way, while you're debugging this web server, it's probably
+better to use a real web browser, instead of this book's browser,
 to interact with it. That way you don't have to worry about browser
 bugs while you work on server bugs. But this server does support both
 real and toy browsers.

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -7,7 +7,7 @@ next: text
 
 A web browser doesn't just download a web page; it also has to show
 that page to the user. In the 21^st^ century, that means a graphical
-application. So in this chapter we'll equip the toy browser with a
+application. So in this chapter we'll equip our browser with a
 graphical user interface.[^1]
 
 [^1]: There are some obscure text-based browsers: I used `w3m` as my
@@ -118,7 +118,7 @@ between zooming and scrolling that's usually absent on desktop.
 Drawing to the window
 =====================
 
-Our toy browser will draw the web page text to a *canvas*,\index{canvas} a
+Our browser will draw the web page text to a *canvas*,\index{canvas} a
 rectangular Tk widget that you can draw circles, lines, and text
 on:[^canvas]
 
@@ -212,7 +212,7 @@ features, because I want to teach you how to implement them.
 Laying out text
 ===============
 
-Let's draw a simple web page on this canvas. So far, the toy browser
+Let's draw a simple web page on this canvas. So far, our browser
 steps through the web page source code character by character and
 prints the text (but not the tags) to the console window. Now we want
 to draw the characters on the canvas instead.
@@ -523,7 +523,7 @@ pixels on the screen are always correct).
     operating system and default font.
 
 Real browsers have a lot of quite tricky optimizations for this, but
-for our toy browser let's limit ourselves to a simple improvement:
+for our browser let's limit ourselves to a simple improvement:
 skip drawing characters that are offscreen:
 
 ``` {.python}
@@ -617,7 +617,7 @@ events.[^more-mousewheel]
 
 [tk-mousewheel]: https://wiki.tcl-lang.org/page/mousewheel
 
-*Emoji*: Add support for emoji to our browser. Emoji are
+*Emoji*: Add support for emoji to your browser. Emoji are
 characters, and you can call `create_text` to draw them, but the
 results aren't very good. Instead, head to [the OpenMoji
 project](https://openmoji.org), download the emoji for ["grinning

--- a/book/html.md
+++ b/book/html.md
@@ -5,7 +5,7 @@ prev: text
 next: layout
 ...
 
-So far, your web browser sees web pages as a stream of open tags,
+So far, our web browser sees web pages as a stream of open tags,
 close tags, and text. But HTML is actually a tree, and though the tree
 structure hasn't been important yet, it will be central to later
 features like CSS, JavaScript, and visual effects. So this chapter
@@ -311,7 +311,7 @@ the `<!doctype html>` tag.
 
 This special tag, called a [doctype][html5-doctype], is always the
 very first thing in an HTML document. But it's not really an element
-at all, nor is it supposed to have a close tag. Our toy browser won't
+at all, nor is it supposed to have a close tag. Our browser won't
 be using the doctype for anything, so it's best to throw it
 away:[^quirks-mode]
 
@@ -514,7 +514,7 @@ attributes with whitespace (like `author` on the fifth `meta` tag)
 are mis-parsed as multiple attributes, and the final slash on the
 self-closing tags is incorrectly treated as an extra attribute. A
 better parser would fix these issues. But let's instead leave our
-parser as is---these issues aren't going to be a problem for the toy
+parser as is---these issues aren't going to be a problem for the
 browser we're building---and move on to integrating it with our
 browser.
 

--- a/book/html.md
+++ b/book/html.md
@@ -5,7 +5,7 @@ prev: text
 next: layout
 ...
 
-So far, our web browser sees web pages as a stream of open tags,
+So far, our browser sees web pages as a stream of open tags,
 close tags, and text. But HTML is actually a tree, and though the tree
 structure hasn't been important yet, it will be central to later
 features like CSS, JavaScript, and visual effects. So this chapter

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -28,7 +28,7 @@ a few frames' delay is distracting. But editing changes the HTML tree
 and therefore the layout tree. Rebuilding the layout tree from
 scratch, which our browser currently does, can drop multiple frames on
 complex pages. Try, for example, loading [this
-chapter](invalidation.md) in our toy browser and typing into this
+chapter](invalidation.md) in our browser and typing into this
 input box:
 
 <input style="width:100%"/>
@@ -62,7 +62,7 @@ invalidation. To begin with, we need to make elements with a
 [^other-values]: Actually, in real browsers, `contenteditable` can be
     set to `true` or `false`, and `false` is useful in case you want
     to have a non-editable element inside an editable one. But I'm
-    not going to implement that in our toy browser.
+    not going to implement that in our browser.
 
 ``` {.python}
 def is_focusable(node):
@@ -146,7 +146,7 @@ class InputLayout(EmbedLayout):
             cmds.append(DrawCursor(self, self.font.measureText(text)))
 ```
 
-You can now edit the examples on this page in your toy browser---but
+You can now edit the examples on this page in your browser---but
 each key stroke will take hundreds of milliseconds, making for a
 frustrating editing experience. So let's work on speeding that up.
 
@@ -242,8 +242,6 @@ interesting applications and gives users a better, more responsive
 experience. The declarative web makes it possible for the invalidation
 algorithms to be written once and then automatically benefit everyone.
 :::
-
-
 
 Idempotence
 ===========
@@ -2605,7 +2603,7 @@ But to obtain maximum performance, the kind you would need for a real
  browser, there's an additional benefit. All these fancy
 `ProtectedFields` add a lot of overhead, mostly because they take up
 more memory and require more function calls. In fact, this chapter
-likely made your toy browser quite a bit slower on an *initial* page
+likely made your browser quite a bit slower on an *initial* page
 load.^[For me, it's about twice as slow.] Some of that can be improved
 by skipping `assert`s,[^python-skip-asserts] but it's definitely not
 ideal.

--- a/book/preface.md
+++ b/book/preface.md
@@ -27,7 +27,7 @@ years' programming experience. Part 4 of this book covers advanced
 topics; those chapters are longer and have more code. The final
 browser weighs in at about 3000 lines.
 
-Your web browser[^yours-ours] will "work" at every step of the way, and
+Your browser[^yours-ours] will "work" at every step of the way, and
 every chapter will build upon the last.[^jrwilcox-idea] That way, you will
 also practice growing and improving complex software. If you feel
 particularly interested in some component, please do flesh it out,

--- a/book/preface.md
+++ b/book/preface.md
@@ -17,7 +17,6 @@ industry programmers and even to researchers. This book dissipates
 that mystery by systematically explaining all major components of a
 modern web browser.
 
-
 Reading this book
 =================
 
@@ -28,15 +27,23 @@ years' programming experience. Part 4 of this book covers advanced
 topics; those chapters are longer and have more code. The final
 browser weighs in at about 3000 lines.
 
-Your web browser will "work" at every step of the way, and every
-chapter will build upon the last.[^jrwilcox-idea] That way, you will
+Your web browser[^yours-ours] will "work" at every step of the way, and
+every chapter will build upon the last.[^jrwilcox-idea] That way, you will
 also practice growing and improving complex software. If you feel
 particularly interested in some component, please do flesh it out,
 complete the exercises, and add missing features. We've tried to
 arrange it so that this doesn't make later chapters more difficult.
 
-[^jrwilcox-idea]: This idea is from [J.R. Wilcox][jrw], inspired in turn by
-    [S. Zdancewic][sz]'s course on compilers.
+[^yours-ours]: This book assumes that you will be building a web browser along
+the way while reading it. However, it does present nearly
+all the code---inlined into the book--for a working browser for every
+chapter. So most of the time, the book uses the term "our browser",
+which refers to the conceptual browser we (you and us, the
+authors) have built so far. In cases where the book is referring specifically
+to the implementation you have built, the book says "your browser".
+
+[^jrwilcox-idea]: This idea is from [J.R. Wilcox][jrw], inspired in
+turn by [S. Zdancewic][sz]'s course on compilers.
 
 The code in this book [uses Python
 3](blog/why-python.md),\index{Python} and we recommend you follow
@@ -50,6 +57,7 @@ and JavaScript evaluation (the text uses DukPy).
 [^py3-cmd]: This is for clarity. On some operating systems, `python`
 means Python 3, but on others that means Python 2. Check which version
 you have!
+
 [sz]: https://www.cis.upenn.edu/~stevez/
 
 This book's browser is irreverent toward standards: it handles only a

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1146,7 +1146,7 @@ adopting a multi-threaded architecture.
 
 ::: {.further}
 
-Our toy browser spends a lot of time copying pixels. That's why
+Our browser spends a lot of time copying pixels. That's why
 [optimizing surfaces][optimize-surfaces] is important! It'll be faster
 by at least 30% if you've done the *interest region* exercise from
 [Chapter 11](visual-effects.md#exercises); making `tab_surface`

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -10,7 +10,7 @@ book](forms.md), with the server generating new web pages for every
 user action. But in the early 2000s, JavaScript-enhanced web
 applications, which can update pages dynamically and respond
 immediately to user actions, took their place. Let's add support for
-this key web technology to our toy browser.
+this key web technology to our browser.
 
 Installing DukPy
 ================
@@ -144,7 +144,7 @@ That's your browser running its first bit of JavaScript!
 Actually, real browsers run JavaScript code as soon as the browser
 *parses* the `<script>` tag, not after the whole page is parsed. Or,
 at least, that is the default; there are [many options][scriptElement].
-What our toy browser does is what a real browser does when the
+What our browser does is what a real browser does when the
 [`defer`][deferAttr] attribute is set. The default behavior is [much
 trickier][speculative] to implement efficiently.
 :::

--- a/book/security.md
+++ b/book/security.md
@@ -398,9 +398,9 @@ class URL:
         # ...
 ```
 
-You should now be able to use your toy browser to log in to the guest
+You should now be able to use your browser to log in to the guest
 book and post to it. Moreover, you should be able to open the guest
-book in two browsers simultaneously---maybe your toy browser and a
+book in two browsers simultaneously---maybe your browser and a
 real browser as well---and log in and post as two different
 users.
 

--- a/book/skipped.md
+++ b/book/skipped.md
@@ -46,7 +46,7 @@ embedded in a font that modifies it to better match the discrete pixel
 grid. Text rendering of course affects Skia, but it also affects
 layout, determining the size and position of content on the screen.
 
-And more broadly, graphics in general is pretty complex! Our toy
+And more broadly, graphics in general is pretty complex! Our
 browser uses Skia, which is the real rasterization engine of Chromium
 and some other browsers. But we didn't really talk at all about how
 Skia actually works, and it turns out to be pretty complex. It not
@@ -152,7 +152,7 @@ Browser UIs and Developer tools
 
 A real browser has a *much* more complex and powerful "browser
 UI"---meaning the chrome around the web page, where you can enter
-URLs, see tabs, and so on---than our toy browser. In fact, a large
+URLs, see tabs, and so on---than our browser. In fact, a large
 fraction of a real browser team works just on this, and not on the
 "web platform" itself. The multi-process nature of a modern browser
 also makes it difficult to interact with synchronous OS APIs, as we

--- a/book/styles.md
+++ b/book/styles.md
@@ -77,7 +77,7 @@ it started and extracts the substring it moved through.
     property names (which use letters and the dash), numbers (which
     use the minus sign, numbers, periods), units (the percent sign),
     and colors (which use the hash sign). Real CSS values have a more
-    complex syntax but this is enough for our toy browser.
+    complex syntax but this is enough for our browser.
 
 Parsing functions can fail. The `word` function we just wrote raises
 an exception if `i` hasn't advanced though at least one
@@ -678,7 +678,7 @@ allows more specific rules to override more general ones, so that you
 can have a browser style sheet, a site-wide style sheet, and maybe a
 special style sheet for a specific web page, all co-existing.
 
-Since our browser only has tag selectors, our cascade order just
+Since our browser only has tag selectors, cascade order just
 counts them:
 
 ``` {.python}
@@ -693,7 +693,7 @@ class DescendantSelector:
         self.priority = ancestor.priority + descendant.priority
 ```
 
-Then our cascade order for rules is just those priorities:
+Then cascade order for rules is just those priorities:
 
 ``` {.python}
 def cascade_priority(rule):

--- a/book/text.md
+++ b/book/text.md
@@ -5,7 +5,7 @@ prev: graphics
 next: html
 ...
 
-In the last chapter, our web browser created a graphical window and
+In the last chapter, our browser created a graphical window and
 drew a grid of characters to it. That's OK for Chinese, but English
 text features characters of different widths grouped into words that
 you can't break across lines.[^1] In this chapter, we'll add those

--- a/book/text.md
+++ b/book/text.md
@@ -5,11 +5,11 @@ prev: graphics
 next: html
 ...
 
-In the last chapter, your web browser created a graphical window and
+In the last chapter, our web browser created a graphical window and
 drew a grid of characters to it. That's OK for Chinese, but English
 text features characters of different widths grouped into words that
 you can't break across lines.[^1] In this chapter, we'll add those
-capabilities. You'll be able to read this page in your browser!
+capabilities. You'll even be able to read this page!
 
 [^1]: There are lots of languages in the world, and lots of
     typographic conventions. A real web browser supports every
@@ -800,7 +800,7 @@ Font caching
 
 Now that you've implemented styled text, you've probably
 noticed---unless you're on macOS[^macos-cache]---that on a large web
-page like this chapter your browser has slowed significantly from the
+page like this chapter our browser has slowed significantly from the
 [last chapter](graphics.md). That's because text layout, and
 specifically the part where you measure each word, is quite
 slow.[^profile]
@@ -892,7 +892,7 @@ grid. Now it does standard English text layout:
 - Text can be bold or italic
 - Text of different sizes can be mixed
 
-You can now use your browser to read an essay, a blog post, or even a
+You can now use our browser to read an essay, a blog post, or even a
 book!
 
 ::: {.signup}


### PR DESCRIPTION
Also:

* Removes the adjective "toy" from almost everywhere (except where we are on purpose referring to its toy-ness. This is good for consistency and avoids the reader thinking our browser is excessively naive.
* Adds a footnote in the preface explaining the nomenclature.
* Uses "our browser" throughout and fixes some cases of "our web browser"