### PR TITLE
Make the Substack blog signup nicer

### DIFF
--- a/infra/signup.html
+++ b/infra/signup.html
@@ -1,4 +1,4 @@
 <div id="signup">
-<iframe src="https://browserbook.substack.com/embed" width="350" height="180" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://browserbook.substack.com/embed" width="350" height="150" frameborder="0" scrolling="no"></iframe>
 <a href="#" id="signup-close">Close</a>
 </div>


### PR DESCRIPTION
Substack has changed their embed styling and now recommends 150 pixels tall instead of 180. Ok.