### PR TITLE
Don't highlight builtins like `type`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ src/lab%.full.py: src/lab%.py infra/inline.py infra/asttools.py
 
 CHAPTER=all
 
-PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json $(FLAGS)
+PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json --highlight-style=infra/python-nobuiltin.theme $(FLAGS)
 
-PANDOC_LATEX=pandoc --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json --lua-filter=infra/filter.lua $(FLAGS)
+PANDOC_LATEX=pandoc --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json --lua-filter=infra/filter.lua --highlight-style=infra/python-nobuiltin.theme $(FLAGS)
 
 # Generates a simple chapter latex rendering meant to be inserted into the larger book skeleton.
 latex-chapters: $(patsubst %,latex/%-chapter.tex,$(CHAPTERS))

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ src/lab%.full.py: src/lab%.py infra/inline.py infra/asttools.py
 
 CHAPTER=all
 
-PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json --highlight-style=infra/python-nobuiltin.theme $(FLAGS)
+PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json --highlight-style=infra/wbecode.theme $(FLAGS)
 
-PANDOC_LATEX=pandoc --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json --lua-filter=infra/filter.lua --highlight-style=infra/python-nobuiltin.theme $(FLAGS)
+PANDOC_LATEX=pandoc --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json --lua-filter=infra/filter.lua --highlight-style=infra/wbecode.theme $(FLAGS)
 
 # Generates a simple chapter latex rendering meant to be inserted into the larger book skeleton.
 latex-chapters: $(patsubst %,latex/%-chapter.tex,$(CHAPTERS))

