### PR TITLE
Clean outline

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -523,8 +523,7 @@ Let's store that in a new file, `browser.css`, and have our browser
 read it when it starts:
 
 ``` {.python replace=browser/browser6}
-browser_styles = open("browser.css")
-DEFAULT_STYLE_SHEET = CSSParser(browser_styles.read()).parse()
+DEFAULT_STYLE_SHEET = CSSParser(open("browser.css").read()).parse()
 ```
 
 Now, when the browser loads a web page, it can apply that default

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -144,7 +144,7 @@ class ResolvePatches(ast.NodeTransformer):
             return None
 
     def visit_ClassDef(self, cmd):
-        if not cmd.decorator_list:
+        if not cmd.decorator_list or not is_patch_decorator(cmd.decorator_list[0]):
             patches = self.patches.get(cmd.name, [])
             if patches:
                 body2 = {}

--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -170,7 +170,7 @@ class ResolvePatches(ast.NodeTransformer):
 class ResolveJSHide(ast.NodeTransformer):
     def visit_FunctionDef(self, cmd):
         if any([
-                isinstance(dec, ast.Attribute) and dec.attr == "js_hide"
+                isinstance(dec, ast.Attribute) and dec.attr in ["js_hide", "delete"]
                 and isinstance(dec.value, ast.Name) and dec.value.id == "wbetools"
                 for dec in cmd.decorator_list
         ]):

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -357,6 +357,8 @@ def compile_method(base, name, args, ctx):
         return base_js + "." + name + "(" + ", ".join(args_js) + ")"
     elif base_js in RT_IMPORTS:
         return base_js + "." + name + "(" + ", ".join(args_js) + ")"
+    elif name == "read" and isinstance(base, ast.Call) and isinstance(base.func, ast.Name) and base.func.id == "open":
+        return base_js + ".read()"
     elif name == "keys":
         assert len(args) == 0
         return "Object.keys(" + base_js + ")"

--- a/infra/outlines.py
+++ b/infra/outlines.py
@@ -92,6 +92,12 @@ def write_html(objs, indent=0):
         print("</code>")
 
 def to_item(cmd):
+    if hasattr(cmd, "decorator_list") and any([
+            isinstance(dec, ast.Attribute) and dec.attr == 'outline_hide'
+            and isinstance(dec.value, ast.Name) and dec.value.id == "wbetools"
+            for dec in cmd.decorator_list
+    ]):
+        return None
     if isinstance(cmd, ast.ClassDef):
         return Class(cmd.name, [to_item(scmd) for scmd in cmd.body])
     elif isinstance(cmd, ast.FunctionDef):

--- a/infra/outlines.py
+++ b/infra/outlines.py
@@ -21,7 +21,7 @@ class Function(Item):
         return "def {}({})".format(self.name, ", ".join(args))
 
     def html(self):
-        return self.str().replace("def", "<span class=kw>def</span>")
+        return "<span class=kw>def</span> {}({})".format(self.name, ", ".join(args))
 
     def sub(self):
         return None
@@ -35,7 +35,7 @@ class Class:
         return "class {}:".format(self.name)
 
     def html(self):
-        return self.str().replace("class", "<span class=kw>class</span>")
+        return "<span class=kw>class</span> {}:".format(self.name)
 
     def sub(self):
         return self.fns

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -30,7 +30,7 @@ from lab10 import COOKIE_JAR, JSContext, URL
 from lab11 import get_font, DrawLine, DrawRect, DrawOutline
 from lab11 import linespace, DrawText, Blend
 from lab11 import BlockLayout, LineLayout, TextLayout, InputLayout, Chrome
-from lab11 import Tab, Browser, paint_tree, parse_color
+from lab11 import Tab, Browser, paint_tree, parse_color, parse_blend_mode
 from lab11 import NAMED_COLORS, FONTS
 
 class MeasureTime:

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -348,6 +348,7 @@ class Task:
         self.task_code = None
         self.args = None
 
+@wbetools.outline_hide
 class SingleThreadedTaskRunner:
     def __init__(self, tab):
         self.tab = tab

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -780,8 +780,6 @@ class JSContext:
             self.XMLHttpRequest_send)
         self.interp.export_function("setTimeout",
             self.setTimeout)
