### PR TITLE
Fix bug when closing threads

### DIFF
--- a/src/lab12.py
+++ b/src/lab12.py
@@ -428,7 +428,7 @@ class TaskRunner:
                 task.run()
 
             self.condition.acquire(blocking=True)
-            if len(self.tasks) == 0 or self.needs_quit:
+            if len(self.tasks) == 0 and not self.needs_quit:
                 self.condition.wait()
             self.condition.release()
 
@@ -730,10 +730,6 @@ class Browser:
         for tab in self.tabs:
             tab.task_runner.set_needs_quit()
         sdl2.SDL_DestroyWindow(self.sdl_window)
-
-
-
-
 
 def mainloop(browser):
     event = sdl2.SDL_Event()

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1480,7 +1480,8 @@ class Browser:
 
     def handle_quit(self):
         self.measure.finish()
-        self.active_tab.task_runner.set_needs_quit()
+        for tab in self.tabs:
+            tab.task_runner.set_needs_quit()
         if wbetools.USE_GPU:
             sdl2.SDL_GL_DeleteContext(self.gl_context)
         sdl2.SDL_DestroyWindow(self.sdl_window)


### PR DESCRIPTION
We should only pause the thread if needs_quit is not true.

I found this because sometimes a long task will run, and if you try to quit the browser during it then the thread would never quit and the browser would hang.

We were also failing to notify all tab threads. lab12 gets it right but lab13 was broken.