### PR TITLE
Filter out internal links in print format

### DIFF
--- a/book/preface.md
+++ b/book/preface.md
@@ -45,8 +45,7 @@ to the implementation you have built, the book says "your browser".
 [^jrwilcox-idea]: This idea is from [J.R. Wilcox][jrw], inspired in
 turn by [S. Zdancewic][sz]'s course on compilers.
 
-The code in this book [uses Python
-3](blog/why-python.md),\index{Python} and we recommend you follow
+The code in this book uses Python 3,\index{Python} and we recommend you follow
 along in the same. When the book shows Python command lines, it calls
 the Python binary `python3`.[^py3-cmd] That said, the text avoids
 dependencies where possible and you can try to follow along in another

--- a/book/preface.md
+++ b/book/preface.md
@@ -45,7 +45,7 @@ to the implementation you have built, the book says "your browser".
 [^jrwilcox-idea]: This idea is from [J.R. Wilcox][jrw], inspired in
 turn by [S. Zdancewic][sz]'s course on compilers.
 
-The code in this book uses Python 3,\index{Python} and we recommend you follow
+The code in this book uses [Python 3](https://browserbook.substack.com/p/why-python),\index{Python} and we recommend you follow
 along in the same. When the book shows Python command lines, it calls
 the Python binary `python3`.[^py3-cmd] That said, the text avoids
 dependencies where possible and you can try to follow along in another

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -54,7 +54,7 @@ regular releases that change APIs or break compatibility; version 87
 is fairly old and should work reliably on most systems. In your own
 projects, or before filing bug reports in Skia, please do use more
 recent Skia releases. It's also possible that future Python version no
-longer support Skia 87; our [porting notes](porting.md) explain how
+longer support Skia 87; our [porting notes](https://browser.engineering/porting.html) explain how
 to use recent Skia releases for the code in this book.
 
 :::

--- a/infra/filter.lua
+++ b/infra/filter.lua
@@ -42,15 +42,17 @@ end
 
 function DisableLinks(el)
   -- Links to Markdown files now link to HTML files
-  if config.print then
-     -- do nothing
-  elseif is_disabled(el.target) then
+  if is_disabled(el.target) then
     el = pandoc.Span(el.content)
     el.classes = { "link" }
-  elseif el.target:find("%.md$") and not el.target:find("://") then
+  elseif not config.print and el.target:find("%.md$") and not el.target:find("://") then
     el.target = string.gsub(el.target, "%.md", ".html")
-  elseif el.target:find("%.md#") and not el.target:find("://") then
+  elseif not config.print and el.target:find("%.md#") and not el.target:find("://") then
     el.target = string.gsub(el.target, "%.md#", ".html#")
+  elseif config.print and (el.target:find("%.md$") or el.target:find("%.md#"))
+         and not el.target:find("://") then
+    el = pandoc.Span(el.content)
+    el.classes = { "link" } -- this does nothing, just there for parallelism with is_disabled
   end
   return el
 end


### PR DESCRIPTION
This PR modifies `filter.lua` to drop internal links when building in print mode. It also fixes two links that I found when testing. I tested it and the PDF indeed no longer has the links. I also examined the list of filtered-out links and they were all good. (I believe `classes.md` isn't in the book itself, so I've left its link to `index.md` in place.)