-        self.interp.export_function("now",
-            self.now)
         self.interp.export_function("requestAnimationFrame",
             self.requestAnimationFrame)
         self.tab.browser.measure.time('script-runtime')
@@ -810,9 +808,6 @@ class JSContext:
         elt = self.handle_to_node[handle]
         elt.attributes["style"] = s;
         self.tab.set_needs_render()
-
-    def now(self):
-        return int(time.time() * 1000)
 
 def parse_transition(value):
     properties = {}
@@ -1159,6 +1154,7 @@ class CommitData:
         self.display_list = display_list
         self.composited_updates = composited_updates
 
+@wbetools.js_hide
 def print_composited_layers(composited_layers):
     print("Composited layers:")
     for layer in composited_layers:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -39,7 +39,7 @@ from lab11 import parse_color, parse_blend_mode
 from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner, Chrome
 from lab12 import Task, REFRESH_RATE_SEC
 from lab13 import JSContext, diff_styles, add_parent_pointers
-from lab13 import local_to_absolute, absolute_bounds_for_obj
+from lab13 import local_to_absolute, absolute_bounds_for_obj, absolute_to_local
 from lab13 import NumericAnimation
 from lab13 import map_translation, parse_transform
 from lab13 import CompositedLayer, paint_visual_effects

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -279,9 +279,6 @@ class LineLayout:
 
         return cmds
 
-    def role(self):
-        return "none"
-
     @wbetools.js_hide
     def __repr__(self):
         return "LineLayout(x={}, y={}, width={}, height={})".format(
@@ -1540,11 +1537,13 @@ class Browser:
         else:
             print(text)
 
+    @wbetools.js_hide
     def toggle_mute(self):
         self.lock.acquire(blocking=True)
         self.muted = not self.muted
         self.lock.release()
 
+    @wbetools.js_hide
     def is_muted(self):
         return self.muted
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -554,15 +554,6 @@ class TextLayout:
         return ("TextLayout(x={}, y={}, width={}, height={}, word={})").format(
             self.x, self.y, self.width, self.height, self.word)
 
-def filter_quality(node):
-    attr = node.style.get("image-rendering", "auto")
-    if attr == "high-quality":
-        return skia.FilterQuality.kHigh_FilterQuality
-    elif attr == "crisp-edges":
-        return skia.FilterQuality.kLow_FilterQuality
-    else:
-        return skia.FilterQuality.kMedium_FilterQuality
-
 class ImageLayout(EmbedLayout):
     def __init__(self, node, parent, previous, frame):
         super().__init__(node, parent, previous, frame)
@@ -682,6 +673,7 @@ class IframeLayout(EmbedLayout):
         return "IframeLayout(src={}, x={}, y={}, width={}, height={})".format(
             self.node.attributes["src"], self.x, self.y, self.width, self.height)
 
+@wbetools.outline_hide
 class AttributeParser:
     def __init__(self, s):
         self.s = s

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -34,7 +34,7 @@ from lab11 import parse_color, parse_blend_mode
 from lab12 import MeasureTime, REFRESH_RATE_SEC
 from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
 from lab13 import diff_styles, parse_transition, add_parent_pointers
-from lab13 import local_to_absolute, absolute_bounds_for_obj
+from lab13 import local_to_absolute, absolute_bounds_for_obj, absolute_to_local
 from lab13 import NumericAnimation
 from lab13 import map_translation, parse_transform
 from lab13 import CompositedLayer, paint_visual_effects

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -215,6 +215,7 @@ class ProtectedField:
     def copy(self, field):
         self.set(field.read(notify=self))
 
+    @wbetools.js_hide
     def __str__(self):
         if self.dirty:
             return "<dirty>"

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -30,7 +30,7 @@ from lab11 import parse_color, parse_blend_mode
 from lab12 import MeasureTime, REFRESH_RATE_SEC
 from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
 from lab13 import diff_styles, parse_transition, add_parent_pointers
-from lab13 import local_to_absolute, absolute_bounds_for_obj
+from lab13 import local_to_absolute, absolute_bounds_for_obj, absolute_to_local
 from lab13 import NumericAnimation
 from lab13 import map_translation, parse_transform
 from lab13 import CompositedLayer, paint_visual_effects

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -476,20 +476,14 @@ class BlockLayout:
             self.x.get(), self.y.get(), self.x.get() + self.width.get(),
             self.y.get() + self.height.get())
 
