### PR TITLE
Add a scroll up listener alongside the scroll down key listener

### DIFF
--- a/src/lab2.py
+++ b/src/lab2.py
@@ -53,6 +53,7 @@ class Browser:
 
         self.scroll = 0
         self.window.bind("<Down>", self.scrolldown)
+        self.window.bind("<Up>", self.scrollup)
 
     def load(self, url):
         body = url.request()
@@ -70,6 +71,12 @@ class Browser:
 
     def scrolldown(self, e):
         self.scroll += SCROLL_STEP
+        self.draw()
+
+    def scrollup(self, e):
+        self.scroll -= SCROLL_STEP
+        if self.scroll < 0:
+            self.scroll = 0
         self.draw()
 
 if __name__ == "__main__":

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -140,6 +140,7 @@ class Browser:
 
         self.scroll = 0
         self.window.bind("<Down>", self.scrolldown)
+        self.window.bind("<Up>", self.scrollup)
         self.display_list = []
 
     def load(self, url):


### PR DESCRIPTION
Salutations! 

I was just playing with the chapter 5 code and noticed that there was no way to "scroll" back up through a page. I'm not sure if this is a desirable feature or not, but here it is!