### PR TITLE
Always create and indent `skia.Paint` objects in the same way

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -258,7 +258,9 @@ class DrawImage(PaintCommand):
         self.quality = parse_image_rendering(quality)
 
     def execute(self, canvas):
-        paint = skia.Paint(FilterQuality=self.quality)
+        paint = skia.Paint(
+            FilterQuality=self.quality,
+        )
         canvas.drawImageRect(self.image, self.rect, paint)
 ```
 

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -434,9 +434,9 @@ class DrawLine:
         path = skia.Path().moveTo(self.x1 - scroll, self.y1) \
                           .lineTo(self.x2 - scroll, self.y2)
         paint = skia.Paint(
-            Style=skia.Paint.kStroke_Style,
-            StrokeWidth=self.thickness,
             Color=parse_color(self.color),
+            StrokeWidth=self.thickness,
+            Style=skia.Paint.kStroke_Style,
         )
         canvas.drawPath(path, paint)
 ```
@@ -523,9 +523,9 @@ the `Paint` to `Stroke_Style`:
 class DrawOutline:
     def execute(self, scroll, canvas):
         paint = skia.Paint(
-            Style=skia.Paint.kStroke_Style,
-            StrokeWidth=self.thickness,
             Color=parse_color(self.color),
+            StrokeWidth=self.thickness,
+            Style=skia.Paint.kStroke_Style,
         )
         canvas.drawRect(self.rect.makeOffset(0, -scroll), paint)
 ```

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -433,9 +433,11 @@ class DrawLine:
     def execute(self, canvas, scroll):
         path = skia.Path().moveTo(self.x1 - scroll, self.y1) \
                           .lineTo(self.x2 - scroll, self.y2)
-        paint = skia.Paint(Color=parse_color(self.color))
-        paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(self.thickness)
+        paint = skia.Paint(
+            Style=skia.Paint.kStroke_Style,
+            StrokeWidth=self.thickness,
+            Color=parse_color(self.color),
+        )
         canvas.drawPath(path, paint)
 ```
 
@@ -457,7 +459,9 @@ We do something similar to draw text using `drawString`:
 class DrawText:
     def execute(self, canvas, scroll):
         paint = skia.Paint(
-            AntiAlias=True, Color=parse_color(self.color))
+            AntiAlias=True,
+            Color=parse_color(self.color),
+        )
         baseline = self.top - scroll - self.font.getMetrics().fAscent
         canvas.drawString(self.text, float(self.left), baseline,
             self.font, paint)
@@ -478,8 +482,9 @@ Finally, for drawing rectangles you use `drawRect`:
 ``` {.python replace=%2c%20scroll/,rect.makeOffset(0%2c%20-scroll)/rect}
 class DrawRect:
     def execute(self, canvas, scroll):
-        paint = skia.Paint()
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Color=parse_color(self.color),
+        )
         canvas.drawRect(self.rect.makeOffset(0, -scroll), paint)
 ```
 
@@ -517,10 +522,11 @@ the `Paint` to `Stroke_Style`:
 ``` {.python replace=%2c%20scroll/,rect.makeOffset(0%2c%20-scroll)/rect}
 class DrawOutline:
     def execute(self, scroll, canvas):
-        paint = skia.Paint()
-        paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(self.thickness)
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Style=skia.Paint.kStroke_Style,
+            StrokeWidth=self.thickness,
+            Color=parse_color(self.color),
+        )
         canvas.drawRect(self.rect.makeOffset(0, -scroll), paint)
 ```
 
@@ -605,9 +611,10 @@ class DrawRRect:
         self.color = color
 
     def execute(self, scroll, canvas):
-        sk_color = parse_color(self.color)
-        canvas.drawRRect(self.rrect,
-            paint=skia.Paint(Color=sk_color))
+        paint = skia.Paint(
+            Color=parse_color(self.color),
+        )
+        canvas.drawRRect(self.rrect, paint)
 ```
 
 Then we can draw these rounded rectangles for backgrounds:
@@ -859,8 +866,9 @@ command's `execute` method:
 ``` {.python}
 class DrawRect:
     def execute(self, canvas):
-        paint = skia.Paint()
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Color=parse_color(self.color),
+        )
         canvas.drawRect(self.rect, paint)
 ```
 
@@ -1055,7 +1063,7 @@ that that effect will be applied to, like this:
 
 ``` {.python .example}
 # draw parent
