### PR TITLE
Use the metrics array in Chapter 3

### DIFF
--- a/book/text.md
+++ b/book/text.md
@@ -737,8 +737,8 @@ line:
 ``` {.python indent=4}
 def flush(self):
     if not self.line: return
-    max_ascent = max([font.metrics("ascent")
-        for x, word, font in self.line])
+    metrics = [font.metrics() for x, word, font in self.line]
+    max_ascent = max([metric["ascent"] for metric in metrics])
 ```
 
 The line is then `max_ascent` below `self.y`—or actually a little more
@@ -770,8 +770,7 @@ accomodate that word's ascent. Now `y` must move far enough down below
 `baseline` to account for the deepest descender:
 
 ``` {.python}
-max_descent = max([font.metrics("descent")
-    for x, word, font in self.line])
+max_descent = max([metric["descent"] for metric in metrics])
 self.cursor_y = baseline + 1.25 * max_descent
 ```
 

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -111,16 +111,14 @@ class Layout:
         wbetools.record("initial_y", self.cursor_y, self.line);
         metrics = [font.metrics() for x, word, font in self.line]
         wbetools.record("metrics", metrics)
-        max_ascent = max([font.metrics("ascent")
-            for x, word, font in self.line])
+        max_ascent = max([metric["ascent"] for metric in metrics])
         baseline = self.cursor_y + 1.25 * max_ascent
         wbetools.record("max_ascent", max_ascent);
         for x, word, font in self.line:
             y = baseline - font.metrics("ascent")
             self.display_list.append((x, y, word, font))
             wbetools.record("aligned", self.display_list);
-        max_descent = max([font.metrics("descent")
-            for x, word, font in self.line])
+        max_descent = max([metric["descent"] for metric in metrics])
         wbetools.record("max_descent", max_descent);
         self.cursor_y = baseline + 1.25 * max_descent
         self.cursor_x = HSTEP


### PR DESCRIPTION
In Chapters 5 onward, we expect that `max_ascent` and `max_descent` in `flush` are computed from an array called `metrics`, which stores the font metrics for each word in the line. But in Chapter 3, we don't actually do it that way in the book. This PR changes Chapter 3 to match later chapters; as a side benefit, the code now needs fewer line breaks.