### PR TITLE
Fix clip rect for visual effect clips

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -683,9 +683,19 @@ class SaveLayer(VisualEffect):
             self.should_save)
 ```
 
-The other visual effect, `ClipRRect`, should do something similar. We
-won't be cloning paint commands, since they're all going to be inside
-a composited layer, so we don't need to implement `clone` for them.
+The other visual effect, `ClipRRect`, should do something similar (note
+how we are using `rrect.rect()`, since the first parameter needs to be the
+actual cliping rect):
+
+``` {.python}
+class ClipRRect(VisualEffect):
+    def clone(self, children):
+        return ClipRRect(self.rrect.rect(), self.radius, children, \
+            self.should_clip)
+```
+
+We won't be cloning paint commands, since they're all going to be inside a
+composited layer, so we don't need to implement `clone` for them.
 
 We can now build the draw display list. For each composited layer,
 create a `DrawCompositedLayer` command (which we'll define in just a
@@ -1856,6 +1866,7 @@ Skia canvas `translate` method:
 class Transform(VisualEffect):
     def __init__(self, translation, rect, node, children):
         super().__init__(rect, children, node)
+        self.self_rect = rect
         self.translation = translation
 
     def execute(self, canvas):
@@ -1869,7 +1880,7 @@ class Transform(VisualEffect):
             canvas.restore()
 
     def clone(self, children):
-        return Transform(self.translation, self.rect,
+        return Transform(self.translation, self.self_rect,
             self.node, children)
 
     def __repr__(self):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -84,6 +84,7 @@ def map_translation(rect, translation, reversed=False):
 class Transform(VisualEffect):
     def __init__(self, translation, rect, node, children):
         super().__init__(rect, children, node)
+        self.self_rect = rect
         self.translation = translation
 
     def execute(self, canvas):
@@ -103,7 +104,7 @@ class Transform(VisualEffect):
         return map_translation(rect, self.translation, True)
 
     def clone(self, children):
-        return Transform(self.translation, self.rect,
+        return Transform(self.translation, self.self_rect,
             self.node, children)
 
     def __repr__(self):
@@ -240,7 +241,7 @@ class ClipRRect(VisualEffect):
         return rect
 
     def clone(self, children):
-        return ClipRRect(self.rect, self.radius, children, \
+        return ClipRRect(self.rrect.rect(), self.radius, children, \
             self.should_clip)
 
     def __repr__(self):


### PR DESCRIPTION
`self.rect` includes the union of all descendants, since it's the "visual rect bounds" of the contents, and is computed
in the `VisualEffect` super-class. (That part could also be removed if we want).

`self.rrect.rect()` is the actual clip rect.

It was broken in [this PR](https://github.com/browserengineering/book/pull/916).