### PR TITLE
Change `top_level_url` to `referrer` (close #1155)

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -269,9 +269,9 @@ browser is using; this will help you verify that it's actually using
 your GPU. I'm using a Chromebook to write this chapter, so for me it
 says:[^virgl]
 
-::: {.example}
-    OpenGL initialized: vendor=b'Red Hat', renderer=b'virgl'
-:::
+``` {.output}
+OpenGL initialized: vendor=b'Red Hat', renderer=b'virgl'
+```
 
 [^virgl]: The `virgl` renderer stands for "virtual GL", a way of
 hardware-accelerating the Linux subsystem of ChromeOS that works with
@@ -458,21 +458,21 @@ class Tab:
 For our opacity example, the (key part of) the display list one one frame
 might look like this:
 
-::: {.example}
-    Blend(alpha=0.112375)
-      DrawText(text=This)
-      DrawText(text=text)
-      DrawText(text=fades)
-:::
+``` {.output}
+Blend(alpha=0.112375)
+  DrawText(text=This)
+  DrawText(text=text)
+  DrawText(text=fades)
+```
 
 On the next frame, it instead might like this:
 
-::: {.example}
-    Blend(alpha=0.119866666667)
-      DrawText(text=This)
-      DrawText(text=text)
-      DrawText(text=fades)
-:::
+``` {.output}
+Blend(alpha=0.119866666667)
+  DrawText(text=This)
+  DrawText(text=text)
+  DrawText(text=fades)
+```
 
 In each case, rastering this display list means first rastering the three words
 to a Skia surface created by `Blend`, and then copying that to the root
@@ -483,29 +483,29 @@ The idea is to first raster the three words to a separate surface (but this time
 owned by us, not Skia), which we'll call a *composited layer*, that is saved
 for future use:
 
-::: {.example}
-    Composited Layer:
-      DrawText(text=This)
-      DrawText(text=text)
-      DrawText(text=fades)
-:::
+::: {.output}
+Composited Layer:
+  DrawText(text=This)
+  DrawText(text=text)
+  DrawText(text=fades)
+```
 
 Now instead of rastering those three words, we can just copy over the
 composited layer with a `DrawCompositedLayer` command:
 
-::: {.example}
-    Blend(alpha=0.112375)
-      DrawCompositedLayer()
-:::
+``` {.example}
+Blend(alpha=0.112375)
+  DrawCompositedLayer()
+```
 
 Importantly, on the next frame, the `Blend` changes but the
 `DrawText`s don't, so on that frame all we need to do is rerun the
 `Blend`:
 
-::: {.example}
-    Blend(alpha=0.119866666667)
-      DrawCompositedLayer()
-:::
+``` {.example}
+Blend(alpha=0.119866666667)
+  DrawCompositedLayer()
+```
 
 In other words, the idea behind compositing is to split the display
 list into two pieces: a set of composited layers, which are rastered
@@ -1871,12 +1871,12 @@ mostly a historical artifact.)
 
 [transform-def]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
 
-::: {.example}
-    <div style="background-color:lightblue;
-                transform:translate(50px, 50px)">Underneath</div>
-    <div style="background-color:lightgreen;
-                transform:translate(0px, 0px)">On top</div>
-:::
+``` {.html .example}
+<div style="background-color:lightblue;
+            transform:translate(50px, 50px)">Underneath</div>
+<div style="background-color:lightgreen;
+            transform:translate(0px, 0px)">On top</div>
+```
 
 Supporting these transforms is simple. First let's parse the property
 values:[^space-separated]

--- a/book/animations.md
+++ b/book/animations.md
@@ -483,7 +483,7 @@ The idea is to first raster the three words to a separate surface (but this time
 owned by us, not Skia), which we'll call a *composited layer*, that is saved
 for future use:
 
-::: {.output}
+``` {.output}
 Composited Layer:
   DrawText(text=This)
   DrawText(text=text)

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -62,7 +62,7 @@ The change is pretty minimal: instead of passing the `"r"` flag to
 
 ``` {.python}
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         # ...
         response = s.makefile("b")
         # ...
@@ -74,7 +74,7 @@ parser code to explicitly `decode` the data:
 
 ``` {.python}
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         # ...
         statusline = response.readline().decode("utf8")
         # ...

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1681,12 +1681,12 @@ window.Node = function(handle) { this.handle = handle; }
 Do the same for every function or variable in the `runtime.js` file.
 If you miss one, you'll get errors like this:
 
-::: {.example}
-    dukpy.JSRuntimeError: ReferenceError: identifier 'Node'
-        undefined
-    	duk_js_var.c:1258
-    	eval src/pyduktape.c:1 preventsyield
-:::
+``` {.output}
+dukpy.JSRuntimeError: ReferenceError: identifier 'Node'
+    undefined
+	duk_js_var.c:1258
+	eval src/pyduktape.c:1 preventsyield
+```
 
 If you see this error, this means you need to go find where you need
 to write `window.Node` instead of `Node`. You'll also need to modify `EVENT_DISPATCH_JS` to prefix

--- a/book/http.md
+++ b/book/http.md
@@ -76,8 +76,8 @@ On many systems, you can set up this kind of connection using the
 telnet example.org 80
 ```
 
-(Note: when you see a gray outline, it means that the code in question is
-an example only, and *not* actually part of our browser's code.)
+(Note: when a code block has an "Example Code" tag, that means that
+the code in question is *not* actually part of our browser.)
 
 ::: {.installation}
 You might need to install `telnet`; it is often disabled by default.

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1794,31 +1794,31 @@ class DocumentLayout:
 If you look at your output again, you should now see two phases.
 First, there's a lot of `style` re-computation:
     
-::: {.example}
-    Change ProtectedField(<body>, style)
-    Change ProtectedField(<header>, style)
-    Change ProtectedField(<h1 class="title">, style)
-    Change ProtectedField('Reusing Previous Computations', style)
-    Change ProtectedField(<a href="...">, style)
-    Change ProtectedField('Twitter', style)
-    Change ProtectedField(' ·\n', style)
-    ...
-:::
+``` {.output}
+Change ProtectedField(<body>, style)
+Change ProtectedField(<header>, style)
+Change ProtectedField(<h1 class="title">, style)
+Change ProtectedField('Reusing Previous Computations', style)
+Change ProtectedField(<a href="...">, style)
+Change ProtectedField('Twitter', style)
+Change ProtectedField(' ·\n', style)
+...
+```
 
 Then, we recompute four layout fields repeatedly:
 
-::: {.example}
-    Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
-    Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
-    Change ProtectedField(<head>, zoom)
-    Change ProtectedField(<head>, children)
-    Change ProtectedField(<head>, height)
-    Change ProtectedField(<body>, zoom)
-    Change ProtectedField(<body>, y)
-    Change ProtectedField(<header>, zoom)
-    Change ProtectedField(<header>, y)
-    ...
-:::
+``` {.output}
+Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
+Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
+Change ProtectedField(<head>, zoom)
+Change ProtectedField(<head>, children)
+Change ProtectedField(<head>, height)
+Change ProtectedField(<body>, zoom)
+Change ProtectedField(<body>, y)
+Change ProtectedField(<header>, zoom)
+Change ProtectedField(<header>, y)
+...
+```
 
 Let's fix these. First, let's tackle `style`. The reason `style` is
 being recomputed repeatedly is just that we recompute it even if
@@ -1867,11 +1867,11 @@ value, any downstream computations don't actually need to change. This
 small tweak should reduce the number of field changes down to the
 minimum:
 
-::: {.example}
-    Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
-    Change ProtectedField(<div class="demo" ...>, children)
-    Change ProtectedField(<div class="demo" ...>, height)
-:::
+``` {.output}
+Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
+Change ProtectedField(<div class="demo" ...>, children)
+Change ProtectedField(<div class="demo" ...>, height)
+```
 
 All that's happening here is recreating the `contenteditable`
 element's `children` (which we have to do, to incorporate the new

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -454,9 +454,11 @@ def querySelectorAll(self, selector_text):
 
 However, this throws an error:[^7]
 
-    _dukpy.JSRuntimeError: EvalError:
-    Error while calling Python Function:
-    TypeError('Object of type Element is not JSON serializable')
+``` {.output}
+_dukpy.JSRuntimeError: EvalError:
+Error while calling Python Function:
+TypeError('Object of type Element is not JSON serializable')
+```
 
 [^7]: Yes, that's a confusing error message. Is it a `JSRuntimeError`,
     an `EvalError`, or a `TypeError`? The confusion is a consequence

--- a/book/security.md
+++ b/book/security.md
@@ -379,7 +379,7 @@ well.[^multiple-resources]
 When the browser visits a page, it needs to send the cookie for that
 site:
 
-``` {.python replace=(self/(self%2c%20top_level_url,cookie%20%3d/cookie%2c%20params%20%3d}
+``` {.python replace=(self/(self%2c%20referrer,cookie%20%3d/cookie%2c%20params%20%3d}
 class URL:
     def request(self, payload=None):
         # ...
@@ -396,7 +396,7 @@ Symmetrically, the browser has to update the cookie jar when it sees a
     `Set-Cookie` headers to set multiple cookies in one request,
     though our browser won't handle that correctly.
 
-``` {.python replace=(self/(self%2c%20top_level_url,%3d%20cookie/%3d%20(cookie%2c%20params)}
+``` {.python replace=(self/(self%2c%20referrer,%3d%20cookie/%3d%20(cookie%2c%20params)}
 class URL:
     def request(self, payload=None):
         # ...
@@ -809,7 +809,7 @@ requests.[^iow-links]
 First, let's modify `COOKIE_JAR` to store cookie/parameter pairs, and
 then parse those parameters out of `Set-Cookie` headers:
 
-``` {.python indent=4 replace=(self/(self%2c%20top_level_url}
+``` {.python indent=4 replace=(self/(self%2c%20referrer}
 def request(self, payload=None):
     if "set-cookie" in response_headers:
         cookie = response_headers["set-cookie"]
@@ -828,7 +828,7 @@ def request(self, payload=None):
 When sending a cookie in an HTTP request, the browser only sends the
 cookie value, not the parameters:
 
-``` {.python indent=4 replace=(self/(self%2c%20top_level_url}
+``` {.python indent=4 replace=(self/(self%2c%20referrer}
 def request(self, payload=None):
     if self.host in COOKIE_JAR:
         cookie, params = COOKIE_JAR[self.host]
@@ -837,11 +837,19 @@ def request(self, payload=None):
 
 This stores the `SameSite` parameter of a cookie. But to actually use
 it, we need to know which site an HTTP request is being made from.
-Let's add a new `top_level_url` parameter to `request` to track that:
+Let's add a new `referrer` parameter to `request` to track that:[^not-referrer]
+
+[^not-referrer]: The "referrer" is the web page that "referred" our
+    browser to make the current request. `SameSite` cookies are
+    actually supposed to [use the "top-level site"][samesite-def], not
+    the referrer, to determine if the cookies should be sent, but the
+    differences are subtle and I'm skipping them for simplicity.
+    
+[samesite-def]: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-same-site-00#section-2.1
 
 ``` {.python}
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         # ...
 ```
 
@@ -894,7 +902,7 @@ class JSContext:
         # ...
 ```
 
-The `request` function can now check the `top_level_url` argument
+The `request` function can now check the `referrer` argument
 before sending `SameSite` cookies. Remember that `SameSite` cookies
 are only sent for `GET` requests or if the new URL and the top-level
 URL have the same host name:[^schemeful]
@@ -911,20 +919,20 @@ URL have the same host name:[^schemeful]
 [origin-bound-cookies]: https://github.com/sbingler/Origin-Bound-Cookies
 
 ``` {.python indent=4}
-def request(self, top_level_url, payload=None):
+def request(self, referrer, payload=None):
     if self.host in COOKIE_JAR:
         # ...
         cookie, params = COOKIE_JAR[self.host]
         allow_cookie = True
-        if top_level_url and params.get("samesite", "none") == "lax":
+        if referrer and params.get("samesite", "none") == "lax":
             if method != "GET":
-                allow_cookie = self.host == top_level_url.host
+                allow_cookie = self.host == referrer.host
         if allow_cookie:
             request += "Cookie: {}\r\n".format(cookie)
         # ...
 ```
 
-Note that we check whether the `top_level_url` is set---it won't be
+Note that we check whether the `referrer` is set---it won't be
 when we're loading the first web page in a new tab.
 
 Our guest book can now mark its cookies `SameSite`:
@@ -1082,7 +1090,7 @@ to return the response headers:
 
 ``` {.python}
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         # ...
         return response_headers, content
 ```

--- a/book/security.md
+++ b/book/security.md
@@ -47,17 +47,17 @@ Here are the technical details. An HTTP response can contain a
 example, the following header sets the value of the `foo` cookie to
 `bar`:
 
-::: {.example}
-    Set-Cookie: foo=bar
-:::
+``` {.example}
+Set-Cookie: foo=bar
+```
     
 The browser remembers this key-value pair, and the next time it makes
 a request to the same server (cookies are site-specific), the browser
 echoes it back in the `Cookie` header:
 
-::: {.example}
-    Cookie: foo=bar
-:::
+``` {.example}
+Cookie: foo=bar
+```
 
 Servers can also set multiple cookies and also set parameters like
 expiration dates, but this `Set-Cookie` / `Cookie` mechanism is the
@@ -790,9 +790,9 @@ will not send them in cross-site form submissions.[^in-progress]
 
 A cookie is marked `SameSite` in the `Set-Cookie` header like this:
 
-::: {.example}
-    Set-Cookie: foo=bar; SameSite=Lax
-:::
+``` {.example}
+Set-Cookie: foo=bar; SameSite=Lax
+```
 
 The `SameSite` attribute can take the value `Lax`, `Strict`, or
 `None`, and as I write, browsers have and plan different defaults. Our
@@ -981,16 +981,16 @@ Note that `entry` can be anything, including anything the user might
 stick into our comment form. That includes HTML tags, like a custom
 `<script>` tag! So, a malicious user could post this comment:
 
-::: {.example}
-    Hi! <script src="http://my-server/evil.js"></script>
-:::
+``` {.html .example}
+Hi! <script src="http://my-server/evil.js"></script>
+```
 
 The server would then output this HTML:
 
-::: {.example}
-    <p>Hi! <script src="http://my-server/evil.js"></script>
-    <i>by crashoverride</i></p>
-:::
+``` {.html .example}
+<p>Hi! <script src="http://my-server/evil.js"></script>
+<i>by crashoverride</i></p>
+```
 
 Every user's browser would then download and run the `evil.js` script,
 which can send[^document-cookie][^cross-domain][^how-send] the cookies
@@ -1067,9 +1067,9 @@ specification for this header is quite complex, but in the simplest
 case, the header is set to the keyword `default-src` followed by a
 space-separated list of servers:
 
-::: {.example}
-    Content-Security-Policy: default-src http://example.org
-:::
+``` {.example}
+Content-Security-Policy: default-src http://example.org
+```
 
 This header asks the browser not to load any resources (including CSS,
 JavaScript, images, and so on) except from the listed origins. If our

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -26,7 +26,7 @@ import wbetools
 
 @wbetools.patch(URL)
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         s = socket.socket(
             family=socket.AF_INET,
             type=socket.SOCK_STREAM,
@@ -44,9 +44,9 @@ class URL:
         if self.host in COOKIE_JAR:
             cookie, params = COOKIE_JAR[self.host]
             allow_cookie = True
-            if top_level_url and params.get("samesite", "none") == "lax":
+            if referrer and params.get("samesite", "none") == "lax":
                 if method != "GET":
-                    allow_cookie = self.host == top_level_url.host
+                    allow_cookie = self.host == referrer.host
             if allow_cookie:
                 request += "Cookie: {}\r\n".format(cookie)
         if payload:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -49,7 +49,7 @@ from lab14 import parse_outline, paint_outline, \
 
 @wbetools.patch(URL)
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         s = socket.socket(
             family=socket.AF_INET,
             type=socket.SOCK_STREAM,
@@ -67,9 +67,9 @@ class URL:
         if self.host in COOKIE_JAR:
             cookie, params = COOKIE_JAR[self.host]
             allow_cookie = True
-            if top_level_url and params.get("samesite", "none") == "lax":
+            if referrer and params.get("samesite", "none") == "lax":
                 if method != "GET":
-                    allow_cookie = self.host == top_level_url.host
+                    allow_cookie = self.host == referrer.host
             if allow_cookie:
                 body += "Cookie: {}\r\n".format(cookie)
         if payload:

--- a/www/book.css
+++ b/www/book.css
@@ -163,7 +163,7 @@ body.main { padding: 0 4ex; }
   .note form { display: inline; }
 }
 
-.todo, .quirk, .warning, .installation, .further, .demo, .example { padding: 1em 1em 0; margin: 1em 0; }
+.todo, .quirk, .warning, .installation, .further, .demo { padding: 1em 1em 0; margin: 1em 0; }
 .quirk:before, .warning:before, .installation:before {
     font-weight: bold; font-family: 'Vollkorn', 'Garamond', serif;
     text-align: center;
@@ -185,7 +185,6 @@ img { max-width: 100%; }
 .further > :first-child:before { content: "Go further: "; font-weight: bold; color: green; }
 .widget { width: 100%; border: 2px solid navy; }
 .center { text-align: center }
-.example { border: 2px solid lightgray; padding: 1em }
 
 @media (prefers-color-scheme: dark) {
 .quirk { border: 2px solid #CBC3E3; }
@@ -212,6 +211,28 @@ code .kw { color: #a0a; }
 code .im { color: #a0a; }
 code .co { color: #C4A484; }
 }
+
+/* Tagging code blocks with where they go */
+pre.example::after, pre.output::after, .sourceCode[data-file]::after {
+    position: absolute; top: 0; right: 0; color: #888;
+    font: bold 83% 'Vollkorn', 'Garamond', serif;
+    padding: 1px 1ex; border: 2px solid #aaa;
+    pointer-events: none; /* So you can select / scroll under tag */
+}
+
+/* Note that ::after:hover is not supported in CSS so this is best we can do */
+pre.example:hover::after, pre.output:hover::after, .sourceCode[data-file]:hover::after {
+    opacity: 30%; /* In case it covers some code */
+}
+
+pre.example::after { content: "Example code"; }
+pre.output::after { content: "Example output"; }
+.sourceCode[data-file=server]::after { content: "server.py" }
+.sourceCode[data-file=runtime]::after { content: "runtime.js" }
+.sourceCode[data-file=comment]::after { content: "comment.js" }
+.sourceCode[data-file=eventloop]::after { content: "eventloop.js" } /* Named in a code block! */
+.sourceCode[data-file^=lab]::after { } /* Not tagged because still browser */
+.sourceCode[data-file^=example]::after { content: "Example code"; } /* All examples */
 
 .todo { background: darkred; color: white; padding-bottom: 1em; }
 .todo:before { content: "This book is a work in progress:"; }


### PR DESCRIPTION
This PR closes #1155 by renaming `top_level_url` to `referrer` and leaving a footnote noting the difference.