### PR TITLE
Fix geometry bugs in the a11y tree

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1428,9 +1428,10 @@ class FrameAccessibilityNode(AccessibilityNode):
         self.zoom = self.node.layout_object.zoom
 
     def hit_test(self, x, y):
-        if not self.bounds.contains(x, y): return
-        new_x = x - self.bounds.x() - dpx(1, self.zoom)
-        new_y = y - self.bounds.y() - dpx(1, self.zoom) + self.scroll
+        bounds = self.bounds[0]
+        if not bounds.contains(x, y): return
+        new_x = x - bounds.x() - dpx(1, self.zoom)
+        new_y = y - bounds.y() - dpx(1, self.zoom) + self.scroll
         node = self
         for child in self.children:
             res = child.hit_test(new_x, new_y)
@@ -1456,24 +1457,31 @@ class AccessibilityNode:
             child = AccessibilityNode(child_node, self)
 ```
 
-And now the method to map to absolute coordinates:
+And now we're ready for the method to map to absolute coordinates. This
+loops over all bounds rects and maps them up to the root. Note that there is
+a specal case for `FrameAccessibilityNode`, because its self-bounds are in
+the coordinate space of the frame containing the iframe.
 
 ``` {.python}
 class AccessibilityNode:
     def absolute_bounds(self):
-        rect = skia.Rect.MakeXYWH(
-            self.bounds.x(), self.bounds.y(),
-            self.bounds.width(), self.bounds.height())
-        obj = self
-        while obj:
-            obj.map_to_parent(rect)
-            obj = obj.parent
-        return rect
+        abs_bounds = []
+        for bound in self.bounds:
+            abs_bound = bound.makeOffset(0.0, 0.0)
+            if isinstance(self, FrameAccessibilityNode):
+                obj = self.parent
+            else:
+                obj = self
+            while obj:
+                obj.map_to_parent(abs_bound)
+                obj = obj.parent
+            abs_bounds.append(abs_bound)
+        return abs_bounds
 ```
 
-This method calls `map_to_parent` to adjust the bounds. For
-most accessibility nodes we don't need to do anything, because they are in the same
-coordinate space as their parent:
+This method calls `map_to_parent` to adjust the bounds. For most accessibility
+nodes we don't need to do anything, because they are in the same coordinate
+space as their parent:
 
 ``` {.python}
 class AccessibilityNode:
@@ -1481,12 +1489,15 @@ class AccessibilityNode:
         pass
 ```
 
-A `FrameAccessibilityNode`, on the other hand, adjusts for the iframe's position:
+A `FrameAccessibilityNode`, on the other hand, adjusts for the iframe's
+postion and clipping:
 
 ``` {.python}
 class FrameAccessibilityNode(AccessibilityNode):
     def map_to_parent(self, rect):
