### PR TITLE
Fix small images in LaTeX

### DIFF
--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -296,7 +296,7 @@ $if(graphics)$
 % Scale images if necessary, so that they will not overflow the page
 % margins by default, and it is still possible to overwrite the defaults
 % using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+\setkeys{Gin}{width=\linewidth,keepaspectratio}
 % Set default figure placement to htbp
 \makeatletter
 \def\fps@figure{htbp}


### PR DESCRIPTION
I think the `\maxwidth` call here is having an issue with the `centering` environment and using `\linewidth` avoids it. Honestly, wish I knew, but this does seem to fix the issue; I examined a number of images throughout the book and they all looked normal.