### PR TITLE
Change `top_level_url` to `referrer` (close #1155)

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -62,7 +62,7 @@ The change is pretty minimal: instead of passing the `"r"` flag to
 
 ``` {.python}
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         # ...
         response = s.makefile("b")
         # ...
@@ -74,7 +74,7 @@ parser code to explicitly `decode` the data:
 
 ``` {.python}
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         # ...
         statusline = response.readline().decode("utf8")
         # ...

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -26,7 +26,7 @@ import wbetools
 
 @wbetools.patch(URL)
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         s = socket.socket(
             family=socket.AF_INET,
             type=socket.SOCK_STREAM,
@@ -44,9 +44,9 @@ class URL:
         if self.host in COOKIE_JAR:
             cookie, params = COOKIE_JAR[self.host]
             allow_cookie = True
-            if top_level_url and params.get("samesite", "none") == "lax":
+            if referrer and params.get("samesite", "none") == "lax":
                 if method != "GET":
-                    allow_cookie = self.host == top_level_url.host
+                    allow_cookie = self.host == referrer.host
             if allow_cookie:
                 request += "Cookie: {}\r\n".format(cookie)
         if payload:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -49,7 +49,7 @@ from lab14 import parse_outline, paint_outline, \
 
 @wbetools.patch(URL)
 class URL:
-    def request(self, top_level_url, payload=None):
+    def request(self, referrer, payload=None):
         s = socket.socket(
             family=socket.AF_INET,
             type=socket.SOCK_STREAM,
@@ -67,9 +67,9 @@ class URL:
         if self.host in COOKIE_JAR:
             cookie, params = COOKIE_JAR[self.host]
             allow_cookie = True
-            if top_level_url and params.get("samesite", "none") == "lax":
+            if referrer and params.get("samesite", "none") == "lax":
                 if method != "GET":
-                    allow_cookie = self.host == top_level_url.host
+                    allow_cookie = self.host == referrer.host
             if allow_cookie:
                 body += "Cookie: {}\r\n".format(cookie)
         if payload:


### PR DESCRIPTION
This PR closes #1155 by renaming `top_level_url` to `referrer` and leaving a footnote noting the difference.