### PR TITLE
Editorial edits for chapter 8, and focus cleanup

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -398,33 +398,35 @@ remember that in its own `focus` field!
 
 In other words, when you click on the web page, the `Browser` updates
 its `focus` field to remember that the user is interacting with the
-page, not the browser interface:
+page, not the browser chrome:
 
 ``` {.python}
 class Browser:
     def handle_click(self, e):
         if e.y < self.chrome.bottom:
-            self.focus = "chrome"
+            self.focus = None
             # ...
         else:
             self.focus = "content"
+            self.chrome.focus = None
             # ...
         self.draw()
 ```
 
-The `if` branch that corresponds to clicks in the browser interface
-unsets `focus` by default, but some existing code in that branch will
-set `focus` to `"address bar"` if the user actually clicked in the
-address bar.
+The `if` branch that corresponds to clicks in the browser chrome
+unsets `focus`, but some existing code in that branch will
+set the `Chrome` `focus` to `"address bar"` if the user actually clicked
+in the address bar.
 
 When a key press happens, the `Browser` sends it either to the address
-bar or calls the active tab's `keypress` method:
+bar or calls the active tab's `keypress` method (or neither, if nothing is
+focused):
 
 ``` {.python}
 class Browser:
     def handle_key(self, e):
         # ...
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.keypress(e.char)
             self.draw()
         elif self.focus == "content":

--- a/book/forms.md
+++ b/book/forms.md
@@ -783,8 +783,7 @@ import socket
 s = socket.socket(
     family=socket.AF_INET,
     type=socket.SOCK_STREAM,
-    proto=socket.IPPROTO_TCP,
-)
+    proto=socket.IPPROTO_TCP)
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 ```
 

--- a/book/forms.md
+++ b/book/forms.md
@@ -414,9 +414,8 @@ class Browser:
 ```
 
 The `if` branch that corresponds to clicks in the browser chrome
-unsets `focus`, but some existing code in that branch will
-set the `Chrome` `focus` to `"address bar"` if the user actually clicked
-in the address bar.
+unsets `focus`, meaning focus is no longer on the page contents,
+and key presses will thus be sent to the `Chrome`.
 
 When a key press happens, the `Browser` sends it either to the address
 bar or calls the active tab's `keypress` method (or neither, if nothing is

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -741,12 +741,12 @@ class Browser:
             self.set_needs_raster_and_draw()
 
     def handle_key(self, char):
-        if self.focus == "chrome":
+        if self.chrome.focus:
             # ...
             self.set_needs_raster_and_draw()
 
     def handle_enter(self):
-        if self.focus == "chrome":
+        if self.chrome.focus:
             # ...
             self.set_needs_raster_and_draw()
 ```
@@ -1340,7 +1340,7 @@ The same logic holds for `keypress`:
 class Browser:
     def handle_key(self, char):
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "chrome":
+        if self.chrome.focus:
             # ...
         elif self.focus == "content":
             task = Task(self.active_tab.keypress, char)

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1567,7 +1567,7 @@ import math
 
 class Browser:
     def raster_tab(self):
-        tab_height = math.ceil(self.active_tab.document.height)
+        tab_height = math.ceil(self.active_tab.document.height + 2*VSTEP)
 
         if not self.tab_surface or \
                 tab_height != self.tab_surface.height():

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -344,7 +344,7 @@ class InputLayout:
             self.x = self.parent.x
 
     def self_rect(self):
