### PR TITLE
Don't crash on malformed URLs

### DIFF
--- a/book/http.md
+++ b/book/http.md
@@ -790,7 +790,7 @@ itself what you need to replace.)
 
 Encrypted HTTP connections usually use port 443 instead of port 80:
 
-``` {.python}
+``` {.python expected=False}
 class URL:
     def __init__(self, url):
         # ...

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -10,22 +10,25 @@ import wbetools
 
 class URL:
     def __init__(self, url):
-        self.scheme, url = url.split("://", 1)
-        assert self.scheme in ["http", "https"]
+        try:
+            self.scheme, url = url.split("://", 1)
+            assert self.scheme in ["http", "https"]
 
-        if "/" not in url:
-            url = url + "/"
-        self.host, url = url.split("/", 1)
-        self.path = "/" + url
+            if "/" not in url:
+                url = url + "/"
+            self.host, url = url.split("/", 1)
+            self.path = "/" + url
 
-        if self.scheme == "http":
-            self.port = 80
-        elif self.scheme == "https":
-            self.port = 443
+            if self.scheme == "http":
+                self.port = 80
+            elif self.scheme == "https":
+                self.port = 443
 
-        if ":" in self.host:
-            self.host, port = self.host.split(":", 1)
-            self.port = int(port)
+            if ":" in self.host:
+                self.host, port = self.host.split(":", 1)
+                self.port = int(port)
+        except:
+            self.__init__("https://browser.engineering")
 
     def request(self):
         s = socket.socket(

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -28,6 +28,8 @@ class URL:
                 self.host, port = self.host.split(":", 1)
                 self.port = int(port)
         except:
+            print("Malformed URL found, falling back to the WBE home page.")
+            print("  URL was: " + url)
             self.__init__("https://browser.engineering")
 
     def request(self):


### PR DESCRIPTION
Instead, fall back to the WBE homepage.

Even better would be to properly show nothing or an error message, but this is very simple and works.

I omitted this detail from the book because it doesn't seem relevant enough to justify inclusion in the text. However,
it constantly happens when trying to type URLs and making mistakes. Therefore the code we provide should avoid
crashing in this situation.