### PR TITLE
Reorganize first half of Chapter 11

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -250,7 +250,7 @@ limited gamut of expressible colors.
     [calibrate their screen][calibrate] to display colors accurately.
     For the rest of us, the software still communicates with the
     display in terms of standard red, green, and blue colors, and the
-    display hardware converts to whatever pixels it uses.
+    display hardware converts them to whatever pixels it uses.
 
 [^opaque]: Alpha is implicitly 255, meaning opaque, in this case.
     

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -193,7 +193,7 @@ performance.
 In Skia and SDL, a *surface* is a representation of a
 graphics buffer into which you can draw *pixels* (bits representing
 colors). We implicitly created an SDL surface when we created
-and SDL window; let's also create a surface for Skia to draw to:
+an SDL window; let's also create a surface for Skia to draw to:
 
 ``` {.python}
 class Browser:


### PR DESCRIPTION
This PR reorganizes the following sections of Chapter 11:

- SDL creates the window (11.2)
- Rasterizing with Skia (11.3)
- Pixels, color, and raster (11.6)

The reorganization creates a new section on "surfaces". It contains the material on surfaces, pixels, and color from 11.3 and 11.6, plus the material on blitting from 11.2. The benefits of this reorganization are:

- Focus more material on the central concept of a surface
- Shorten sections 11.2 and 11.3 a bit, making the port from Tk to SDL+Skia feel less overwhelming.
- Section 11.6, the theory section I didn't like, goes away.