### PR TITLE
Fix bugs breaking wikipedia cats in chapter 15

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -599,8 +599,7 @@ including query-relative and scheme-relative URLs, that I'm skipping.]
 -   A path-relative URL, which doesn't start with a slash and is
     resolved like a file name would be.
 -   A protocol-relative URL that starts with "//" followed by a full URL,
-    which should be completed to a full url using the same protocol
-    (`http` or` https`) as the current URL.
+    which should use the existing scheme.
 
 To download the style sheets, we'll need to convert each relative URL
 into a full URL:

--- a/book/styles.md
+++ b/book/styles.md
@@ -598,7 +598,7 @@ including query-relative and scheme-relative URLs, that I'm skipping.]
     existing scheme and host; or
 -   A path-relative URL, which doesn't start with a slash and is
     resolved like a file name would be.
--   A protocol-relative URL that starts with "//" followed by a full URL,
+-   A scheme-relative URL that starts with "//" followed by a full URL,
     which should use the existing scheme.
 
 To download the style sheets, we'll need to convert each relative URL

--- a/book/styles.md
+++ b/book/styles.md
@@ -598,6 +598,9 @@ including query-relative and scheme-relative URLs, that I'm skipping.]
     existing scheme and host; or
 -   A path-relative URL, which doesn't start with a slash and is
     resolved like a file name would be.
+-   A protocol-relative URL that starts with "//" followed by a full URL,
+    which should be completed to a full url using the same protocol
+    (`http` or` https`) as the current URL.
 
 To download the style sheets, we'll need to convert each relative URL
 into a full URL:
@@ -609,8 +612,11 @@ class URL:
         if not url.startswith("/"):
             dir, _ = self.path.rsplit("/", 1)
             url = dir + "/" + url
-        return URL(self.scheme + "://" + self.host + \
-                   ":" + str(self.port) + url)
+        if url.startswith("//"):
+            return URL(self.scheme + ":" + url)
+        else:
+            return URL(self.scheme + "://" + self.host + \
+                       ":" + str(self.port) + url)
 ```
 
 Also, because of the early web architecture, browsers are responsible

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -695,7 +695,9 @@ class AttributeParser:
                 self.i += 1
             else:
                 break
-        assert self.i > start
+        if self.i == start:
+            self.i = len(self.s)
+            return ""
         if quoted:
             return self.s[start+1:self.i-1]
         return self.s[start:self.i]
@@ -1284,7 +1286,8 @@ class Frame:
                 img.encoded_data = body
                 data = skia.Data.MakeWithoutCopy(body)
                 img.image = skia.Image.MakeFromEncoded(data)
-                assert img.image, "Failed to recognize image format for " + image_url
+                assert img.image, \
+                    "Failed to recognize image format for " + str(image_url)
             except Exception as e:
                 print("Image", image_url, "crashed", e)
                 img.image = BROKEN_IMAGE

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -25,6 +25,9 @@ Testing resolve_url
     >>> lab6.URL("http://bar.com/url1/").resolve("url2")
     URL(scheme=http, host=bar.com, port=80, path='/url1/url2')
 
+    >>> lab6.URL("http://bar.com/url1/").resolve("//baz.com/url2")
+    URL(scheme=http, host=baz.com, port=80, path='/url2')
+
 A trailing slash is automatically added if omitted:
 
     >>> lab6.URL("http://bar.com").resolve("url2")

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -28,8 +28,12 @@ class URL:
                 if "/" in dir:
                     dir, _ = dir.rsplit("/", 1)
             url = dir + "/" + url
-        return URL(self.scheme + "://" + self.host + \
-                   ":" + str(self.port) + url)
+        if url.startswith("//"):
+            return URL(self.scheme + ":" + url)
+        else:
+            return URL(self.scheme + "://" + self.host + \
+                       ":" + str(self.port) + url)
+
 
 def tree_to_list(tree, list):
     list.append(tree)


### PR DESCRIPTION
1. Protocol-relative URLs were not supported, and that's most of the images on this page.
2. The `AttributeParser` got confused in some situations where a style sheet ended up being parsed as an attribute. I fixed it by eating the rest of the string if `word` fails to advance.
3. A typo in the exception handler for failed image loads.

Now this URL can be loaded, and the images show: https://en.wikipedia.org/wiki/Cat