### PR TITLE
Move Chapters 11+ to a `mainloop` function

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -98,7 +98,7 @@ class Tab:
 ```
 
 ``` {.python expected=False}
-if __name__ == "__main__":
+def mainloop(browser):
     while True:
         # ...
         browser.active_tab.task_runner.run()
@@ -614,8 +614,7 @@ loop, after running a task on the active tab the browser will need to
 raster-and-draw, in case that task was a rendering task:
 
 ``` {.python expected=False}
-if __name__ == "__main__":
-    browser = Browser()
+def mainloop(browser):
     while True:
         # ...
         browser.active_tab.task_runner.run()
@@ -1552,7 +1551,7 @@ Luckily, that's exactly what we're doing:
 pipeline by means of the speed of its end is called *back pressure*.
 
 ``` {.python}
-if __name__ == "__main__":
+def mainloop(browser):
     while True:
         # ...
         browser.raster_and_draw()

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -236,8 +236,7 @@ That's because SDL doesn't have a `mainloop` or `bind` method; we have
 to implement it ourselves:
 
 ``` {.python}
-if __name__ == "__main__":
-    # ...
+def mainloop(browser):
     event = sdl2.SDL_Event()
     while True:
         while sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
@@ -259,11 +258,20 @@ class Browser:
         sdl2.SDL_DestroyWindow(self.sdl_window)
 ```
 
-We'll also need to handle all of the other events in this
-loop---clicks, typing, and so on. The SDL syntax looks like this:
+Call `mainloop` in place of `tkinter.mainloop`:
 
 ``` {.python}
 if __name__ == "__main__":
+    # ...
+    mainloop(browser)
+```
+
+In place of all the `bind` calls in the `Browser` constructor, we can
+just directly call methods for various types of events, like clicks,
+typing, and so on. The SDL syntax looks like this:
+
+``` {.python}
+def mainloop(browser):
     while True:
         while sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
             # ...
@@ -278,14 +286,12 @@ if __name__ == "__main__":
                 browser.handle_key(event.text.text.decode('utf8'))
 ```
 
