### PR TITLE
Delete extra go-further block in Chapter 11

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1677,20 +1677,6 @@ few lines of Python.
 [classic]: https://en.wikipedia.org/wiki/Computer_Graphics:_Principles_and_Practice
 
 
-::: {.further}
-Besides using fewer surfaces, real browsers also need to avoid
-surfaces getting too big. Real browsers use *tiling* for this,
-breaking up the surface into a grid of tiles which have their own
-raster surfaces and their own *x* and *y* offset to the page. Whenever
-content that intersects a tile changes its display list, the tile is
-re-rastered. Tiles that are not on or "near"[^near] the screen are not
-rastered at all. This all happens on the GPU, since surfaces (Skia
-ones [in particular](https://kyamagu.github.io/skia-python/reference/skia.Surface.html))
-can be stored on the GPU.
-:::
-
-[^near]: For example, tiles that just scrolled off-screen.
-
 
 Summary
 =======


### PR DESCRIPTION
This PR just deletes the extra "tiling" go-further. We do have an extra in this chapter now, as a result of #1054. It's not the least fun go further, but deleting it makes, I think, the most sense.