--- a/infra/python-nobuiltin.theme
+++ b/infra/python-nobuiltin.theme
@@ -1,0 +1,211 @@
+{
+    "text-color": null,
+    "background-color": null,
+    "line-number-color": "#aaaaaa",
+    "line-number-background-color": null,
+    "text-styles": {
+        "Alert": {
+            "text-color": "#ff0000",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Annotation": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        },
+        "Attribute": {
+            "text-color": "#7d9029",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "BaseN": {
+            "text-color": "#40a070",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "BuiltIn": {
+            "text-color": null,
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Char": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Comment": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
+        },
+        "CommentVar": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        },
+        "Constant": {
+            "text-color": "#880000",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "ControlFlow": {
+            "text-color": "#007020",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "DataType": {
+            "text-color": "#902000",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "DecVal": {
+            "text-color": "#40a070",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Documentation": {
+            "text-color": "#ba2121",
+            "background-color": null,
+            "bold": false,
+            "italic": true,
+            "underline": false
+        },
+        "Error": {
+            "text-color": "#ff0000",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Extension": {
+            "text-color": null,
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Float": {
+            "text-color": "#40a070",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Function": {
+            "text-color": "#06287e",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Import": {
+            "text-color": "#008000",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Information": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        },
+        "Keyword": {
+            "text-color": "#007020",
+            "background-color": null,
+            "bold": true,
+            "italic": false,
+            "underline": false
+        },
+        "Operator": {
+            "text-color": "#666666",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Other": {
+            "text-color": "#007020",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Preprocessor": {
+            "text-color": "#bc7a00",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "SpecialChar": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "SpecialString": {
+            "text-color": "#bb6688",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "String": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Variable": {
+            "text-color": "#19177c",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "VerbatimString": {
+            "text-color": "#4070a0",
+            "background-color": null,
+            "bold": false,
+            "italic": false,
+            "underline": false
+        },
+        "Warning": {
+            "text-color": "#60a0b0",
+            "background-color": null,
+            "bold": true,
+            "italic": true,
+            "underline": false
+        }
+    }
+}

--- a/infra/wbecode.theme
+++ b/infra/wbecode.theme
@@ -19,14 +19,14 @@
             "underline": false
         },
         "Attribute": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "BaseN": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
@@ -40,7 +40,7 @@
             "underline": false
         },
         "Char": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
@@ -54,14 +54,14 @@
             "underline": false
         },
         "CommentVar": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": true,
             "italic": true,
             "underline": false
         },
         "Constant": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
@@ -75,28 +75,28 @@
             "underline": false
         },
         "DataType": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "DecVal": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Documentation": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": true,
             "underline": false
         },
         "Error": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": true,
             "italic": false,
@@ -110,14 +110,14 @@
             "underline": false
         },
         "Float": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Function": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
@@ -131,7 +131,7 @@
             "underline": false
         },
         "Information": {
-            "text-color": theme,
+            "text-color": null,
             "background-color": null,
             "bold": true,
             "italic": true,

--- a/infra/wbecode.theme
+++ b/infra/wbecode.theme
@@ -5,28 +5,28 @@
     "line-number-background-color": null,
     "text-styles": {
         "Alert": {
-            "text-color": "#ff0000",
+            "text-color": null,
             "background-color": null,
             "bold": true,
             "italic": false,
             "underline": false
         },
         "Annotation": {
-            "text-color": "#60a0b0",
+            "text-color": null,
             "background-color": null,
             "bold": true,
             "italic": true,
             "underline": false
         },
         "Attribute": {
-            "text-color": "#7d9029",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "BaseN": {
-            "text-color": "#40a070",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
@@ -40,63 +40,63 @@
             "underline": false
         },
         "Char": {
-            "text-color": "#4070a0",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Comment": {
-            "text-color": "#60a0b0",
+            "text-color": "#aa8866",
             "background-color": null,
             "bold": false,
             "italic": true,
             "underline": false
         },
         "CommentVar": {
-            "text-color": "#60a0b0",
+            "text-color": theme,
             "background-color": null,
             "bold": true,
             "italic": true,
             "underline": false
         },
         "Constant": {
-            "text-color": "#880000",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "ControlFlow": {
-            "text-color": "#007020",
+            "text-color": "#660066",
             "background-color": null,
             "bold": true,
             "italic": false,
             "underline": false
         },
         "DataType": {
-            "text-color": "#902000",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "DecVal": {
-            "text-color": "#40a070",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Documentation": {
-            "text-color": "#ba2121",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": true,
             "underline": false
         },
         "Error": {
-            "text-color": "#ff0000",
+            "text-color": theme,
             "background-color": null,
             "bold": true,
             "italic": false,
@@ -110,98 +110,98 @@
             "underline": false
         },
         "Float": {
-            "text-color": "#40a070",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Function": {
-            "text-color": "#06287e",
+            "text-color": theme,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Import": {
-            "text-color": "#008000",
+            "text-color": "#660066",
             "background-color": null,
             "bold": true,
             "italic": false,
             "underline": false
         },
         "Information": {
-            "text-color": "#60a0b0",
+            "text-color": theme,
             "background-color": null,
             "bold": true,
             "italic": true,
             "underline": false
         },
         "Keyword": {
-            "text-color": "#007020",
+            "text-color": "#660066",
             "background-color": null,
             "bold": true,
             "italic": false,
             "underline": false
         },
         "Operator": {
-            "text-color": "#666666",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Other": {
-            "text-color": "#007020",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Preprocessor": {
-            "text-color": "#bc7a00",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "SpecialChar": {
-            "text-color": "#4070a0",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "SpecialString": {
-            "text-color": "#bb6688",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "String": {
-            "text-color": "#4070a0",
+            "text-color": "#666666",
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Variable": {
-            "text-color": "#19177c",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "VerbatimString": {
-            "text-color": "#4070a0",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,
             "underline": false
         },
         "Warning": {
-            "text-color": "#60a0b0",
+            "text-color": null,
             "background-color": null,
             "bold": true,
             "italic": true,


### PR DESCRIPTION
Our copyeditor pointed out that in Chapter 1 (and by the way same issue in Chapter 9), when we create a socket with `socket.socket(type=...)`, the word `type` should not be syntax-highlighted because it's not actually a builtin function but just a named parameter. I noticed that the website _doesn't_ have this problem. It turns out that's because we have a very minimal highlighting style on the website: comments, strings, and keywords are the only things with a color. So I made the LaTeX in the book do the same thing.