### PR TITLE
Fix slow compositing in chapter 16

### DIFF
--- a/src/lab11.py
+++ b/src/lab11.py
@@ -84,7 +84,7 @@ def parse_blend_mode(blend_mode_str):
         return skia.BlendMode.kDifference
     elif blend_mode_str == "destination-in":
         return skia.BlendMode.kDstIn
-    elif blend_mode_str == "source-over":
+    elif blend_mode_str == "normal":
         return skia.BlendMode.kSrcOver
     else:
         return skia.BlendMode.kSrcOver
@@ -95,6 +95,7 @@ def linespace(font):
 
 class Blend:
     def __init__(self, opacity, blend_mode, children):
+        print("blend")
         self.opacity = opacity
         self.blend_mode = blend_mode
         self.should_save = self.blend_mode or self.opacity < 1

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -714,7 +714,6 @@ class TextLayout:
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
 
-
 @wbetools.patch(EmbedLayout)
 class EmbedLayout:
     def __init__(self, node, parent, previous, frame):
@@ -1266,7 +1265,6 @@ class Frame:
                 self.set_needs_render()
                 return
             elt = elt.parent
-
 
 @wbetools.patch(Tab)
 class Tab:


### PR DESCRIPTION
The root cause was that we were calling `parse_blend_mode` in chapter 16 inside of `paint_visual_effects`, which was:
* A mismatch from what the `Blend` class needed (it expected to parse it itself)
* Causing the `blend_mode` variable to be not `None` (because it was `kSrcOver` due to the `normal` value for `mix-blend-mode`, which in turn made each such `Blend`'s `should_save` true, which in turn triggers compositing.

The fix is:
* Always expected `skia.BlendMode` parameter to `Blend`
* Define `should_save` to look for non-srcover blending