### PR TITLE
Pass over Chapter 16

### DIFF
--- a/book/change.md
+++ b/book/change.md
@@ -7,7 +7,7 @@ prev: skipped
 
 The web is a dynamic, ever-changing place. The first web browser, in
 1989, did not support colors, images, styling, or scripting. Three
-decades of evolution driven by market forces, implementation quirks,
+decades of market forces, implementation quirks,
 and the ever-expanding reach of the web then made browsers what they
 are today. Those forces are as strong as ever.  Browsers continue to evolve!
 

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -210,7 +210,7 @@ incremental, but this chapter focuses on layout.[^why-layout]
     improvements possible without implementing the invalidation
     techniques from this chapter, but invalidation is still essential
     for incremental performance, which is a kind of asymptotic
-    guarantee that optimization alone won't achieve.
+    guarantee that micro-optimization alone won't achieve.
 
 The key to this cache-and-invalidate approach will be tracking the
 effects of changes. When one part of the page, like a `style`

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -821,7 +821,7 @@ class BlockLayout:
 ```
 
 However, recall that with dirty flags we must always think about
-setting them (with `mark`), checking them (with `get`), and resetting
+invalidating them (with `mark`), checking them (with `get`), and resetting
 them (with `set`). We've added `get` and `set`, but who *marks* the
 `zoom` dirty flag?[^why-mark]
 

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -2317,7 +2317,7 @@ we add new style and layout features. This *auditability* concern
 happens in real browsers, too. After all, real browsers are millions,
 not thousands, of lines long, and support thousands of CSS properties.
 Their dependency graphs are
-dramatically more complex our browser's.
+dramatically more complex than our browser's.
 
 We'd therefore like to make it easier to see the dependency graph.
 And along the way we can centralize *invariants* about the shape of

--- a/book/skipped.md
+++ b/book/skipped.md
@@ -7,7 +7,7 @@ next: change
 
 The last sixteen chapters have, I hope, given you a solid understanding
 of all of the major components of a web browser, from the network
-requests it makes to way it stores your data and keeps it safe. With
+requests it makes to the way it stores your data safely. With
 such a vast topic I had to leave a few things out. Here's my list of
 the most important things not covered by this book, in no particular
 order.
@@ -22,7 +22,7 @@ using runtime type analysis. Plus, techniques like hidden classes
 infer structure where JavaScript doesn't provide any, lowering memory
 usage and garbage collection pressure. On top of all of that, modern
 browsers also execute WebAssembly, a hardware-independent bytecode format
-target for many other programming languages that may one day be co-equal
+for many other programming languages to target, and which may one day be co-equal
 to JavaScript on the web.
 
 This book skips building the JavaScript engine, instead using DukPy. I
@@ -37,7 +37,7 @@ Text & Graphics Rendering
 
 Text rendering is much more complex than it may seem at the surface.
 Letters differ in widths and heights. Accents may need to be stacked
-atop characters. Characters may change shape by proximity to other
+atop characters. Characters may change shape when next to other
 characters, like for ligatures or for *shaping* (for cursive fonts).
 Sometimes languages are written right-to-left or top-to-bottom. Then
 there are typographic features, like kerning and variants. But the
@@ -47,7 +47,7 @@ grid. Text rendering of course affects Skia, but it also affects
 layout, determining the size and position of content on the screen.
 
 And more broadly, graphics in general is pretty complex! Our
-browser uses Skia, which is the real rasterization engine of Chromium
+browser uses Skia, which is the actual rasterization engine used by Chromium
 and some other browsers. But we didn't really talk at all about how
 Skia actually works, and it turns out to be pretty complex. It not
 only renders text but applies all sorts of blends and effects quickly
@@ -55,7 +55,7 @@ and with high quality on basically all CPUs and GPUs. In a real
 browser this becomes even more complex, with fancy compositing
 systems, graphics process security sandboxing, and various
 platform-specific font and OS compositing integrations. And there is a
-whole lot of additional effort to implementation lower-level
+whole lot of additional effort to implement lower-level
 JavaScript-exposed APIs like [Canvas], [WebGL], and [WebGPU].
 
 [Canvas]: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API
@@ -76,7 +76,7 @@ protocols with bewildering names like AES-GCM, ChaCha20, and
 HMAC-SHA512. These protocols protect against malicious actors with the
 ability to read or write network packets. At the broadest
 level, connection security is established via the TLS protocol (which
-cameos in [Chapter 1](http.md)) and maintained by an ecosystem of
+cameos in [Chapter 1](http.md)) and is maintained by an ecosystem of
 cryptographers, certificate authorities, and open-source projects.
 
 I chose to skip an in-depth discussion of TLS because this book's
@@ -119,8 +119,8 @@ world of complexity in real-time video encoding, decoding and
 rendering. Real browsers have large teams devoted to these services
 and APIs, and many researchers across the world work on video
 compression. Video codecs are fascinating, but again not very
-browser-specific, so this book skips it entirely, and I suggest
-dedicated books on these subjects.
+browser-specific, so this book skips them entirely, and I advise
+reading a dedicated book about them.
 
 Fancier Layout Modes
 ====================
@@ -147,7 +147,7 @@ much about.
     example of multi-phase layout, and real browsers have much more
     complex sets of layout phases.
 
-Browser UIs and Developer tools
+Browser UIs and Developer Tools
 ===============================
 
 A real browser has a *much* more complex and powerful "browser
@@ -164,9 +164,9 @@ developers to extend the browser UI. To help with that, browser UIs
 are often implemented in HTML and rendered by the browser itself.
 
 Also, it'd be almost impossible to build complex web apps without some
-kind of debugging aid, so all real browsres have built-in debuggers.
-Believe it or not, for quite a long time browser engineers just did a
-lot of [printf debugging][printf]. This changed in a big way with the
+kind of debugging aid, so all real browsers have built-in debuggers.
+Believe it or not, for quite a long time we developers just did a
+lot of [`console.log` debugging][printf] (or even `alert` debugging, before there was an easy way to see the console!). This changed in a big way with the
 innovative [Firebug] browser extension for Firefox, and eventually
 today's integrated developer tools. These developer tools have deep
 integration with the browser engine itself to implement features like
@@ -189,7 +189,7 @@ Testing
 
 Real browsers have evolved an incredibly impressive array of testing
 techniques to ensure they maintain and improve quality over time. In total,
-they have batteries of hundreds of thousands of [unit], and [integration] tests.
+they have batteries of hundreds of thousands of [unit] and [integration] tests.
 Recently, a lot of focus has been put on robust
 [cross-browser tests](https://wpt.fyi) that allow a single automated test
 to run on all browsers to verify that they all behave the same on the same

--- a/book/styles.md
+++ b/book/styles.md
@@ -598,6 +598,8 @@ including query-relative and scheme-relative URLs, that I'm skipping.]
     existing scheme and host; or
 -   A path-relative URL, which doesn't start with a slash and is
     resolved like a file name would be.
+-   A scheme-relative URL that starts with "//" followed by a full URL,
+    which should use the existing scheme.
 
 To download the style sheets, we'll need to convert each relative URL
 into a full URL:
@@ -609,8 +611,11 @@ class URL:
         if not url.startswith("/"):
             dir, _ = self.path.rsplit("/", 1)
             url = dir + "/" + url
-        return URL(self.scheme + "://" + self.host + \
-                   ":" + str(self.port) + url)
+        if url.startswith("//"):
+            return URL(self.scheme + ":" + url)
+        else:
+            return URL(self.scheme + "://" + self.host + \
+                       ":" + str(self.port) + url)
 ```
 
 Also, because of the early web architecture, browsers are responsible

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -718,6 +718,7 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
+    browser.draw()
     mainloop(browser)
 
 

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -840,4 +840,5 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
+    browser.raster_and_draw()
     mainloop(browser)