-    def is_atomic(self):
-        return not isinstance(self.node, Text) and \
-            (self.node.tag == "input" or self.node.tag == "button")
-
     def paint(self):
         cmds = []
-
-        if not self.is_atomic():
-            bgcolor = self.node.style["background-color"].get()
-            if bgcolor != "transparent":
-                radius = dpx(
-                    float(self.node.style["border-radius"].get()[:-2]),
-                    self.zoom.get())
-                cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
+        bgcolor = self.node.style["background-color"].get()
+        if bgcolor != "transparent":
+            radius = dpx(
+                float(self.node.style["border-radius"].get()[:-2]),
+                self.zoom.get())
+            cmds.append(DrawRRect(self.self_rect(), radius, bgcolor))
         return cmds
  
     def paint_effects(self, cmds):

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -156,6 +156,9 @@ class Layout:
         self.recurse(tree)
         self.flush()
 
+    @wbetools.delete
+    def token(self, tok): pass
+
     def recurse(self, tree):
         if isinstance(tree, Text):
             for word in tree.text.split():

--- a/src/lab6.hints
+++ b/src/lab6.hints
@@ -4,6 +4,5 @@
 {"code": "'style' in node.attributes", "type": "dict"},
 {"code": "'href' in node.attributes", "type": "dict"},
 {"code": "'/' in dir", "type": "str"},
-{"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
-{"code": "browser6_styles.read()", "js": "constants.browser6_styles.read()"}
+{"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"}
 ]

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -251,13 +251,11 @@ class BlockLayout:
                                          word, font, color))
         return cmds
 
-    @wbetools.js_hide
-    def open_tag(self, tag):
-        pass
+    @wbetools.delete
+    def open_tag(self, tag): pass
 
-    @wbetools.js_hide
-    def close_tag(self, tag):
-        pass
+    @wbetools.delete
+    def close_tag(self, tag): pass
 
     @wbetools.js_hide
     def __repr__(self):

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -285,8 +285,7 @@ class DrawText:
     def __repr__(self):
         return "DrawText(text={})".format(self.text)
 
-browser6_styles = open("browser6.css")
-DEFAULT_STYLE_SHEET = CSSParser(browser6_styles.read()).parse()
+DEFAULT_STYLE_SHEET = CSSParser(open("browser6.css").read()).parse()
 
 @wbetools.patch(Browser)
 class Browser:

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -153,6 +153,9 @@ class BlockLayout:
             for child in node.children:
                 self.recurse(child)
 
+    @wbetools.delete
+    def flush(self): pass
+
     def new_line(self):
         self.cursor_x = 0
         last_line = self.children[-1] if self.children else None

--- a/src/lab8.hints
+++ b/src/lab8.hints
@@ -5,7 +5,6 @@
  {"code": "'action' in elt.attributes", "type": "dict"},
  {"code": "'href' in elt.attributes", "type": "dict"},
  {"code": "'name' in node.attributes", "type": "dict"},
- {"code": "browser8.read()", "js": "constants.browser8.read()"},
  {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
  {"code": "response.read()", "js": "response.read()"}
 ]

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -81,8 +81,7 @@ class URL:
         s.close()
         return content
 
-browser8 = open("browser8.css")
-DEFAULT_STYLE_SHEET = CSSParser(browser8.read()).parse()
+DEFAULT_STYLE_SHEET = CSSParser(open("browser8.css").read()).parse()
 
 INPUT_WIDTH_PX = 200
 

--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -59,6 +59,9 @@ def patchable(f):
 def js_hide(f):
     return f
 
+def outline_hide(f):
+    return f
+
 def delete(f):
     return f
 

--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -59,6 +59,9 @@ def patchable(f):
 def js_hide(f):
     return f
 
+def delete(f):
+    return f
+
 def named_params(f):
     return f
 


### PR DESCRIPTION
This PR cleans up the outline somewhat, removing obsolete methods, hiding some debugging functions, and so on.

I still plan to do the following in follow-up PRs:

- Make a "template order" for the outline so that the functions / classes are always in a sane order
- Include superclasses in class headers
- Use `diff` to check again that chapter-by-chapter we're adding/removing the right functions (didn't accidentally remove something by forgetting to import it)

See also #1210, which I found while working on the outline.