-This loop replaces all of the `bind` calls in the `Browser`
-constructor, which you can now remove. I've changed the signatures of
-the various event handler methods. For example, the `handle_click`
-method is now passed a `MouseButtonEvent` object, which thankfully
-contains `x` and `y` coordinates, while the `handle_enter` and
-`handle_down` methods aren't passed any argument at all, because we
-don't use that argument anyway. You'll need to change the `Browser`
-methods' signatures to match.
+I've changed the signatures of the various event handler methods. For
+example, the `handle_click` method is now passed a `MouseButtonEvent`
+object, which thankfully contains `x` and `y` coordinates, while the
+`handle_enter` and `handle_down` methods aren't passed any argument at
+all, because we don't use that argument anyway. You'll need to change
+the `Browser` methods' signatures to match.
 
 ::: {.further}
 SDL is most popular for making games. Their site lists [a selection of

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -84,7 +84,6 @@ started:
 
 ``` {.python}
 if __name__ == "__main__":
-    import sys
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -4,6 +4,7 @@ up to and including Chapter 11 (Adding Visual Effects),
 without exercises.
 """
 
+import sys
 import ctypes
 import dukpy
 import math
@@ -723,7 +724,6 @@ def mainloop(browser):
                 browser.handle_key(event.text.text.decode('utf8'))
 
 if __name__ == "__main__":
-    import sys
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -704,12 +704,7 @@ class Browser:
     def handle_quit(self):
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
-if __name__ == "__main__":
-    import sys
-    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
-    browser = Browser()
-    browser.new_tab(URL(sys.argv[1]))
-
+def mainloop(browser):
     event = sdl2.SDL_Event()
     while True:
         while sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
@@ -726,4 +721,12 @@ if __name__ == "__main__":
                     browser.handle_down()
             elif event.type == sdl2.SDL_TEXTINPUT:
                 browser.handle_key(event.text.text.decode('utf8'))
+
+if __name__ == "__main__":
+    import sys
+    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
+    browser = Browser()
+    browser.new_tab(URL(sys.argv[1]))
+    mainloop(browser)
+
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -4,6 +4,7 @@ up to and including Chapter 12 (Scheduling and Threading),
 without exercises.
 """
 
+import sys
 import ctypes
 import dukpy
 import math
@@ -807,24 +808,7 @@ class Chrome:
             self.focus = None
             self.browser.focus = None
 
-if __name__ == "__main__":
-    import sys
-    import argparse
-
-    parser = argparse.ArgumentParser(description='Toy browser')
-    parser.add_argument("url", type=str, help="URL to load")
-    parser.add_argument('--single_threaded', action="store_true", default=False,
-        help='Whether to run the browser without a browser thread')
-    parser.add_argument('--trace', action="store_true", default=False,
-        help='Whether to generate a browser trace file')
-    args = parser.parse_args()
-
-    wbetools.USE_BROWSER_THREAD = not args.single_threaded
-    wbetools.OUTPUT_TRACE = args.trace
-
-    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
-    browser = Browser()
-    browser.new_tab(URL(args.url))
+def mainloop(browser):
     event = sdl2.SDL_Event()
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
@@ -850,3 +834,10 @@ if __name__ == "__main__":
                 browser.render()
         browser.raster_and_draw()
         browser.schedule_animation_frame()
+
+if __name__ == "__main__":
+    wbetools.parse_flags()
+    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
+    browser = Browser()
+    browser.new_tab(URL(sys.argv[1]))
+    mainloop(browser)

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -28,7 +28,7 @@ from lab9 import EVENT_DISPATCH_JS
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, parse_color, NAMED_COLORS, parse_blend_mode, linespace
 from lab11 import paint_tree
-from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
+from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner, mainloop
 from lab12 import Tab, Browser, Task, REFRESH_RATE_SEC, Chrome, JSContext
 
 @wbetools.patch(Text)
@@ -1510,29 +1510,4 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
-
-    event = sdl2.SDL_Event()
-    while True:
-        if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
-            if event.type == sdl2.SDL_QUIT:
-                browser.handle_quit()
-                sdl2.SDL_Quit()
-                sys.exit()
-                break
-            elif event.type == sdl2.SDL_MOUSEBUTTONUP:
-                browser.handle_click(event.button)
-            elif event.type == sdl2.SDL_KEYDOWN:
-                if event.key.keysym.sym == sdl2.SDLK_RETURN:
-                    browser.handle_enter()
-                elif event.key.keysym.sym == sdl2.SDLK_DOWN:
-                    browser.handle_down()
-            elif event.type == sdl2.SDL_TEXTINPUT:
-                browser.handle_key(event.text.text.decode('utf8'))
-        if not wbetools.USE_BROWSER_THREAD:
-            if browser.active_tab.task_runner.needs_quit:
-                break
-            if browser.needs_animation_frame:
-                browser.needs_animation_frame = False
-                browser.render()
-        browser.composite_raster_and_draw()
-        browser.schedule_animation_frame()
+    mainloop(browser)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1604,11 +1604,7 @@ class Browser:
             sdl2.SDL_BlitSurface(sdl_surface, rect, window_surface, rect)
             sdl2.SDL_UpdateWindowSurface(self.sdl_window)
 
-def main_func(url):
-    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
-    browser = Browser()
-    browser.new_tab(url)
-
+def mainloop(browser):
     event = sdl2.SDL_Event()
     ctrl_down = False
     while True:
@@ -1676,5 +1672,8 @@ def main_func(url):
 
 if __name__ == "__main__":
     wbetools.parse_flags()
-    main_func(URL(sys.argv[1]))
+    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
+    browser = Browser()
+    browser.new_tab(URL(sys.argv[1]))
+    mainloop(browser)
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -45,7 +45,7 @@ from lab14 import DrawRRect, \
     parse_outline, paint_outline, \
     dpx, cascade_priority, style, \
     is_focusable, get_tabindex, speak_text, \
-    CSSParser, DrawOutline, main_func, Browser, Chrome, Tab, \
+    CSSParser, DrawOutline, mainloop, Browser, Chrome, Tab, \
     AccessibilityNode
 
 @wbetools.patch(URL)
@@ -1722,4 +1722,7 @@ class Browser:
 
 if __name__ == "__main__":
     wbetools.parse_flags()
-    main_func(URL(sys.argv[1]))
+    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
+    browser = Browser()
+    browser.new_tab(URL(sys.argv[1]))
+    mainloop(browser)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -41,7 +41,7 @@ from lab14 import parse_outline, DrawRRect, \
     paint_outline, \
     dpx, cascade_priority, \
     is_focusable, get_tabindex, speak_text, \
-    CSSParser, main_func, DrawOutline
+    CSSParser, mainloop, DrawOutline
 from lab15 import URL, HTMLParser, AttributeParser, DrawImage, \
     DocumentLayout, BlockLayout, \
     EmbedLayout, InputLayout, LineLayout, TextLayout, ImageLayout, \
@@ -1357,4 +1357,7 @@ class Tab:
 
 if __name__ == "__main__":
     wbetools.parse_flags()
-    main_func(URL(sys.argv[1]))
+    sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
+    browser = Browser()
+    browser.new_tab(URL(sys.argv[1]))
+    mainloop(browser)


### PR DESCRIPTION
Basically, in Chapters 11+ we had a bit of a mess, with some early chapters inlining the event loop into the `if __main__` block while later chapters had a `main_func` function but it wasn't a close analog of Tk's `mainloop` function. So this PR changes it to be a function called `mainloop` introduced in Chapter 11 and expanded on from then on.

Incidentally, I also changed Chapter 12 to use the `wbetools` command line parsing function, somehow that got lost somewhere.