### PR TITLE
Remove the alternate encoding exercise

### DIFF
--- a/book/http.md
+++ b/book/http.md
@@ -927,10 +927,6 @@ make it so that, if your browser is started without a URL being given,
 some specific file on your computer is opened. You can use that file
 for quick testing.
 
-*Alternate encodings:* read the encoding from the `Content-Type`
-header instead of always using `utf8`. Test it on a real site that
-doesn't use `utf8`, like `google.com`.
-
 *data:* Yet another scheme is *data*, which
 allows inlining HTML content into the URL itself. Try navigating to
 `data:text/html,Hello world!` in a real browser to see what happens. Add


### PR DESCRIPTION
Fix #1110 but removing the "alternate encodings" exercise. It seems like non-UTF8 web pages are not long for this world! Good riddance, maybe? Perhaps not if you are Japanese? Hard to say, but it's probably not a good exercise.