### PR TITLE
Fix animation bugs

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -428,7 +428,7 @@ class Blend:
         args = ""
         if self.opacity < 1:
             args += ", opacity={}".format(self.opacity)
-        if self.blend_mode != "normal":
+        if self.blend_mode:
             args += ", blend_mode={}".format(self.blend_mode)
         if not args:
             args = ", <no-op>"

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1367,7 +1367,7 @@ to `paint_visual_effects`:
 ``` {.python expected=False}
 def paint_visual_effects(node, cmds, rect):
     # ...
-    blend_mode = node.style.get("mix-blend-mode", "normal")
+    blend_mode = node.style.get("mix-blend-mode")
     
     return [
         Blend(blend_mode, [
@@ -1660,7 +1660,7 @@ class Blend:
     def __init__(self, opacity, blend_mode, children):
         self.opacity = opacity
         self.blend_mode = blend_mode
-        self.should_save = self.blend_mode != "normal" or self.opacity < 1
+        self.should_save = self.blend_mode or self.opacity < 1
 
         self.children = children
         self.rect = skia.Rect.MakeEmpty()

--- a/src/lab11-tests.md
+++ b/src/lab11-tests.md
@@ -75,11 +75,13 @@ make a canvas in which to draw the circular clip mask.
     >>> browser.new_tab(lab11.URL(size_and_rounded_clip_url))
     >>> browser.tab_surface.printTabCommands()
     clear(color=ffffffff)
+    saveLayer(color=ff000000)
     drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(5, 5), color=ff0000ff)
     drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(0, 0), color=ff0000ff)
     drawString(text=Clip, x=13.0, y=33.0, color=ff000000)
     saveLayer(color=ff000000, blend_mode=BlendMode.kDstIn)
     drawRRect(bounds=Rect(13, 18, 787, 38), radius=Point(5, 5), color=ffffffff)
+    restore()
     restore()
     drawString(text=), x=13.0, y=53.0, color=ff000000)
 

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -97,7 +97,7 @@ class Blend:
     def __init__(self, opacity, blend_mode, children):
         self.opacity = opacity
         self.blend_mode = blend_mode
-        self.should_save = self.blend_mode != "normal" or self.opacity < 1
+        self.should_save = self.blend_mode or self.opacity < 1
 
         self.children = children
         self.rect = skia.Rect.MakeEmpty()
@@ -383,7 +383,7 @@ class InputLayout:
 
 def paint_visual_effects(node, cmds, rect):
     opacity = float(node.style.get("opacity", "1.0"))
-    blend_mode = node.style.get("mix-blend-mode", "normal")
+    blend_mode = node.style.get("mix-blend-mode")
 
     if node.style.get("overflow", "visible") == "clip":
         border_radius = float(node.style.get("border-radius", "0px")[:-2])

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -263,7 +263,7 @@ class Blend(VisualEffect):
         args = ""
         if self.opacity < 1:
             args += ", opacity={}".format(self.opacity)
-        if self.blend_mode != "normal":
+        if self.blend_mode:
             args += ", blend_mode={}".format(self.blend_mode)
         if not args:
             args = ", <no-op>"

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -221,7 +221,7 @@ class Blend(VisualEffect):
         super().__init__(skia.Rect.MakeEmpty(), children, node)
         self.opacity = opacity
         self.blend_mode = blend_mode
-        self.should_save = self.blend_mode != "normal" or self.opacity < 1
+        self.should_save = self.blend_mode or self.opacity < 1
 
         if wbetools.USE_COMPOSITING and self.should_save:
             self.needs_compositing = True
@@ -732,7 +732,7 @@ class InputLayout:
 
 def paint_visual_effects(node, cmds, rect):
     opacity = float(node.style.get("opacity", "1.0"))
-    blend_mode = node.style.get("mix-blend-mode", "normal")
+    blend_mode = node.style.get("mix-blend-mode")
     translation = parse_transform(
         node.style.get("transform", ""))
 
@@ -741,7 +741,7 @@ def paint_visual_effects(node, cmds, rect):
         if not blend_mode:
             blend_mode = "source-over"
         cmds.append(Blend(1.0, "destination-in", None, [
-            DrawRRect(rect, border_radius, cmds)
+            DrawRRect(rect, border_radius, "white")
         ]))
 
     blend_op = Blend(opacity, blend_mode, node, cmds)


### PR DESCRIPTION
This PR undoes some previous half-done changes. Basically, we at some point switched the default `mix-blend-mode` from `None` to `"normal"`. But we missed changing the code that guarantees isolation if there is a clip. I tried both methods and concluded that `None` is a more reasonable default, in the sense that it's harder to forget that it needs special treatment.

(This PR was made in the course of making another PR.)