### PR TITLE
Fix raster tab size in chapter 11

### DIFF
--- a/src/lab11.py
+++ b/src/lab11.py
@@ -634,7 +634,7 @@ class Browser:
         self.draw()
 
     def raster_tab(self):
-        tab_height = math.ceil(self.active_tab.document.height)
+        tab_height = math.ceil(self.active_tab.document.height + 2*VSTEP)
 
         if not self.tab_surface or \
                 tab_height != self.tab_surface.height():


### PR DESCRIPTION
It needs to include 2*VSTEP in its sizing. This is already the case in chapter 12+, and was a regression from recent refactoring.