-canvas.saveLayer(paint=skia.Paint(Alphaf=0.5))
+canvas.saveLayer(skia.Paint(Alphaf=0.5))
 # draw children
 canvas.restore()
 ```
@@ -1092,8 +1100,10 @@ class Opacity:
             self.rect.join(cmd.rect)
 
     def execute(self, canvas):
-        paint = skia.Paint(Alphaf=self.opacity)
-        canvas.saveLayer(paint=paint)
+        paint = skia.Paint(
+            Alphaf=self.opacity
+        )
+        canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         canvas.restore()
@@ -1371,8 +1381,9 @@ class Blend:
 
     def execute(self, canvas):
         paint = skia.Paint(
-            BlendMode=parse_blend_mode(self.blend_mode))
-        canvas.saveLayer(paint=paint)
+            BlendMode=parse_blend_mode(self.blend_mode),
+        )
+        canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         canvas.restore()
@@ -1627,9 +1638,11 @@ opacity is actually applied:
 ``` {.python file=examples11.py}
 class Opacity:
     def execute(self, canvas):
-        paint = skia.Paint(Alphaf=self.opacity)
+        paint = skia.Paint(
+            Alphaf=self.opacity,
+        )
         if self.opacity < 1:
-            canvas.saveLayer(paint=paint)
+            canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.opacity < 1:
@@ -1670,9 +1683,10 @@ Anyway, now `Blend` can skip `saveLayer` if no blend mode is passed:
 class Blend:
     def execute(self, canvas):
         paint = skia.Paint(
-            BlendMode=parse_blend_mode(self.blend_mode))
+            BlendMode=parse_blend_mode(self.blend_mode),
+        )
         if self.blend_mode:
-            canvas.saveLayer(paint=paint)
+            canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.blend_mode:
@@ -1706,9 +1720,10 @@ class Blend:
     def execute(self, canvas):
         paint = skia.Paint(
             Alphaf=self.opacity,
-            BlendMode=parse_blend_mode(self.blend_mode))
+            BlendMode=parse_blend_mode(self.blend_mode),
+        )
         if self.should_save:
-            canvas.saveLayer(paint=paint)
+            canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.should_save:

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -235,11 +235,6 @@ LIBRARY_METHODS = [
     # skia.GrDirectContext
     "MakeGL",
 
-    # skia.Paint
-    "setStyle",
-    "setColor",
-    "getAlphaf",
-
     # skia.Surface
     "makeImageSnapshot",
     "height",

--- a/src/examples11.py
+++ b/src/examples11.py
@@ -70,7 +70,7 @@ class Opacity:
     def execute(self, canvas):
         paint = skia.Paint(Alphaf=self.opacity)
         if self.opacity < 1:
-            canvas.saveLayer(paint=paint)
+            canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.opacity < 1:

--- a/src/examples11.py
+++ b/src/examples11.py
@@ -68,7 +68,9 @@ class Opacity:
             self.rect.join(cmd.rect)
 
     def execute(self, canvas):
-        paint = skia.Paint(Alphaf=self.opacity)
+        paint = skia.Paint(
+            Alphaf=self.opacity,
+        )
         if self.opacity < 1:
             canvas.saveLayer(paint)
         for cmd in self.children:

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -107,7 +107,7 @@ class Blend:
     def execute(self, canvas):
         paint = skia.Paint(
             Alphaf=self.opacity,
-            BlendMode=parse_blend_mode(self.blend_mode)
+            BlendMode=parse_blend_mode(self.blend_mode),
         )
         if self.should_save:
             canvas.saveLayer(paint)
@@ -124,7 +124,7 @@ class DrawRect:
 
     def execute(self, canvas):
         paint = skia.Paint(
-            Color=parse_color(self.color)
+            Color=parse_color(self.color),
         )
         canvas.drawRect(self.rect, paint)
 
@@ -150,7 +150,7 @@ class DrawText:
     def execute(self, canvas):
         paint = skia.Paint(
             AntiAlias=True,
-            Color=parse_color(self.color)
+            Color=parse_color(self.color),
         )
         baseline = self.top - self.font.getMetrics().fAscent
         canvas.drawString(self.text, float(self.left), baseline,
@@ -167,7 +167,7 @@ class DrawOutline:
         paint = skia.Paint(
             Style=skia.Paint.kStroke_Style,
             StrokeWidth=self.thickness,
-            Color=self.color,
+            Color=parse_color(self.color),
         )
         canvas.drawRect(self.rect, paint)
 
@@ -186,7 +186,7 @@ class DrawLine:
         path = skia.Path().moveTo(self.x1, self.y1) \
                           .lineTo(self.x2, self.y2)
         paint = skia.Paint(
-            Style=skia.Paint.kStrokeStyle,
+            Style=skia.Paint.kStroke_Style,
             StrokeWidth=self.thickness,
             Color=parse_color(self.color),
         )

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -165,9 +165,9 @@ class DrawOutline:
 
     def execute(self, canvas):
         paint = skia.Paint(
-            Style=skia.Paint.kStroke_Style,
-            StrokeWidth=self.thickness,
             Color=parse_color(self.color),
+            StrokeWidth=self.thickness,
+            Style=skia.Paint.kStroke_Style,
         )
         canvas.drawRect(self.rect, paint)
 
@@ -186,9 +186,9 @@ class DrawLine:
         path = skia.Path().moveTo(self.x1, self.y1) \
                           .lineTo(self.x2, self.y2)
         paint = skia.Paint(
-            Style=skia.Paint.kStroke_Style,
-            StrokeWidth=self.thickness,
             Color=parse_color(self.color),
+            StrokeWidth=self.thickness,
+            Style=skia.Paint.kStroke_Style,
         )
         canvas.drawPath(path, paint)
 

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -107,9 +107,10 @@ class Blend:
     def execute(self, canvas):
         paint = skia.Paint(
             Alphaf=self.opacity,
-            BlendMode=parse_blend_mode(self.blend_mode))
+            BlendMode=parse_blend_mode(self.blend_mode)
+        )
         if self.should_save:
-            canvas.saveLayer(paint=paint)
+            canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.should_save:
@@ -122,8 +123,9 @@ class DrawRect:
         self.color = color
 
     def execute(self, canvas):
-        paint = skia.Paint()
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Color=parse_color(self.color)
+        )
         canvas.drawRect(self.rect, paint)
 
     @wbetools.js_hide
