### PR TITLE
Pin Skia version to 87.* and explain why

### DIFF
--- a/book/porting.md
+++ b/book/porting.md
@@ -1,0 +1,46 @@
+---
+title: Porting *WBE* to Recent Software Releases
+...
+
+The code in this book was developed for and tested on particular
+versions of the libraries it depends on, including Python 3.11, Skia
+87, Tk 8.6.14, DukPy 0.3.0, and PySDL2 0.9.15. This page documents
+code changes necessary to port the code of *Web Browser Engineering*
+to the most recent release of each library. It will be regularly
+updated as new versions are released and tested.
+
+Porting to Skia 124
+-------------------
+
+Skia 124, and the associated skia-python 124b6 release, changes a
+could of APIs used in this book. One major change is the removal of
+`FilterQuality`, used in [Chapter 15](embeds.md), and its replacement
+by `SamplingOptions`. This requires replacing `parse_image_rendering`
+like so:
+
+``` {.python}
+def parse_image_rendering(quality):
+    if quality == "high-quality":
+        return skia.SamplingOptions(skia.CubicResampler.Mitchell())
+    elif quality == "crisp-edges":
+        return skia.SamplingOptions(skia.FilterMode.kNearest, skia.MipmapMode.kNone)
+    else:
+        return skia.SamplingOptions(skia.FilterMode.kLinear, skia.MipmapMode.kLinear)
+```
+
+And changing the `execute` method of `DrawImage` like so:
+
+``` {.python}
+class DrawImage:
+    def execute(self, canvas):
+        canvas.drawImageRect(self.image, self.rect, self.quality)
+```
+
+The new API is somewhat cleaner and more customizable.
+ 
+Additionally, this release has difficulties drawing anti-aliased text
+and lines on macOS, and writes error messages about shader compilation
+to the console. These are believed to be due to compatibility issues
+between Skia 124's GL backend and the macOS GL implementation. Future
+versions of Skia may resolve these issues by switching to an
+alternative, Metal-based backend on macOS.

--- a/book/porting.md
+++ b/book/porting.md
@@ -3,7 +3,7 @@ title: Porting *WBE* to Recent Software Releases
 ...
 
 The code in this book was developed for and tested on particular
-versions of the libraries it depends on, including Python 3.11, Skia
+versions of the libraries it depends on, including Python 3.12, Skia
 87, Tk 8.6.14, DukPy 0.3.0, and PySDL2 0.9.15. This page documents
 code changes necessary to port the code of *Web Browser Engineering*
 to the most recent release of each library. It will be regularly
@@ -12,11 +12,12 @@ updated as new versions are released and tested.
 Porting to Skia 124
 -------------------
 
-Skia 124, and the associated skia-python 124b6 release, changes a
-could of APIs used in this book. One major change is the removal of
-`FilterQuality`, used in [Chapter 15](embeds.md), and its replacement
-by `SamplingOptions`. This requires replacing `parse_image_rendering`
-like so:
+The text of this book uses Skia 87, and the associated skia-python
+87.6 release. Skia 124, and the associated skia-python 124b7 release,
+changes a couple of APIs used in this book. One major change is the
+removal of `FilterQuality`, used in [Chapter 15](embeds.md), and its
+replacement by `SamplingOptions`. This requires updating
+`parse_image_rendering` like so:
 
 ``` {.python}
 def parse_image_rendering(quality):
@@ -38,9 +39,9 @@ class DrawImage:
 
 The new API is somewhat cleaner and more customizable.
  
-Additionally, this release has difficulties drawing anti-aliased text
-and lines on macOS, and writes error messages about shader compilation
-to the console. These are believed to be due to compatibility issues
-between Skia 124's GL backend and the macOS GL implementation. Future
-versions of Skia may resolve these issues by switching to an
-alternative, Metal-based backend on macOS.
+Additionally, as of our latest testing, this release has difficulties
+drawing anti-aliased text and lines on macOS, and writes error
+messages about shader compilation to the console. These are believed
+to be due to compatibility issues between Skia 124's GL backend and
+the macOS GL implementation. Future versions of Skia may resolve these
+issues by switching to an alternative, Metal-based backend on macOS.

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -39,7 +39,7 @@ graphics cards and GPUs became widespread.
 ::: {.installation}
 Start by installing [Skia][skia-python] and [SDL][sdl-python]:
 
-    python3 -m pip install skia-python pysdl2 pysdl2-dll
+    python3 -m pip install skia-python==87 pysdl2 pysdl2-dll
 
 As elsewhere in this book, you may need to install the `pip` package
 first, or use your IDE's package installer. If you're on Linux, you'll
@@ -48,6 +48,15 @@ Also, you may not be able to install `pysdl2-dll`; if so, you'll need
 to find SDL in your system package manager instead. Consult the
 [`skia-python`][skia-python] and [`pysdl2`][sdl-python] web pages for
 more details.
+
+Note that I'm explicitly installing Skia version 87. Skia makes
+regular releases that change APIs or break compatibility; version 87
+is fairly old and should work reliably on most systems. In your own
+projects, or before filing bug reports in Skia, please do use more
+recent Skia releases. It's also possible that future Python version no
+longer support Skia 87; our [porting notes](porting.md) explain how
+to use recent Skia releases for the code in this book.
+
 :::
 
 [skia-python]: https://kyamagu.github.io/skia-python/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 dukpy==0.3.0
 
 # Skia is used in Chapters 11+ for advanced graphics
-skia-python==87.5
+skia-python==87
 pybind11==2.10.4
 
 # SDL2 is used in Chapters 11+ for a Skia-compatible GUI


### PR DESCRIPTION
I've discussed this with the Skia-Python maintainers and I think the conclusion we've come to (I'll send them this PR and ask if they agree!) is to release a new 87.6 release that supports Python 3.12 but otherwise has minimal changes from 87.5, and to pin that version in the book. To that end, I've added a paragraph about the version issue, asked users to check recent Skia versions before filing bugs, and added a new page about porting (not linked from the table of contents so that it's not included in the printed book, but which we can link after that's done).

@HinTak, @kyamagu, hopefully you agree with the text, if not, there's about a week to change it.