### PR TITLE
Put the request body in a variable

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -668,7 +668,7 @@ class URL:
         # ...
         method = "POST" if payload else "GET"
         # ...
-        body = "{} {} HTTP/1.0\r\n".format(method, self.path)
+        request = "{} {} HTTP/1.0\r\n".format(method, self.path)
         # ...
 ```
 
@@ -680,7 +680,7 @@ class URL:
         # ...
         if payload:
             length = len(payload.encode("utf8"))
-            body += "Content-Length: {}\r\n".format(length)
+            request += "Content-Length: {}\r\n".format(length)
         # ...
 ```
 
@@ -692,8 +692,8 @@ after the headers, we send the payload itself:
 class URL:
     def request(self, payload=None):
         # ...
-        body += "\r\n" + (payload if payload else "")
-        s.send(body.encode("utf8"))
+        if payload: request += payload
+        s.send(request.encode("utf8"))
         # ...
 ```
 

--- a/book/http.md
+++ b/book/http.md
@@ -459,9 +459,10 @@ To do so, we send it some data using the `send` method:
 class URL:
     def request(self):
         # ...
-        s.send(("GET {} HTTP/1.0\r\n".format(self.path) + \
-                "Host: {}\r\n\r\n".format(self.host)) \
-               .encode("utf8"))
+        request = "GET {} HTTP/1.0\r\n".format(self.path)
+        request += "Host: {}\r\n".format(self.host)
+        request += "\r\n"
+        s.send(request.encode("utf8"))
 ```
 The `send` method just sends the request to the server.[^send-return]
 There are a few things in this code that have to be exactly right. First,
@@ -606,7 +607,7 @@ The usual way to send the data, then, is everything after the headers:
 class URL:
     def request(self):
         # ...
-        body = response.read()
+        content = response.read()
         s.close()
 ```
 
@@ -616,7 +617,7 @@ It's the body that we're going to display, so let's return that:
 class URL:
     def request(self):
         # ...
-        return body
+        return content
 ```
 
 Now let's actually display the text in the response body.

--- a/book/security.md
+++ b/book/security.md
@@ -385,7 +385,7 @@ class URL:
         # ...
         if self.host in COOKIE_JAR:
             cookie = COOKIE_JAR[self.host]
-            body += "Cookie: {}\r\n".format(cookie)
+            request += "Cookie: {}\r\n".format(cookie)
         # ...
 ```
 
@@ -832,7 +832,7 @@ cookie value, not the parameters:
 def request(self, payload=None):
     if self.host in COOKIE_JAR:
         cookie, params = COOKIE_JAR[self.host]
-        body += "Cookie: {}\r\n".format(cookie)
+        request += "Cookie: {}\r\n".format(cookie)
 ```
 
 This stores the `SameSite` parameter of a cookie. But to actually use
@@ -920,7 +920,7 @@ def request(self, top_level_url, payload=None):
             if method != "GET":
                 allow_cookie = self.host == top_level_url.host
         if allow_cookie:
-            body += "Cookie: {}\r\n".format(cookie)
+            request += "Cookie: {}\r\n".format(cookie)
         # ...
 ```
 
@@ -1084,7 +1084,7 @@ to return the response headers:
 class URL:
     def request(self, top_level_url, payload=None):
         # ...
-        return response_headers, body
+        return response_headers, content
 ```
 
 Make sure to update all existing uses of `request` to ignore the

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -43,10 +43,12 @@ class URL:
         if self.scheme == "https":
             ctx = ssl.create_default_context()
             s = ctx.wrap_socket(s, server_hostname=self.host)
-    
-        s.send(("GET {} HTTP/1.0\r\n".format(self.path) + \
-                "Host: {}\r\n\r\n".format(self.host)) \
-               .encode("utf8"))
+
+        request = "GET {} HTTP/1.0\r\n".format(self.path)
+        request += "Host: {}\r\n".format(self.host)
+        request += "\r\n"
+
+        s.send(request.encode("utf8"))
         response = s.makefile("r", encoding="utf8", newline="\r\n")
     
         statusline = response.readline()
@@ -62,10 +64,10 @@ class URL:
         assert "transfer-encoding" not in response_headers
         assert "content-encoding" not in response_headers
     
-        body = response.read()
+        content = response.read()
         s.close()
     
-        return body
+        return content
 
     @wbetools.js_hide
     def __repr__(self):

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -54,14 +54,14 @@ class URL:
             s = ctx.wrap_socket(s, server_hostname=self.host)
     
         method = "POST" if payload else "GET"
-        
-        body = "{} {} HTTP/1.0\r\n".format(method, self.path)
+        request = "{} {} HTTP/1.0\r\n".format(method, self.path)
         if payload:
             length = len(payload.encode("utf8"))
-            body += "Content-Length: {}\r\n".format(length)
-        body += "Host: {}\r\n".format(self.host)
-        body += "\r\n" + (payload if payload else "")
-        s.send(body.encode("utf8"))
+            request += "Content-Length: {}\r\n".format(length)
+        request += "Host: {}\r\n".format(self.host)
+        request += "\r\n"
+        if payload: request += payload
+        s.send(request.encode("utf8"))
         response = s.makefile("r", encoding="utf8", newline="\r\n")
     
         statusline = response.readline()
@@ -77,9 +77,9 @@ class URL:
         assert "transfer-encoding" not in response_headers
         assert "content-encoding" not in response_headers
     
-        body = response.read()
+        content = response.read()
         s.close()
-        return body
+        return content
 
 browser8 = open("browser8.css")
 DEFAULT_STYLE_SHEET = CSSParser(browser8.read()).parse()


### PR DESCRIPTION
This makes the Ch 1 code a little less ugly and also makes Ch 8 involve one less tiny refactor that confused students. I also renamed the output from `body` (which is confusing—request or response body) to `content` (which I think makes more sense, it is the content you requested)