--- a/src/lab13.hints
+++ b/src/lab13.hints
@@ -19,5 +19,6 @@
  {"code": "'style' in node.attributes", "type": "dict"},
  {"code": "node in self.composited_updates", "type": "list"},
  {"code": "child.tag in BLOCK_ELEMENTS", "type": "list"},
- {"code": "rect.outset(1, 1)", "js": "rect.outset(1, 1)"}
+ {"code": "rect.outset(1, 1)", "js": "rect.outset(1, 1)"},
+ {"code": "sys.exit()", "js": ""}
 ]

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -28,7 +28,7 @@ from lab9 import EVENT_DISPATCH_JS
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, get_font, parse_color, NAMED_COLORS, parse_blend_mode, linespace
 from lab11 import paint_tree
-from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner, mainloop
+from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner
 from lab12 import Tab, Browser, Task, REFRESH_RATE_SEC, Chrome, JSContext
 
 @wbetools.patch(Text)
@@ -1484,6 +1484,33 @@ class Browser:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)
 
+def mainloop(browser):
+    event = sdl2.SDL_Event()
+    while True:
+        if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
+            if event.type == sdl2.SDL_QUIT:
+                browser.handle_quit()
+                sdl2.SDL_Quit()
+                sys.exit()
+                break
+            elif event.type == sdl2.SDL_MOUSEBUTTONUP:
+                browser.handle_click(event.button)
+            elif event.type == sdl2.SDL_KEYDOWN:
+                if event.key.keysym.sym == sdl2.SDLK_RETURN:
+                    browser.handle_enter()
+                elif event.key.keysym.sym == sdl2.SDLK_DOWN:
+                    browser.handle_down()
+            elif event.type == sdl2.SDL_TEXTINPUT:
+                browser.handle_key(event.text.text.decode('utf8'))
+        if not wbetools.USE_BROWSER_THREAD:
+            if browser.active_tab.task_runner.needs_quit:
+                break
+            if browser.needs_animation_frame:
+                browser.needs_animation_frame = False
+                browser.render()
+        browser.composite_raster_and_draw()
+        browser.schedule_animation_frame()
+
 if __name__ == "__main__":
     import sys
     wbetools.parse_flags()
