### PR TITLE
Use self_rect insted of rect in lab15

### DIFF
--- a/src/lab15.py
+++ b/src/lab15.py
@@ -479,7 +479,7 @@ class LineLayout:
         for child in self.children:
             outline_str = child.node.parent.style.get("outline")
             if parse_outline(outline_str):
-                outline_rect.join(child.rect())
+                outline_rect.join(child.self_rect())
                 outline_node = child.node.parent
 
         if outline_node:


### PR DESCRIPTION
The old code was I think just wrong. lab14 uses `self_rect`. I found this by loading lab15 and then pressing tab; it
crashed when creating an outline of a text object.