### PR TITLE
Update renderingng link in scheduling.md

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -812,7 +812,7 @@ Chromium, for example, [only recently][renderingng] finished 100% of the work
 to leverage this model, though of course work (always) remains to be done.
 :::
 
-[renderingng]: https://developer.chrome.com/blog/renderingng/
+[renderingng]: https://developer.chrome.com/docs/chromium/renderingng
 
 Animating frames
 ================


### PR DESCRIPTION
The link [https://developer.chrome.com/blog/renderingng/](https://developer.chrome.com/blog/renderingng/) referenced by text "only recently" is outdated.

I guess the link you want to link is [https://developer.chrome.com/docs/chromium/renderingng](https://developer.chrome.com/docs/chromium/renderingng). Please feel free to edit to the desired link.