-        rect.offset(self.bounds.x(), self.bounds.y() - self.scroll)
+        bounds = self.bounds[0]
+        rect.offset(bounds.x(), bounds.y() - self.scroll)
+        rect.intersect(bounds)
 ```
 
 You should now be able to hover on nodes and have them read out by our

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -538,15 +538,11 @@ class AccessibilityNode:
     def compute_bounds(node):
         if node.layout_object:
             return [absolute_bounds_for_obj(node.layout_object)]
-
-        inline = node.parent
         if isinstance(node, Text):
             return []
-
+        inline = node.parent
         bounds = []
         while not inline.layout_object: inline = inline.parent
-        assert inline.layout_object.layout_mode() == "inline"
-        print(inline.layout_object)
         for line in inline.layout_object.children:
             line_bounds = skia.Rect.MakeEmpty()
             for child in line.children:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -512,11 +512,7 @@ class AccessibilityNode:
         self.node = node
         self.children = []
         self.text = ""
-
-        if node.layout_object:
-            self.bounds = [absolute_bounds_for_obj(node.layout_object)]
-        else:
-            self.bounds = AccessibilityNode.inline_bounds(node)
+        self.bounds = AccessibilityNode.compute_bounds(node)
 
         if isinstance(node, Text):
             if is_focusable(node.parent):
@@ -539,14 +535,15 @@ class AccessibilityNode:
             else:
                 self.role = "none"
 
-    def inline_bounds(node):
-        assert not node.layout_object
-        inline = node.parent
-        bounds = []
-        if isinstance(node, Text):
-            return bounds
+    def compute_bounds(node):
+        if node.layout_object:
+            return [absolute_bounds_for_obj(node.layout_object)]
 
-        print('here2')
+        inline = node.parent
+        if isinstance(node, Text):
+            return []
+
+        bounds = []
         while not inline.layout_object: inline = inline.parent
         assert inline.layout_object.layout_mode() == "inline"
         print(inline.layout_object)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -512,7 +512,7 @@ class AccessibilityNode:
         self.node = node
         self.children = []
         self.text = ""
-        self.bounds = AccessibilityNode.compute_bounds(node)
+        self.bounds = self.compute_bounds()
 
         if isinstance(node, Text):
             if is_focusable(node.parent):
@@ -535,18 +535,18 @@ class AccessibilityNode:
             else:
                 self.role = "none"
 
-    def compute_bounds(node):
-        if node.layout_object:
-            return [absolute_bounds_for_obj(node.layout_object)]
-        if isinstance(node, Text):
+    def compute_bounds():
+        if self.node.layout_object:
+            return [absolute_bounds_for_obj(self.node.layout_object)]
+        if isinstance(self.node, Text):
             return []
-        inline = node.parent
+        inline = self.node.parent
         bounds = []
         while not inline.layout_object: inline = inline.parent
         for line in inline.layout_object.children:
             line_bounds = skia.Rect.MakeEmpty()
             for child in line.children:
-                if child.node.parent == node:
+                if child.node.parent == self.node:
                     line_bounds.join(skia.Rect.MakeXYWH(
                         child.x, child.y, child.width, child.height))
             bounds.append(line_bounds)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -552,7 +552,6 @@ class AccessibilityNode:
             bounds.append(line_bounds)
         return bounds
 
-
     def build(self):
         for child_node in self.node.children:
             self.build_internal(child_node)
@@ -990,7 +989,6 @@ class Tab:
         if self.needs_accessibility:
             self.accessibility_tree = AccessibilityNode(self.nodes)
             self.accessibility_tree.build()
-            print_tree(self.accessibility_tree)
             self.needs_accessibility = False
 
         if self.needs_paint:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -535,7 +535,7 @@ class AccessibilityNode:
             else:
                 self.role = "none"
 
-    def compute_bounds():
+    def compute_bounds(self):
         if self.node.layout_object:
             return [absolute_bounds_for_obj(self.node.layout_object)]
         if isinstance(self.node, Text):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -514,9 +514,9 @@ class AccessibilityNode:
         self.text = ""
 
         if node.layout_object:
-            self.bounds = absolute_bounds_for_obj(node.layout_object)
+            self.bounds = [absolute_bounds_for_obj(node.layout_object)]
         else:
-            self.bounds = None
+            self.bounds = []
 
         if isinstance(node, Text):
             if is_focusable(node.parent):
@@ -580,8 +580,9 @@ class AccessibilityNode:
                 self.build_internal(grandchild_node)
 
     def intersects(self, x, y):
-        if self.bounds:
-            return self.bounds.contains(x, y)
+        for bound in self.bounds:
+            if bound.contains(x, y):
+                return True
         return False
 
     def hit_test(self, x, y):
@@ -1332,9 +1333,10 @@ class Browser:
         self.pending_hover = None
 
         if self.hovered_a11y_node:
-            self.draw_list.append(DrawOutline(
-                self.hovered_a11y_node.bounds,
-                "white" if self.dark_mode else "black", 2))
+            for bound in self.hovered_a11y_node.bounds:
+                self.draw_list.append(DrawOutline(
+                    bound,
+                    "white" if self.dark_mode else "black", 2))
 
     def update_accessibility(self):
         if not self.accessibility_tree: return

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1145,9 +1145,10 @@ class FrameAccessibilityNode(AccessibilityNode):
         self.build_internal(self.node.frame.nodes)
 
     def hit_test(self, x, y):
-        if not self.bounds.contains(x, y): return
-        new_x = x - self.bounds.x() - dpx(1, self.zoom)
-        new_y = y - self.bounds.y() - dpx(1, self.zoom) + self.scroll
+        bounds = self.bounds[0]
+        if not bounds.contains(x, y): return
+        new_x = x - bounds.x() - dpx(1, self.zoom)
+        new_y = y - bounds.y() - dpx(1, self.zoom) + self.scroll
         node = self
         for child in self.children:
             res = child.hit_test(new_x, new_y)
@@ -1155,7 +1156,8 @@ class FrameAccessibilityNode(AccessibilityNode):
         return node
 
     def map_to_parent(self, rect):
-        rect.offset(self.bounds.x(), self.bounds.y() - self.scroll)
+        bounds = self.bounds[0]
+        rect.offset(bounds.x(), bounds.y() - self.scroll)
 
     def __repr__(self):
         return "FrameAccessibilityNode(node={} role={} text={}".format(

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1126,14 +1126,18 @@ class AccessibilityNode:
         pass
 
     def absolute_bounds(self):
-        rect = skia.Rect.MakeXYWH(
-            self.bounds.x(), self.bounds.y(),
-            self.bounds.width(), self.bounds.height())
-        obj = self
-        while obj:
-            obj.map_to_parent(rect)
-            obj = obj.parent
-        return rect
+        abs_bounds = []
+        for bound in self.bounds:
+            abs_bound = bound.makeOffset(0.0, 0.0)
+            if isinstance(self, FrameAccessibilityNode):
+                obj = self.parent
+            else:
+                obj = self
+            while obj:
+                obj.map_to_parent(abs_bound)
+                obj = obj.parent
+            abs_bounds.append(abs_bound)
+        return abs_bounds
 
 class FrameAccessibilityNode(AccessibilityNode):
     def __init__(self, node, parent = None):
@@ -1158,6 +1162,7 @@ class FrameAccessibilityNode(AccessibilityNode):
     def map_to_parent(self, rect):
         bounds = self.bounds[0]
         rect.offset(bounds.x(), bounds.y() - self.scroll)
+        rect.intersect(bounds)
 
     def __repr__(self):
         return "FrameAccessibilityNode(node={} role={} text={}".format(
@@ -1709,7 +1714,38 @@ class Browser:
         task = Task(self.active_tab.scrolldown)
         self.active_tab.task_runner.schedule_task(task)
         self.needs_animation_frame = True
-        self.lock.release()        
+        self.lock.release()
+
+    def paint_draw_list(self):
+        self.draw_list = []
+        for composited_layer in self.composited_layers:
+            current_effect = \
+                DrawCompositedLayer(composited_layer)
+            if not composited_layer.display_items: continue
+            parent = composited_layer.display_items[0].parent
+            while parent:
+                current_effect = \
+                    self.clone_latest(parent, current_effect)
+                parent = parent.parent
+            self.draw_list.append(current_effect)
+
+        if self.pending_hover:
+            (x, y) = self.pending_hover
+            y += self.active_tab_scroll
+            a11y_node = self.accessibility_tree.hit_test(x, y)
+            if a11y_node:
+                if not self.hovered_a11y_node or \
+                    a11y_node.node != self.hovered_a11y_node.node:
+                    self.needs_speak_hovered_node = True
+                self.hovered_a11y_node = a11y_node
+        self.pending_hover = None
+
+        if self.hovered_a11y_node:
+            for bound in self.hovered_a11y_node.absolute_bounds():
+                self.draw_list.append(DrawOutline(
+                    bound,
+                    "white" if self.dark_mode else "black", 2))
+     
 
 if __name__ == "__main__":
     wbetools.parse_flags()

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1139,10 +1139,6 @@ class AccessibilityNode:
             obj = obj.parent
         return rect
 
-    def __repr__(self):
-        return "AccessibilityNode(node={} role={} text={}".format(
-            str(self.node), self.role, self.text)
-
 class FrameAccessibilityNode(AccessibilityNode):
     def __init__(self, node, parent = None):
         super().__init__(node, parent)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1043,11 +1043,7 @@ class AccessibilityNode:
         self.children = []
         self.parent = parent
         self.text = ""
-
-        if node.layout_object:
-            self.bounds = [absolute_bounds_for_obj(node.layout_object)]
-        else:
-            self.bounds = None
+        self.bounds = AccessibilityNode.compute_bounds(node)
 
         if isinstance(node, Text):
             if is_focusable(node.parent):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1045,7 +1045,7 @@ class AccessibilityNode:
         self.text = ""
 
         if node.layout_object:
-            self.bounds = absolute_bounds_for_obj(node.layout_object)
+            self.bounds = [absolute_bounds_for_obj(node.layout_object)]
         else:
             self.bounds = None
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1043,7 +1043,7 @@ class AccessibilityNode:
         self.children = []
         self.parent = parent
         self.text = ""
-        self.bounds = AccessibilityNode.compute_bounds(node)
+        self.bounds = self.compute_bounds()
 
         if isinstance(node, Text):
             if is_focusable(node.parent):


### PR DESCRIPTION
* An earlier PR accidentally deleted code that properly mapped hover rectangles up to the root of the page.
* Support bounds for inline elements (e.g. `<a>`)