@@ -1491,4 +1518,5 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
+    browser.draw()
     mainloop(browser)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1675,5 +1675,6 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
+    browser.draw()
     mainloop(browser)
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -699,7 +699,9 @@ class AttributeParser:
                 self.i += 1
             else:
                 break
-        assert self.i > start
+        if self.i == start:
+            self.i = len(self.s)
+            return ""
         if quoted:
             return self.s[start+1:self.i-1]
         return self.s[start:self.i]
@@ -1288,7 +1290,8 @@ class Frame:
                 img.encoded_data = body
                 data = skia.Data.MakeWithoutCopy(body)
                 img.image = skia.Image.MakeFromEncoded(data)
-                assert img.image, "Failed to recognize image format for " + image_url
+                assert img.image, \
+                    "Failed to recognize image format for " + str(image_url)
             except Exception as e:
                 print("Image", image_url, "crashed", e)
                 img.image = BROKEN_IMAGE

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1678,6 +1678,101 @@ class Tab:
 
 @wbetools.patch(Browser)
 class Browser:
+    def __init__(self):
+        self.chrome = Chrome(self)
+
+        if wbetools.USE_GPU:
+            self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
+                sdl2.SDL_WINDOWPOS_CENTERED,
+                sdl2.SDL_WINDOWPOS_CENTERED,
+                WIDTH, HEIGHT,
+                sdl2.SDL_WINDOW_SHOWN | sdl2.SDL_WINDOW_OPENGL)
+            self.gl_context = sdl2.SDL_GL_CreateContext(
+                self.sdl_window)
+            print(("OpenGL initialized: vendor={}," + \
+                "renderer={}").format(
+                OpenGL.GL.glGetString(OpenGL.GL.GL_VENDOR),
+                OpenGL.GL.glGetString(OpenGL.GL.GL_RENDERER)))
+
+            self.skia_context = skia.GrDirectContext.MakeGL()
+
+            self.root_surface = \
+                skia.Surface.MakeFromBackendRenderTarget(
+                self.skia_context,
+                skia.GrBackendRenderTarget(
+                    WIDTH, HEIGHT, 0, 0, 
+                    skia.GrGLFramebufferInfo(0, OpenGL.GL.GL_RGBA8)),
+                    skia.kBottomLeft_GrSurfaceOrigin,
+                    skia.kRGBA_8888_ColorType,
+                    skia.ColorSpace.MakeSRGB())
+            assert self.root_surface is not None
+
+            self.chrome_surface = skia.Surface.MakeRenderTarget(
+                    self.skia_context, skia.Budgeted.kNo,
+                    skia.ImageInfo.MakeN32Premul(WIDTH, math.ceil(self.chrome.bottom)))
+            assert self.chrome_surface is not None
+        else:
+            self.sdl_window = sdl2.SDL_CreateWindow(b"Browser",
+            sdl2.SDL_WINDOWPOS_CENTERED, sdl2.SDL_WINDOWPOS_CENTERED,
+            WIDTH, HEIGHT, sdl2.SDL_WINDOW_SHOWN)
+            self.root_surface = skia.Surface.MakeRaster(
+                skia.ImageInfo.Make(
+                WIDTH, HEIGHT,
+                ct=skia.kRGBA_8888_ColorType,
+                at=skia.kUnpremul_AlphaType))
+            self.chrome_surface = skia.Surface(WIDTH, math.ceil(self.chrome.bottom))
+            self.skia_context = None
+
+        self.tabs = []
+        self.active_tab = None
+        self.focus = None
+        self.address_bar = ""
+        self.lock = threading.Lock()
+        self.active_tab_url = None
+        self.active_tab_scroll = 0
+
+        self.measure = MeasureTime()
+
+        if sdl2.SDL_BYTEORDER == sdl2.SDL_BIG_ENDIAN:
+            self.RED_MASK = 0xff000000
+            self.GREEN_MASK = 0x00ff0000
+            self.BLUE_MASK = 0x0000ff00
+            self.ALPHA_MASK = 0x000000ff
+        else:
+            self.RED_MASK = 0x000000ff
+            self.GREEN_MASK = 0x0000ff00
+            self.BLUE_MASK = 0x00ff0000
+            self.ALPHA_MASK = 0xff000000
+
+        self.animation_timer = None
+
+        self.needs_animation_frame = False
+        self.needs_composite = False
+        self.needs_raster = False
+        self.needs_draw = False
+        self.needs_accessibility = False
+
+        self.active_tab_height = 0
+        self.active_tab_display_list = None
+
+        self.composited_updates = {}
+        self.composited_layers = []
+        self.draw_list = []
+        self.muted = True
+        self.dark_mode = False
+
+        self.accessibility_is_on = False
+        self.has_spoken_document = False
+        self.pending_hover = None
+        self.hovered_a11y_node = None
+        self.focus_a11y_node = None
+        self.needs_speak_hovered_node = False
+        self.tab_focus = None
+        self.last_tab_focus = None
+        self.active_alerts = []
+        self.spoken_alerts = []
+        self.root_frame_focused = False
+
     def commit(self, tab, data):
         self.lock.acquire(blocking=True)
         if tab == self.active_tab:
@@ -1732,4 +1827,5 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
+    browser.draw()
     mainloop(browser)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -928,8 +928,9 @@ class IframeLayout(EmbedLayout):
         offset = (self.x.get() + diff, self.y.get() + diff)
         cmds = [Transform(offset, rect, self.node, cmds)]
         inner_rect = skia.Rect.MakeLTRB(self.x.get() + diff, self.y.get() + diff, self.x.get() + self.width.get() - diff, self.y.get() + self.height.get() - diff)
-        cmds = paint_visual_effects(self.node, cmds, inner_rect)
+        cmds = [ClipRRect(inner_rect, 0, cmds)]
         paint_outline(self.node, cmds, rect, self.zoom.get())
+        cmds = paint_visual_effects(self.node, cmds, inner_rect)
         return cmds
 
 def init_style(node):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1361,4 +1361,5 @@ if __name__ == "__main__":
     sdl2.SDL_Init(sdl2.SDL_INIT_EVENTS)
     browser = Browser()
     browser.new_tab(URL(sys.argv[1]))
+    browser.draw()
     mainloop(browser)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -776,6 +776,8 @@ class EmbedLayout:
         else:
             self.x.copy(self.parent.x)
 
+        self.has_dirty_descendants = False
+
 @wbetools.patch(InputLayout)
 class InputLayout(EmbedLayout):
     def layout(self):

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -25,6 +25,9 @@ Testing resolve_url
     >>> lab6.URL("http://bar.com/url1/").resolve("url2")
     URL(scheme=http, host=bar.com, port=80, path='/url1/url2')
 
+    >>> lab6.URL("http://bar.com/url1/").resolve("//baz.com/url2")
+    URL(scheme=http, host=baz.com, port=80, path='/url2')
+
 A trailing slash is automatically added if omitted:
 
     >>> lab6.URL("http://bar.com").resolve("url2")

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -28,8 +28,12 @@ class URL:
                 if "/" in dir:
                     dir, _ = dir.rsplit("/", 1)
             url = dir + "/" + url
-        return URL(self.scheme + "://" + self.host + \
-                   ":" + str(self.port) + url)
+        if url.startswith("//"):
+            return URL(self.scheme + ":" + url)
+        else:
+            return URL(self.scheme + "://" + self.host + \
+                       ":" + str(self.port) + url)
+
 
 def tree_to_list(tree, list):
     list.append(tree)


### PR DESCRIPTION
The main thing this pass had to do is align with the new `ascent` and `descent` fields on `EmbedLayout`.

Note: I switched from `super().layout()` to `EmbedLayout.layout(self)`. This has something complicated to do with how `super()` works, which I don't understand, and our patch system. But it should be invisible to the reader and won't be a big problem to maintain.