### PR TITLE
Wait until the page is loaded to run animation frames for widgets

### DIFF
--- a/src/lab12.py
+++ b/src/lab12.py
@@ -178,6 +178,7 @@ class Tab:
         self.needs_render = False
         self.js = None
         self.browser = browser
+        self.loaded = False
         if wbetools.USE_BROWSER_THREAD:
             self.task_runner = TaskRunner(self)
         else:
@@ -188,6 +189,7 @@ class Tab:
             self.default_style_sheet = CSSParser(f.read()).parse()
 
     def load(self, url, payload=None):
+        self.loaded = False
         self.scroll = 0
         self.scroll_changed_in_tab = True
         self.task_runner.clear_pending_tasks()
@@ -238,6 +240,7 @@ class Tab:
                 continue
             self.rules.extend(CSSParser(body).parse())
         self.set_needs_render()
+        self.loaded = True
 
     def set_needs_render(self):
         self.needs_render = True
@@ -559,7 +562,8 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         self.active_tab.task_runner.run_tasks()
-        self.active_tab.run_animation_frame(self.scroll)
+        if self.active_tab.loaded:
+            self.active_tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1114,6 +1114,7 @@ class Tab:
         self.needs_layout = False
         self.needs_paint = False
         self.browser = browser
+        self.loaded = False
         if wbetools.USE_BROWSER_THREAD:
             self.task_runner = TaskRunner(self)
         else:
@@ -1133,6 +1134,7 @@ class Tab:
         return Task(self.js.run, script, script_text)
 
     def load(self, url, payload=None):
+        self.loaded = False
         self.scroll = 0
         self.scroll_changed_in_tab = True
         self.task_runner.clear_pending_tasks()
@@ -1182,6 +1184,7 @@ class Tab:
                 continue
             self.rules.extend(CSSParser(body).parse())
         self.set_needs_render()
+        self.loaded = True
 
     def set_needs_render(self):
         self.needs_style = True
@@ -1438,7 +1441,8 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         self.active_tab.task_runner.run_tasks()
-        self.active_tab.run_animation_frame(self.scroll)
+        if self.active_tab.loaded:
+            self.active_tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -918,6 +918,7 @@ class Tab:
         self.needs_paint = False
         self.document = None
         self.dark_mode = browser.dark_mode
+        self.loaded = False
 
         self.accessibility_tree = None
 
@@ -943,6 +944,7 @@ class Tab:
         return Task(self.js.run, script, script_text)
 
     def load(self, url, payload=None):
+        self.loaded = False
         self.focus_element(None)
         self.zoom = 1
         self.scroll = 0
@@ -995,6 +997,7 @@ class Tab:
                 continue
             self.rules.extend(CSSParser(body).parse())
         self.set_needs_render()
+        self.loaded = True
 
     def set_needs_render(self):
         self.needs_style = True
@@ -1410,7 +1413,8 @@ class Browser:
     def render(self):
         assert not wbetools.USE_BROWSER_THREAD
         self.active_tab.task_runner.run_tasks()
-        self.active_tab.run_animation_frame(self.scroll)
+        if self.active_tab.loaded:
+            self.active_tab.run_animation_frame(self.scroll)
 
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1477,6 +1477,7 @@ class Tab:
         self.accessibility_tree = None
         self.has_spoken_document = False
         self.accessibility_focus = None
+        self.loaded = False
 
         self.browser = browser
         if wbetools.USE_BROWSER_THREAD:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1493,12 +1493,14 @@ class Tab:
         self.origin_to_js = {}
 
     def load(self, url, payload=None):
+        self.loaded = False
         self.history.append(url)
         self.task_runner.clear_pending_tasks()
         self.root_frame = Frame(self, None, None)
         self.root_frame.load(url, payload)
         self.root_frame.frame_width = WIDTH
         self.root_frame.frame_height = self.tab_height
+        self.loaded = True
 
     def get_js(self, origin):
         if wbetools.FORCE_CROSS_ORIGIN_IFRAMES:


### PR DESCRIPTION
Fetching a URL via `fetch` is not blocking and you have to wait async for it to load.