-        rect = skia.Rect.MakeLTRB(
+        return skia.Rect.MakeLTRB(
             self.x, self.y, self.x + self.width,
             self.y + self.height)
 
@@ -539,6 +539,7 @@ class Chrome:
             self.browser.active_tab.go_back()
         elif self.address_rect.contains(x, y):
             self.focus = "address bar"
+            print('set focus')
             self.address_bar = ""
         else:
             for i, tab in enumerate(self.browser.tabs):
@@ -587,12 +588,13 @@ class Browser:
 
     def handle_click(self, e):
         if e.y < self.chrome.bottom:
-            self.focus = "chrome"
+            self.focus = None
             self.chrome.click(e.x, e.y)
             self.raster_chrome()
         else:
             if self.focus != "content":
                 self.focus = "content"
+                self.chrome.focus = None
                 self.raster_chrome()
             url = self.active_tab.url
             tab_y = e.y - self.chrome.bottom
@@ -604,7 +606,7 @@ class Browser:
 
     def handle_key(self, char):
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.keypress(char)
             self.raster_chrome()
             self.draw()
@@ -614,7 +616,7 @@ class Browser:
             self.draw()
 
     def handle_enter(self):
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.enter()
             self.raster_tab()
             self.raster_chrome()

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -538,7 +538,6 @@ class Chrome:
             self.browser.active_tab.go_back()
         elif self.address_rect.contains(x, y):
             self.focus = "address bar"
-            print('set focus')
             self.address_bar = ""
         else:
             for i, tab in enumerate(self.browser.tabs):

--- a/src/lab12-tests.md
+++ b/src/lab12-tests.md
@@ -78,8 +78,8 @@ Scrolling down causes a draw but nothing else.
     but not tab raster
 
     >>> browser.handle_click(Event(51, 51))
-    >>> browser.focus
-    'chrome'
+    >>> browser.chrome.focus
+    'address bar'
     >>> browser.handle_key('c')
     >>> browser.needs_raster_and_draw
     True

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -315,6 +315,11 @@ class Tab:
                     elt = elt.parent
             elt = elt.parent
 
+    def keypress(self, char):
+        if self.focus:
+            self.focus.attributes["value"] += char
+            self.set_needs_render()
+
 class Task:
     def __init__(self, task_code, *args):
         self.task_code = task_code
@@ -333,6 +338,7 @@ class SingleThreadedTaskRunner:
 
     def schedule_task(self, callback):
         self.tasks.append(callback)
+        self.tab.browser.needs_animation_frame = True
 
     def run_tasks(self):
         while self.tasks:
@@ -639,15 +645,14 @@ class Browser:
     def handle_click(self, e):
         self.lock.acquire(blocking=True)
         if e.y < self.chrome.bottom:
-            self.focus = "chrome"
+            self.focus = None
             self.chrome.click(e.x, e.y)
             self.set_needs_raster_and_draw()
         else:
             if self.focus != "content":
                 self.focus = "content"
                 self.set_needs_raster_and_draw()
-            else:
-                self.focus = "content"
+            self.chrome.focus = None
             tab_y = e.y - self.chrome.bottom
             task = Task(self.active_tab.click, e.x, tab_y)
             self.active_tab.task_runner.schedule_task(task)
@@ -656,7 +661,7 @@ class Browser:
     def handle_key(self, char):
         self.lock.acquire(blocking=True)
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.keypress(char)
             self.set_needs_raster_and_draw()
         elif self.focus == "content":
@@ -671,7 +676,7 @@ class Browser:
 
     def handle_enter(self):
         self.lock.acquire(blocking=True)
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.enter()
             self.set_needs_raster_and_draw()
         self.lock.release()

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1607,13 +1607,14 @@ class Browser:
     def handle_click(self, e):
         self.lock.acquire(blocking=True)
         if e.y < self.chrome.bottom:
-            self.focus = "chrome"
+            self.focus = None
             self.chrome.click(e.x, e.y)
             self.set_needs_raster()
         else:
             if self.focus != "content":
                 self.set_needs_raster()
             self.focus = "content"
+            self.chrome.focus = None
             tab_y = e.y - self.chrome.bottom
             task = Task(self.active_tab.click, e.x, tab_y)
             self.active_tab.task_runner.schedule_task(task)
@@ -1622,7 +1623,7 @@ class Browser:
     def handle_key(self, char):
         self.lock.acquire(blocking=True)
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.keypress(char)
             self.set_needs_raster()
         elif self.focus == "content":
@@ -1636,7 +1637,7 @@ class Browser:
 
     def handle_enter(self):
         self.lock.acquire(blocking=True)
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.enter()
             self.set_needs_raster()
         self.lock.release()

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1210,6 +1210,7 @@ class Tab:
 
         if idx < len(focusable_nodes):
             self.focus_element(focusable_nodes[idx])
+            self.browser.focus_content()
         else:
             self.focus_element(None)
             self.browser.focus_addressbar()
@@ -1646,12 +1647,19 @@ class Browser:
 
     def handle_tab(self):
         self.focus = "content"
+        self.chrome.focus = "none"
         task = Task(self.active_tab.advance_tab)
         self.active_tab.task_runner.schedule_task(task)
 
+    def focus_content(self):
+        self.lock.acquire(blocking=True)
+        self.chrome.focus = None
+        self.focus = "content"
+        self.lock.release()
+
     def focus_addressbar(self):
         self.lock.acquire(blocking=True)
-        self.focus = "chrome"
+        self.focus = None
         self.chrome.focus_addressbar()
         text = "Address bar focused"
         if self.accessibility_is_on:
@@ -1738,13 +1746,14 @@ class Browser:
     def handle_click(self, e):
         self.lock.acquire(blocking=True)
         if e.y < self.chrome.bottom:
-            self.focus = "chrome"
+            self.focus = None
             self.chrome.click(e.x, e.y)
             self.set_needs_raster()
         else:
             if self.focus != "content":
                 self.set_needs_raster()
             self.focus = "content"
+            self.chrome.focus = None
             tab_y = e.y - self.chrome.bottom
             task = Task(self.active_tab.click, e.x, tab_y)
             self.active_tab.task_runner.schedule_task(task)
@@ -1760,7 +1769,7 @@ class Browser:
     def handle_key(self, char):
         self.lock.acquire(blocking=True)
         if not (0x20 <= ord(char) < 0x7f): return
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.keypress(char)
             self.set_needs_raster()
         elif self.focus == "content":
@@ -1774,7 +1783,7 @@ class Browser:
 
     def handle_enter(self):
         self.lock.acquire(blocking=True)
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.enter()
             self.set_needs_raster()
         elif self.focus == "content":

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1335,6 +1335,7 @@ class Frame:
 
         if idx < len(focusable_nodes):
             self.focus_element(focusable_nodes[idx])
+            self.tab.browser.focus_content()
         else:
             self.focus_element(None)
             self.tab.browser.focus_addressbar()

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -160,3 +160,29 @@ If a `<button>` contains rich markup inside of it, it should print nothing:
     Ignoring HTML contents inside button
     >>> browser.tabs[0].display_list
     [DrawRect(top=20.25 left=13 bottom=32.25 right=213 color=orange), DrawText(text=)]
+
+Testing focus
+=============
+
+    Clicking on the address bar focuses it
+    >>> browser.handle_click(test.Event(51, 51))
+    >>> browser.focus
+    >>> browser.chrome.focus
+    'address bar'
+
+    Clicking back on the content area unfocuses it
+    >>> browser.handle_click(test.Event(200, 200))
+    >>> browser.focus
+    'content'
+    >>> browser.chrome.focus
+
+    Clicking on the back button 
+    >>> rect = browser.chrome.back_rect
+    >>> browser.handle_click(test.Event(rect.left + 1, rect.top + 1))
+    >>> browser.focus
+    >>> browser.chrome.focus
+
+    >>> browser.handle_click(test.Event(200, 200))
+    >>> browser.focus
+    'content'
+    >>> browser.chrome.focus

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -328,10 +328,11 @@ class Browser:
 
     def handle_click(self, e):
         if e.y < self.chrome.bottom:
-            self.focus = "chrome"
+            self.focus = None
             self.chrome.click(e.x, e.y)
         else:
             self.focus = "content"
+            self.chrome.focus = None
             tab_y = e.y - self.chrome.bottom
             self.active_tab.click(e.x, tab_y)
         self.draw()
@@ -339,7 +340,7 @@ class Browser:
     def handle_key(self, e):
         if len(e.char) == 0: return
         if not (0x20 <= ord(e.char) < 0x7f): return
-        if self.focus == "chrome":
+        if self.chrome.focus:
             self.chrome.keypress(e.char)
             self.draw()
         elif self.focus == "content":

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -171,7 +171,6 @@ class Tab:
 
     def keypress(self, char):
         if self.focus:
-            print('keypress')
             if self.js.dispatch_event("keydown", self.focus): return
             self.focus.attributes["value"] += char
             self.render()

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -171,6 +171,7 @@ class Tab:
 
     def keypress(self, char):
         if self.focus:
+            print('keypress')
             if self.js.dispatch_event("keydown", self.focus): return
             self.focus.attributes["value"] += char
             self.render()

--- a/src/server8.py
+++ b/src/server8.py
@@ -70,8 +70,7 @@ if __name__ == "__main__":
     s = socket.socket(
         family=socket.AF_INET,
         type=socket.SOCK_STREAM,
-        proto=socket.IPPROTO_TCP,
-    )
+        proto=socket.IPPROTO_TCP)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind(('', 8000))
     s.listen()


### PR DESCRIPTION
* There is a focus field on both Browser and Chrome. The former can be set only to "content" and the latter only to "address book".
* Schedule render on keypress and enter for chapters 12+ (bugfix I found while fixing focus).
* Fixed one broken `self_rect` method.