@@ -147,7 +149,9 @@ class DrawText:
 
     def execute(self, canvas):
         paint = skia.Paint(
-            AntiAlias=True, Color=parse_color(self.color))
+            AntiAlias=True,
+            Color=parse_color(self.color)
+        )
         baseline = self.top - self.font.getMetrics().fAscent
         canvas.drawString(self.text, float(self.left), baseline,
             self.font, paint)
@@ -160,10 +164,11 @@ class DrawOutline:
         self.thickness = thickness
 
     def execute(self, canvas):
-        paint = skia.Paint()
-        paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(self.thickness)
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Style=skia.Paint.kStroke_Style,
+            StrokeWidth=self.thickness,
+            Color=self.color,
+        )
         canvas.drawRect(self.rect, paint)
 
 @wbetools.patch(DrawLine)
@@ -180,9 +185,11 @@ class DrawLine:
     def execute(self, canvas):
         path = skia.Path().moveTo(self.x1, self.y1) \
                           .lineTo(self.x2, self.y2)
-        paint = skia.Paint(Color=parse_color(self.color))
-        paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(self.thickness)
+        paint = skia.Paint(
+            Style=skia.Paint.kStrokeStyle,
+            StrokeWidth=self.thickness,
+            Color=parse_color(self.color),
+        )
         canvas.drawPath(path, paint)
 
 class DrawRRect:
@@ -192,9 +199,10 @@ class DrawRRect:
         self.color = color
 
     def execute(self, canvas):
-        sk_color = parse_color(self.color)
-        canvas.drawRRect(self.rrect,
-            paint=skia.Paint(Color=sk_color))
+        paint = skia.Paint(
+            Color=parse_color(self.color),
+        )
+        canvas.drawRRect(self.rrect, paint)
 
 def paint_tree(layout_object, display_list):
     cmds = []

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -125,10 +125,13 @@ class DrawLine(PaintCommand):
         self.thickness = thickness
 
     def execute(self, canvas):
-        path = skia.Path().moveTo(self.x1, self.y1).lineTo(self.x2, self.y2)
-        paint = skia.Paint(Color=parse_color(self.color))
-        paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(self.thickness)
+        path = skia.Path().moveTo(self.x1, self.y1) \
+                          .lineTo(self.x2, self.y2)
+        paint = skia.Paint(
+            Style=skia.Paint.kStrokeStyle,
+            StrokeWidth=self.thickness,
+            Color=parse_color(self.color),
+        )
         canvas.drawPath(path, paint)
 
     def __repr__(self):
@@ -142,9 +145,10 @@ class DrawRRect(PaintCommand):
         self.color = color
 
     def execute(self, canvas):
-        sk_color = parse_color(self.color)
-        canvas.drawRRect(self.rrect,
-            paint=skia.Paint(Color=sk_color))
+        paint = skia.Paint(
+            Color=parse_color(self.color),
+        )
+        canvas.drawRRect(self.rrect, paint)
 
     def print(self, indent=0):
         return " " * indent + self.__repr__()
@@ -166,7 +170,10 @@ class DrawText(PaintCommand):
             self.right, self.bottom))
 
     def execute(self, canvas):
