### PR TITLE
At least do something with scroll offset when zooming

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -233,10 +233,13 @@ class Tab:
         else:
             self.zoom *= 1/1.1
             self.scroll *= 1/1.1
+        self.scroll_changed_in_tab = True
         self.set_needs_render()
 
     def reset_zoom(self):
+        self.scroll /= self.zoom
         self.zoom = 1
+        self.scroll_changed_in_tab = True
         self.set_needs_render()
 ```
 

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -229,8 +229,10 @@ class Tab:
     def zoom_by(self, increment):
         if increment:
             self.zoom *= 1.1
+            self.scroll *= 1.1
         else:
             self.zoom *= 1/1.1
+            self.scroll *= 1/1.1
         self.set_needs_render()
 
     def reset_zoom(self):
@@ -239,8 +241,17 @@ class Tab:
 ```
 
 Note that we need to set the `needs_render` flag when we zoom to
-redraw the screen after zooming is complete. We also need to reset the
-zoom level when we navigate to a new page:
+redraw the screen after zooming is complete. Also note that when we
+zoom the page we also need to adjust the scroll
+position.[^zoom-scroll] We also need to reset the zoom level when we
+navigate to a new page:
+
+[^zoom-scroll]: In a real browser, adjusting the scroll position when
+    zooming is more complex than just multiplying. That's because zoom
+    not only changes the height of individual lines of text, but also
+    changes line breaking, meaning more or fewer lines of text. This
+    means there's no easy correspondence between old and new scroll
+    positions.
 
 ``` {.python}
 class Tab:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -246,7 +246,7 @@ class Tab:
 Note that we need to set the `needs_render` flag when we zoom to
 redraw the screen after zooming is complete. Also note that when we
 zoom the page we also need to adjust the scroll
-position.[^zoom-scroll] We also need to reset the zoom level when we
+position,[^zoom-scroll] and reset the zoom level when we
 navigate to a new page:
 
 [^zoom-scroll]: In a real browser, adjusting the scroll position when

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -251,7 +251,7 @@ navigate to a new page:
     not only changes the height of individual lines of text, but also
     changes line breaking, meaning more or fewer lines of text. This
     means there's no easy correspondence between old and new scroll
-    positions.
+    positions. Most real browsers implement a much more general algorithm called [scroll anchoring](https://drafts.csswg.org/css-scroll-anchoring-1/) that handles all kinds of changes beyond just zoom.
 
 ``` {.python}
 class Tab:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1089,9 +1089,10 @@ class Tab:
     def zoom_by(self, increment):
         if increment:
             self.zoom *= 1.1
+            self.scroll *= 1.1
         else:
             self.zoom *= 1/1.1
-        print(self.zoom)
+            self.scroll *= 1/1.1
         self.set_needs_render()
 
     def reset_zoom(self):

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1093,10 +1093,13 @@ class Tab:
         else:
             self.zoom *= 1/1.1
             self.scroll *= 1/1.1
+        self.scroll_changed_in_tab = True
         self.set_needs_render()
 
     def reset_zoom(self):
+        self.scroll /= self.zoom
         self.zoom = 1
+        self.scroll_changed_in_tab = True
         self.set_needs_render()
 
     def set_dark_mode(self, val):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1669,9 +1669,12 @@ class Tab:
         else:
             self.zoom *= 1/1.1
             self.scroll *= 1/1.1
+        self.scroll_changed_in_tab = True
         self.set_needs_render_all_frames()
 
     def reset_zoom(self):
+        self.scroll_changed_in_tab = True
+        self.scroll /= self.zoom
         self.zoom = 1
         self.set_needs_render_all_frames()
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1665,8 +1665,10 @@ class Tab:
     def zoom_by(self, increment):
         if increment > 0:
             self.zoom *= 1.1
+            self.scroll *= 1.1
         else:
             self.zoom *= 1/1.1
+            self.scroll *= 1/1.1
         self.set_needs_render_all_frames()
 
     def reset_zoom(self):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1287,12 +1287,15 @@ class Tab:
             self.scroll *= 1 / 1.1
         for id, frame in self.window_id_to_frame.items():
             frame.document.zoom.mark()
+        self.scroll_changed_in_tab = True
         self.set_needs_render_all_frames()
 
     def reset_zoom(self):
+        self.scroll /= self.zoom
         self.zoom = 1
         for id, frame in self.window_id_to_frame.items():
             frame.document.zoom.mark()
+        self.scroll_changed_in_tab = True
         self.set_needs_render_all_frames()
 
     def run_animation_frame(self, scroll):

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1281,8 +1281,10 @@ class Tab:
     def zoom_by(self, increment):
         if increment > 0:
             self.zoom *= 1.1
+            self.scroll *= 1.1
         else:
             self.zoom *= 1 / 1.1
+            self.scroll *= 1 / 1.1
         for id, frame in self.window_id_to_frame.items():
             frame.document.zoom.mark()
         self.set_needs_render_all_frames()


### PR DESCRIPTION
This is not really the "right" fix (see added footnote) but I think doing nothing is worse because it suggests that you don't need to worry about scroll offset when zooming. (If there's anything written somewhere about what Chrome does, we can add that to the footnote if you'd like.)