### PR TITLE
Hide `__repr__` methods in Chapter 3 before they're introduced/used

### DIFF
--- a/src/lab3.py
+++ b/src/lab3.py
@@ -16,6 +16,7 @@ class Text:
     def __init__(self, text):
         self.text = text
 
+    @wbetools.js_hide
     def __repr__(self):
         return "Text('{}')".format(self.text)
 
@@ -23,6 +24,7 @@ class Tag:
     def __init__(self, tag):
         self.tag = tag
 
+    @wbetools.js_hide
     def __repr__(self):
         return "Tag('{}')".format(self.tag)
 


### PR DESCRIPTION
This PR fixes #1150, with a different fix from #1153. #1150 asks us to remove the `__repr__` methods from the outline in Chapter 3 because `__repr__` isn't introduced in general until Chapter 4 and moreover those methods are never used. However, we can't actually just remove them because they _are_ used by the tests. So this PR instead adds the annotation that hides them from the outline. I've verified that this makes no changes to widgets either.

Closes #1150, closes #1153.