-        paint = skia.Paint(AntiAlias=True, Color=parse_color(self.color))
+        paint = skia.Paint(
+            AntiAlias=True,
+            Color=parse_color(self.color)
+        )
         baseline = self.top - self.font.getMetrics().fAscent
         canvas.drawString(self.text, float(self.left), baseline,
             self.font, paint)
@@ -184,8 +191,9 @@ class DrawRect(PaintCommand):
         self.color = color
 
     def execute(self, canvas):
-        paint = skia.Paint()
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Color=parse_color(self.color),
+        )
         canvas.drawRect(self.rect, paint)
 
     def __repr__(self):
@@ -201,10 +209,11 @@ class DrawOutline(PaintCommand):
         self.thickness = thickness
 
     def execute(self, canvas):
-        paint = skia.Paint()
-        paint.setStyle(skia.Paint.kStroke_Style)
-        paint.setStrokeWidth(self.thickness)
-        paint.setColor(parse_color(self.color))
+        paint = skia.Paint(
+            Style=skia.Paint.kStroke_Style,
+            StrokeWidth=self.thickness,
+            Color=parse_color(self.color),
+        )
         canvas.drawRect(self.rect, paint)
 
     @wbetools.js_hide
@@ -234,9 +243,10 @@ class Blend(VisualEffect):
     def execute(self, canvas):
         paint = skia.Paint(
             Alphaf=self.opacity,
-            BlendMode=parse_blend_mode(self.blend_mode))
+            BlendMode=parse_blend_mode(self.blend_mode)
+        )
         if self.should_save:
-            canvas.saveLayer(paint=paint)
+            canvas.saveLayer(paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.should_save:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -128,9 +128,9 @@ class DrawLine(PaintCommand):
         path = skia.Path().moveTo(self.x1, self.y1) \
                           .lineTo(self.x2, self.y2)
         paint = skia.Paint(
-            Style=skia.Paint.kStroke_Style,
-            StrokeWidth=self.thickness,
             Color=parse_color(self.color),
+            StrokeWidth=self.thickness,
+            Style=skia.Paint.kStroke_Style,
         )
         canvas.drawPath(path, paint)
 
@@ -210,9 +210,9 @@ class DrawOutline(PaintCommand):
 
     def execute(self, canvas):
         paint = skia.Paint(
-            Style=skia.Paint.kStroke_Style,
-            StrokeWidth=self.thickness,
             Color=parse_color(self.color),
+            StrokeWidth=self.thickness,
+            Style=skia.Paint.kStroke_Style,
         )
         canvas.drawRect(self.rect, paint)
 

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -128,7 +128,7 @@ class DrawLine(PaintCommand):
         path = skia.Path().moveTo(self.x1, self.y1) \
                           .lineTo(self.x2, self.y2)
         paint = skia.Paint(
-            Style=skia.Paint.kStrokeStyle,
+            Style=skia.Paint.kStroke_Style,
             StrokeWidth=self.thickness,
             Color=parse_color(self.color),
         )

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1127,14 +1127,6 @@ class Tab:
         self.dark_mode = val
         self.set_needs_render()
 
-def draw_line(canvas, x1, y1, x2, y2, color):
-    sk_color = parse_color(color)
-    path = skia.Path().moveTo(x1, y1).lineTo(x2, y2)
-    paint = skia.Paint(Color=sk_color)
-    paint.setStyle(skia.Paint.kStroke_Style)
-    paint.setStrokeWidth(1)
-    canvas.drawPath(path, paint)
-
 @wbetools.patch(Chrome)
 class Chrome:
     def paint(self):

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -127,7 +127,9 @@ class DrawImage(PaintCommand):
         self.quality = parse_image_rendering(quality)
 
     def execute(self, canvas):
-        paint = skia.Paint(FilterQuality=self.quality)
+        paint = skia.Paint(
+            FilterQuality=self.quality,
+        )
         canvas.drawImageRect(self.image, self.rect, paint)
 
     @wbetools.js_hide


### PR DESCRIPTION
This PR makes sure we always use `skia.Paint` in the same way, namely like this:

```
paint = skia.Paint(
    prop=value,
    ...
)
canvas.drawXXX(xxx, paint)
```

In other words, we now:

- Always create the whole `Paint` object at once, instead of using `setXXX` methods
- Always pass it to `drawXXX` as a positional argument, not a keyword one
- Always put the property/value pairs one per line with a comma at the end

The specific style isn't actually important (willing to discuss other options; I wouldn't be against, for example, never creating `Paint` objects at all and always using convertability from dicts) but just that we always do the same thing the same way so that readers aren't confused.