### PR TITLE
Remove `__repr__` from lab3.py

### DIFF
--- a/src/lab3.py
+++ b/src/lab3.py
@@ -16,15 +16,9 @@ class Text:
     def __init__(self, text):
         self.text = text
 
-    def __repr__(self):
-        return "Text('{}')".format(self.text)
-
 class Tag:
     def __init__(self, tag):
         self.tag = tag
-
-    def __repr__(self):
-        return "Tag('{}')".format(self.tag)
 
 def lex(body):
     out = []


### PR DESCRIPTION
Closes #1150.

As mentioned in #1150, the `__repr__` method is not covered in the text of Chapter 3 and, therefore, should not be included in its Outline section. Since this method is actually introduced in Chapter 4 (https://github.com/browserengineering/book/blob/main/book/html.md?plain=1#L285-L293), I deemed it appropriate to remove it from the Outline of Chapter 3.