### PR TITLE
Fix parsing of cookie parameters

### DIFF
--- a/book/security.md
+++ b/book/security.md
@@ -818,10 +818,10 @@ def request(self, payload=None):
             cookie, rest = cookie.split(";", 1)
             for param in rest.split(";"):
                 if '=' in param:
-                    param, value = param.strip().split("=", 1)
+                    param, value = param.split("=", 1)
                 else:
                     value = "true"
-                params[param.casefold()] = value.casefold()
+                params[param.strip().casefold()] = value.casefold()
         COOKIE_JAR[self.host] = (cookie, params)
 ```
 

--- a/src/lab10-tests.md
+++ b/src/lab10-tests.md
@@ -58,6 +58,14 @@ The trailing slash is also optional:
     >>> test.socket.last_request(url_no_slash + '/')
     b'GET / HTTP/1.0\r\nHost: test.test\r\nCookie: foo=baz\r\n\r\n'
 
+Cookie parameters are parsed correctly:
+
+    >>> test.socket.respond(url, b"HTTP/1.0 200 OK\r\n" + \
+    ...   b"Set-Cookie: foo=baz; HttpOnly; SameSite=Lax; Secure\r\n\r\n")
+    >>> browser.new_tab(lab10.URL(url))
+    >>> lab10.COOKIE_JAR["test.test"]
+    ('foo=baz', {'httponly': 'true', 'samesite': 'lax', 'secure': 'true'})
+
 Testing XMLHttpRequest
 ======================
 

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -73,10 +73,10 @@ class URL:
                 cookie, rest = cookie.split(";", 1)
                 for param in rest.split(";"):
                     if '=' in param:
-                        param, value = param.strip().split("=", 1)
+                        param, value = param.split("=", 1)
                     else:
                         value = "true"
-                    params[param.casefold()] = value.casefold()
+                    params[param.strip().casefold()] = value.casefold()
             COOKIE_JAR[self.host] = (cookie, params)
     
         assert "transfer-encoding" not in response_headers

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -97,10 +97,10 @@ class URL:
                 cookie, rest = cookie.split(";", 1)
                 for param in rest.split(";"):
                     if '=' in param:
-                        param, value = param.strip().split("=", 1)
+                        param, value = param.split("=", 1)
                     else:
                         value = "true"
-                    params[param.casefold()] = value.casefold()
+                    params[param.strip().casefold()] = value.casefold()
             COOKIE_JAR[self.host] = (cookie, params)
     
         assert "transfer-encoding" not in response_headers


### PR DESCRIPTION
We currently misparse cookie parameters when there are spaces between the semicolon and the parameter, and also it is a boolean parameter, like `foo=bar; HttpOnly`. This PR fixes it by moving a `strip` to happen in boolean parameters too.