### PR TITLE
Fix timer race condition when switching tabs

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1790,6 +1790,7 @@ class Browser:
         self.active_tab_scroll = 0
         self.active_tab_url = None
         self.needs_animation_frame = True
+        self.animation_timer = None
 ```
 
 So far, this is only updating the scroll offset on the browser thread.

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -663,6 +663,7 @@ class Browser:
         self.active_tab_scroll = 0
         self.active_tab_url = None
         self.needs_animation_frame = True
+        self.animation_timer = None
 
     def handle_click(self, e):
         self.lock.acquire(blocking=True)

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1394,6 +1394,7 @@ class Browser:
         self.active_tab = tab
         self.clear_data()
         self.needs_animation_frame = True
+        self.animation_timer = None
 
     def handle_click(self, e):
         self.lock.acquire(blocking=True)

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1493,6 +1493,7 @@ class Browser:
 
         self.clear_data()
         self.needs_animation_frame = True
+        self.animation_timer = None
 
     def go_back(self):
         task = Task(self.active_tab.go_back)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1822,6 +1822,7 @@ class Browser:
 
         self.clear_data()
         self.needs_animation_frame = True
+        self.animation_timer = None
 
     def handle_down(self):
         self.lock.acquire(blocking=True)


### PR DESCRIPTION
If one tab has an animation timer in progress when a tab is switched, then the new tab will never render, because
we don't schedule frames if `animation_timer` is set.

This is fixed by clearing `animation_timer` when changing tabs.

I was able to reproduce this in lab15 by loading a new tab, then switching back to the first tab before browser.engineering finishes loading.