### PR TITLE
Fix makefile to list all chapters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@
 
 FLAGS=
 
-CHAPTERS=about preface intro history http graphics text html \
-layout styles chrome forms scripts security visual-effects \
-scheduling animations accessibility embeds invalidation skipped \
-change glossary bibliography
+CHAPTERS=\
+preface intro history \
+http graphics text \
+html layout styles chrome \
+forms scripts security \
+visual-effects scheduling animations accessibility embeds invalidation \
+skipped change \
+glossary bibliography about classes
 
 EXAMPLE_HTML=$(patsubst src/example%.html,%,$(wildcard src/example*.html))
 EXAMPLE_JS=$(patsubst src/example%.js,%,$(wildcard src/example*.js))


### PR DESCRIPTION
Before, we weren't building `classes.md` because it wasn't in the list. I've also reformatted the list to follow the order on the TOC.