### PR TITLE
Get rid of the font method from chapter 6

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -217,7 +217,13 @@ class BlockLayout:
         previous_word = line.children[-1] if line.children else None
         input = InputLayout(node, line, previous_word)
         line.children.append(input)
-        font = self.font(node)
+
+        weight = node.style["font-weight"]
+        style = node.style["font-style"]
+        if style == "normal": style = "roman"
+        size = int(float(node.style["font-size"][:-2]) * .75)
+        font = get_font(size, weight, style)
+
         self.cursor_x += w + font.measure(" ")
 ```
 

--- a/book/styles.md
+++ b/book/styles.md
@@ -871,20 +871,12 @@ class BlockLayout:
             # ...
 
     def word(self, node, word):
-        font = self.font(node)
-        # ...
-```
-
-Here, the `font` method is a simple wrapper around our font cache:
-
-``` {.python}
-class BlockLayout:
-    def font(self, node):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(node.style["font-size"][:-2]) * .75)
-        return get_font(size, weight, style)
+        font = get_font(size, weight, style)
+        # ...
 ```
 
 Note that for `font-style` we need to translate CSS "normal" to Tk

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -204,19 +204,17 @@ class BlockLayout:
             for child in node.children:
                 self.recurse(child)
 
-    def font(self, node):
+    def word(self, node, word):
         weight = node.style["font-weight"]
         style = node.style["font-style"]
         if style == "normal": style = "roman"
         size = int(float(node.style["font-size"][:-2]) * .75)
-        return get_font(size, weight, style)
+        font = get_font(size, weight, style)
 
-    def word(self, node, word):
-        color = node.style["color"]
-        font = self.font(node)
         w = font.measure(word)
         if self.cursor_x + w > self.width:
             self.flush()
+        color = node.style["color"]
         self.line.append((self.cursor_x, word, font, color))
         self.cursor_x += w + font.measure(" ")
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -160,7 +160,12 @@ class BlockLayout:
         self.children.append(new_line)
 
     def word(self, node, word):
-        font = self.font(node)
+        weight = node.style["font-weight"]
+        style = node.style["font-style"]
+        if style == "normal": style = "roman"
+        size = int(float(node.style["font-size"][:-2]) * .75)
+        font = get_font(size, weight, style)
+
         w = font.measure(word)
         if self.cursor_x + w > self.width:
             self.new_line()

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -205,7 +205,13 @@ class BlockLayout:
         previous_word = line.children[-1] if line.children else None
         input = InputLayout(node, line, previous_word)
         line.children.append(input)
-        font = self.font(node)
+
+        weight = node.style["font-weight"]
+        style = node.style["font-style"]
+        if style == "normal": style = "roman"
+        size = int(float(node.style["font-size"][:-2]) * .75)
+        font = get_font(size, weight, style)
+
         self.cursor_x += w + font.measure(" ")
 
     def should_paint(self):


### PR DESCRIPTION
Inline the code instead. 

The global font method introduced in chapter 15 will stay, because it needs to be used by 3 different classes that don't
inherit from each other.