### PR TITLE
Fix iframes under transform

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1119,7 +1119,7 @@ def paint_tree(layout_object, display_list):
 ```
 
 Before putting those commands in the display list, though, we need to add a
-border, clip iframe content that exceeds the visible area available, and
+border, clip iframe content that exceeds the visual area available, and
 transform the coordinate system:
 
 ``` {.python}

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1118,9 +1118,9 @@ def paint_tree(layout_object, display_list):
 
 ```
 
-Before putting those commands in the display list, though, we need to
-add a border, clip content outside of it, and transform the coordinate
-system:
+Before putting those commands in the display list, though, we need to add a
+border, clip iframe content that exceeds the visible area available, and
+transform the coordinate system:
 
 ``` {.python}
 class IframeLayout(EmbedLayout):
@@ -1142,10 +1142,8 @@ class IframeLayout(EmbedLayout):
 The `Transform` shifts over the child frame contents so that its
 top-left corner starts in the right place,[^content-box] `ClipRRect` clips
 the contents of the iframe to the inside of the border, and
-`paint_outline` adds the border and `paint_visual_effects` clips
-content outside the viewable area of the iframe. Conveniently, we've
-already implemented all of these features and can simply trigger them
-from our browser CSS file:
+`paint_outline` adds the border. To trigger the outline, just add this
+to the browser CSS file:
 
 [^content-box]: This book doesn't go into the details of the [CSS box
 model][box-model], but the `width` and `height` attributes of an

--- a/src/browser15.css
+++ b/src/browser15.css
@@ -28,7 +28,6 @@ a:focus {
 
 iframe {
     outline: 1px solid black;
-    overflow: clip;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -97,10 +97,9 @@ Let's load the original image in an iframe.
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     Blend(blend_mode=source-over)
-       ClipRRect(RRect(14, 19, 314, 169, 1))
-         Transform(translate(14.0, 19.0))
-           DrawImage(rect=Rect(13, 29, 18, 34))
+     ClipRRect(RRect(14, 19, 314, 169, 1))
+       Transform(translate(14.0, 19.0))
+         DrawImage(rect=Rect(13, 29, 18, 34))
      DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=1.0)
 
 Iframe layout mode is inline:
@@ -121,10 +120,9 @@ And the sized one:
     >>> browser.tabs[0].advance_tab()
     >>> browser.render()
     >>> test.print_display_list_skip_noops(browser.active_tab_display_list)
-     Blend(blend_mode=source-over)
-       ClipRRect(RRect(14, 19, 314, 169, 1))
-         Transform(translate(14.0, 19.0))
-           DrawImage(rect=Rect(13, 18, 23, 38))
+     ClipRRect(RRect(14, 19, 314, 169, 1))
+       Transform(translate(14.0, 19.0))
+         DrawImage(rect=Rect(13, 18, 23, 38))
      DrawOutline(top=18.0 left=13.0 bottom=170.0 right=315.0 border_color=black thickness=1.0)
 
 Iframes can be sized too:
@@ -177,10 +175,9 @@ Iframes can be sized too:
      DrawText(text=.)
      DrawText(text=.)
      DrawText(text=.)
-     Blend(blend_mode=source-over)
-       ClipRRect(RRect(46, 679, 96, 709, 1))
-         Transform(translate(46.0, 679.0))
-           DrawImage(rect=Rect(13, 29, 18, 34))
+     ClipRRect(RRect(46, 679, 96, 709, 1))
+       Transform(translate(46.0, 679.0))
+         DrawImage(rect=Rect(13, 29, 18, 34))
      DrawOutline(top=678.0 left=45.0 bottom=710.0 right=97.0 border_color=black thickness=1.0)
 
 Now let's test scrolling of the root frame:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -643,12 +643,6 @@ class IframeLayout(EmbedLayout):
                 self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
             cmds.append(DrawRRect(rect, radius, bgcolor))
-        rect = skia.Rect.MakeLTRB(
-            self.x, self.y,
-            self.x + self.width, self.y + self.height)
-        diff = dpx(1, self.zoom)
-        offset = (self.x + diff, self.y + diff)
-
         return cmds
 
     def paint_effects(self, cmds):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -643,6 +643,12 @@ class IframeLayout(EmbedLayout):
                 self.node.style.get("border-radius", "0px")[:-2]),
                 self.zoom)
             cmds.append(DrawRRect(rect, radius, bgcolor))
+        rect = skia.Rect.MakeLTRB(
+            self.x, self.y,
+            self.x + self.width, self.y + self.height)
+        diff = dpx(1, self.zoom)
+        offset = (self.x + diff, self.y + diff)
+
         return cmds
 
     def paint_effects(self, cmds):
@@ -655,8 +661,9 @@ class IframeLayout(EmbedLayout):
         inner_rect = skia.Rect.MakeLTRB(
             self.x + diff, self.y + diff,
             self.x + self.width - diff, self.y + self.height - diff)
-        cmds = paint_visual_effects(self.node, cmds, inner_rect)
+        cmds = [ClipRRect(inner_rect, 0, cmds, should_clip=True)]
         paint_outline(self.node, cmds, rect, self.zoom)
+        cmds = paint_visual_effects(self.node, cmds, rect)
         return cmds
 
     def __repr__(self):
@@ -1441,9 +1448,11 @@ class Frame:
             if isinstance(elt, Text):
                 pass
             elif elt.tag == "iframe":
+                abs_bounds = \
+                    absolute_bounds_for_obj(elt.layout_object)
                 border = dpx(1, elt.layout_object.zoom)
-                new_x = x - elt.layout_object.x - border
-                new_y = y - elt.layout_object.y - border
+                new_x = x - abs_bounds.x() - border
+                new_y = y - abs_bounds.y() - border
                 elt.frame.click(new_x, new_y)
                 return
             elif is_focusable(elt):

--- a/www/examples/example15-iframe.css
+++ b/www/examples/example15-iframe.css
@@ -1,0 +1,3 @@
+iframe {
+	transform: translate(10px, 20px);
+}

--- a/www/examples/example15-iframe.html
+++ b/www/examples/example15-iframe.html
@@ -1,6 +1,7 @@
 <script src="example15-iframe.js"></script>
 <link rel=stylesheet href="example15-iframe.css">
 <iframe src="example15-link.html"></iframe>
+<iframe src="example15-img.html"></iframe>
 <br>
 .
 <br>

--- a/www/examples/example15-iframe.html
+++ b/www/examples/example15-iframe.html
@@ -1,6 +1,6 @@
 <script src="example15-iframe.js"></script>
+<link rel=stylesheet href="example15-iframe.css">
 <iframe src="example15-link.html"></iframe>
-<iframe src="example15-img.html"></iframe>
 <br>
 .
 <br>


### PR DESCRIPTION
Fixes two bugs:

* Incorrect painting under a transform. Turns out we cannot get away with using overflow clip to represent the inner clip of an iframe, because the border rect needs to escape the clip but still be inside the other visual effects.

* Incorrect click hit testing of iframes under transform. Fix turned out to be easy, and removed the exercise.