### PR TITLE
Editorial changes from a read-through of chapter 13

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -173,7 +173,7 @@ Now that we've downloaded and saved the image, we need to use it.
 That just requires calling Skia's `drawImageRect` function:
 
 ``` {.python replace=%2c%20rect/%2c%20rect%2c%20quality,self.rect)/self.rect%2c%20paint)}
-class DrawImage(DrawCommand):
+class DrawImage(PaintCommand):
     def __init__(self, image, rect):
         super().__init__(rect)
         self.image = image
@@ -246,7 +246,7 @@ def parse_image_rendering(quality):
    else:
        return skia.FilterQuality.kMedium_FilterQuality
 
-class DrawImage(DrawCommand):
+class DrawImage(PaintCommand):
     def __init__(self, image, rect, quality):
         # ...
         self.quality = parse_image_rendering(quality)

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -531,8 +531,6 @@ high-density enough to retire these techniques.
 
 [font-hinting]: https://en.wikipedia.org/wiki/Font_hinting
 
-
-
 Browser compositing
 ===================
 

--- a/src/lab13.hints
+++ b/src/lab13.hints
@@ -14,13 +14,10 @@
  {"code": "('layer: composited_bounds={} ' + 'absolute_bounds={} first_chunk={}').format(self.composited_bounds(), self.absolute_bounds(), self.display_items if len(self.display_items) > 0 else 'None')", "js": ""},
  {"code": "('OpenGL initialized: vendor={},' + 'renderer={}').format(OpenGL.GL.glGetString(OpenGL.GL.GL_VENDOR), OpenGL.GL.glGetString(OpenGL.GL.GL_RENDERER))", "js": ""},
  {"code": "self.s[self.i] in chars", "js": "chars.find((c) => c == this.s[this.i])"},
- {"code": "property not in new_transitions", "type": "dict"},
  {"code": "property not in old_style", "type": "dict"},
  {"code": "property not in new_style", "type": "dict"},
  {"code": "'style' in node.attributes", "type": "dict"},
- {"code": "property in ANIMATED_PROPERTIES", "type": "list"},
  {"code": "node in self.composited_updates", "type": "list"},
- {"code": "old_transitions", "type": "dict"},
  {"code": "child.tag in BLOCK_ELEMENTS", "type": "list"},
  {"code": "rect.outset(1, 1)", "js": "rect.outset(1, 1)"}
 ]

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -52,7 +52,7 @@ class Element:
         self.is_focused = False
         self.animations = {}
 
-class DrawCommand:
+class PaintCommand:
     def __init__(self, rect):
         self.rect = rect
         self.children = []
@@ -114,7 +114,7 @@ class Transform(VisualEffect):
         else:
             return "Transform(<no-op>)"
 
-class DrawLine(DrawCommand):
+class DrawLine(PaintCommand):
     def __init__(self, x1, y1, x2, y2, color, thickness):
         super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
         self.x1 = x1
@@ -135,7 +135,7 @@ class DrawLine(DrawCommand):
         return "DrawLine top={} left={} bottom={} right={}".format(
             self.y1, self.x1, self.y2, self.x2)
 
-class DrawRRect(DrawCommand):
+class DrawRRect(PaintCommand):
     def __init__(self, rect, radius, color):
         super().__init__(rect)
         self.rrect = skia.RRect.MakeRectXY(rect, radius, radius)
@@ -153,7 +153,7 @@ class DrawRRect(DrawCommand):
         return "DrawRRect(rect={}, color={})".format(
             str(self.rrect), self.color)
 
-class DrawText(DrawCommand):
+class DrawText(PaintCommand):
     def __init__(self, x1, y1, text, font, color):
         self.left = x1
         self.top = y1
@@ -174,7 +174,7 @@ class DrawText(DrawCommand):
     def __repr__(self):
         return "DrawText(text={})".format(self.text)
 
-class DrawRect(DrawCommand):
+class DrawRect(PaintCommand):
     def __init__(self, x1, y1, x2, y2, color):
         super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
         self.top = y1
@@ -194,7 +194,7 @@ class DrawRect(DrawCommand):
             self.top, self.left, self.bottom,
             self.right, self.color)
 
-class DrawOutline(DrawCommand):
+class DrawOutline(PaintCommand):
     def __init__(self, rect, color, thickness):
         super().__init__(rect)
         self.color = color
@@ -283,7 +283,7 @@ class SaveLayer(VisualEffect):
         else:
             return "SaveLayer(<no-op>)"
 
-class DrawCompositedLayer(DrawCommand):
+class DrawCompositedLayer(PaintCommand):
     def __init__(self, composited_layer):
         self.composited_layer = composited_layer
         super().__init__(
@@ -836,15 +836,9 @@ def parse_transition(value):
     return properties
 
 def diff_styles(old_style, new_style):
-    old_transitions = \
-        parse_transition(old_style.get("transition"))
-    new_transitions = \
-        parse_transition(new_style.get("transition"))
-
     transitions = {}
-    for property in old_transitions:
-        if property not in new_transitions: continue
-        num_frames = new_transitions[property]
+    for property, num_frames in \
+        parse_transition(new_style.get("transition")).items():
         if property not in old_style: continue
         if property not in new_style: continue
         old_value = old_style[property]
@@ -1314,7 +1308,7 @@ class Browser:
                 tree_to_list(cmd, all_commands)
         non_composited_commands = [cmd
             for cmd in all_commands
-            if isinstance(cmd, DrawCommand) or not cmd.needs_compositing
+            if isinstance(cmd, PaintCommand) or not cmd.needs_compositing
             if not cmd.parent or cmd.parent.needs_compositing
         ]
         for cmd in non_composited_commands:
@@ -1464,7 +1458,8 @@ class Browser:
             item.execute(canvas)
         canvas.restore()
 
-        chrome_rect = skia.Rect.MakeLTRB(0, 0, WIDTH, self.chrome.bottom)
+        chrome_rect = skia.Rect.MakeLTRB(
+            0, 0, WIDTH, self.chrome.bottom)
         canvas.save()
         canvas.clipRect(chrome_rect)
         self.chrome_surface.draw(canvas, 0, 0)

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -873,10 +873,6 @@ class NumericAnimation:
             old_value=self.old_value,
             change_per_frame=self.change_per_frame,
             num_frames=self.num_frames)
-
-ANIMATED_PROPERTIES = {
-    "opacity": NumericAnimation
-}
     
 def style(node, rules, tab):
     old_style = node.style
@@ -908,10 +904,9 @@ def style(node, rules, tab):
         transitions = diff_styles(old_style, node.style)
         for property, (old_value, new_value, num_frames) \
             in transitions.items():
-            if property in ANIMATED_PROPERTIES:
+            if property == "opacity":
                 tab.set_needs_render()
-                AnimationClass = ANIMATED_PROPERTIES[property]
-                animation = AnimationClass(
+                animation = NumericAnimation(
                     old_value, new_value, num_frames)
                 node.animations[property] = animation
                 node.style[property] = animation.animate()

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1064,8 +1064,7 @@ class Tab:
                 value = animation.animate()
                 if value:
                     node.style[property_name] = value
-                    if wbetools.USE_COMPOSITING and \
-                        property_name == "opacity":
+                    if wbetools.USE_COMPOSITING:
                         self.composited_updates.append(node)
                         self.set_needs_paint()
                     else:
@@ -1303,7 +1302,8 @@ class Browser:
                 tree_to_list(cmd, all_commands)
         non_composited_commands = [cmd
             for cmd in all_commands
-            if isinstance(cmd, PaintCommand) or not cmd.needs_compositing
+            if isinstance(cmd, PaintCommand) or \
+                not cmd.needs_compositing
             if not cmd.parent or cmd.parent.needs_compositing
         ]
         for cmd in non_composited_commands:
@@ -1393,6 +1393,7 @@ class Browser:
         self.active_tab_url = None
         self.display_list = []
         self.composited_layers = []
+        self.composited_updates = {}
 
     def set_active_tab(self, tab):
         self.active_tab = tab

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -996,8 +996,8 @@ class CompositedLayer:
         canvas.restore()
 
         if wbetools.SHOW_COMPOSITED_LAYER_BORDERS:
-            DrawOutline(0, 0, irect.width() - 1,
-                irect.height() - 1,
+            DrawOutline(0, 0,
+                irect.width() - 1, irect.height() - 1,
                 "red", 1).execute(canvas)
 
     def __repr__(self):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -40,9 +40,9 @@ from lab12 import Task, REFRESH_RATE_SEC
 from lab13 import JSContext, diff_styles, add_parent_pointers
 from lab13 import local_to_absolute, absolute_bounds_for_obj
 from lab13 import NumericAnimation
-from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
+from lab13 import map_translation, parse_transform
 from lab13 import CompositedLayer, paint_visual_effects
-from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, \
+from lab13 import PaintCommand, DrawText, DrawCompositedLayer, DrawOutline, \
     DrawLine, DrawRRect
 from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform, Chrome, \
     Tab, Browser
@@ -349,10 +349,9 @@ def style(node, rules, tab):
         transitions = diff_styles(old_style, node.style)
         for property, (old_value, new_value, num_frames) \
             in transitions.items():
-            if property in ANIMATED_PROPERTIES:
+            if property == "opacity":
                 tab.set_needs_render()
-                AnimationClass = ANIMATED_PROPERTIES[property]
-                animation = AnimationClass(
+                animation = NumericAnimation(
                     old_value, new_value, num_frames)
                 node.animations[property] = animation
                 node.style[property] = animation.animate()

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1456,6 +1456,7 @@ class Browser:
         self.display_list = []
         self.accessibility_tree = None
         self.composited_layers = []
+        self.composited_updates = {}
 
     def set_active_tab(self, tab):
         self.active_tab = tab

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -35,9 +35,10 @@ from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
 from lab13 import diff_styles, parse_transition, add_parent_pointers
 from lab13 import local_to_absolute, absolute_bounds_for_obj
 from lab13 import NumericAnimation
-from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
+from lab13 import map_translation, parse_transform
 from lab13 import CompositedLayer, paint_visual_effects
-from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, DrawLine, DrawRRect
+from lab13 import PaintCommand, DrawText, DrawCompositedLayer, DrawOutline, \
+    DrawLine, DrawRRect
 from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 from lab14 import parse_color, DrawRRect, \
     parse_outline, paint_outline, \
@@ -116,7 +117,7 @@ def parse_image_rendering(quality):
    else:
        return skia.FilterQuality.kMedium_FilterQuality
 
-class DrawImage(DrawCommand):
+class DrawImage(PaintCommand):
     def __init__(self, image, rect, quality):
         super().__init__(rect)
         self.image = image
@@ -1022,10 +1023,9 @@ def style(node, rules, frame):
         transitions = diff_styles(old_style, node.style)
         for property, (old_value, new_value, num_frames) \
             in transitions.items():
-            if property in ANIMATED_PROPERTIES:
+            if property == "opacity":
                 frame.set_needs_render()
-                AnimationClass = ANIMATED_PROPERTIES[property]
-                animation = AnimationClass(
+                animation = NumericAnimation(
                     old_value, new_value, num_frames)
                 node.animations[property] = animation
                 node.style[property] = animation.animate()

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -31,9 +31,9 @@ from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
 from lab13 import diff_styles, parse_transition, add_parent_pointers
 from lab13 import local_to_absolute, absolute_bounds_for_obj
 from lab13 import NumericAnimation
-from lab13 import map_translation, parse_transform, ANIMATED_PROPERTIES
+from lab13 import map_translation, parse_transform
 from lab13 import CompositedLayer, paint_visual_effects
-from lab13 import DrawCommand, DrawText, DrawCompositedLayer, DrawOutline, \
+from lab13 import PaintCommand, DrawText, DrawCompositedLayer, DrawOutline, \
     DrawLine, DrawRRect
 from lab13 import VisualEffect, SaveLayer, ClipRRect, Transform
 from lab14 import parse_color, parse_outline, DrawRRect, \
@@ -983,11 +983,12 @@ def style(node, rules, frame):
             new_style["font-size"] = str(node_pct * parent_px) + "px"
         if old_style:
             transitions = diff_styles(old_style, new_style)
-            for property, (old_value, new_value, num_frames) in transitions.items():
-                if property in ANIMATED_PROPERTIES:
+            for property, (old_value, new_value, num_frames) in \
+                transitions.items():
+                if property == "opacity":
                     frame.set_needs_render()
-                    AnimationClass = ANIMATED_PROPERTIES[property]
-                    animation = AnimationClass(old_value, new_value, num_frames)
+                    animation = NumericAnimation(
+                        old_value, new_value, num_frames)
                     node.animations[property] = animation
                     new_style[property] = animation.animate()
         for property, field in node.style.items():


### PR DESCRIPTION
* Fixed a number of typos
* Improved some awkward sentences
* Removed some obsolete text and footnotes
* Simplified the animation code because we now only have opacity
* Removed a non-animations exercise, and a redundant one
* Renamed DrawCommand to PaintCommand
* Fixed inline examples for transform to skip width and height, which we don't support