### PR TITLE
Fix widgets by updating / extending `rt` and compilation

### DIFF
--- a/src/lab14.hints
+++ b/src/lab14.hints
@@ -21,7 +21,5 @@
 {"code": "(active_idx + 1) % len(self.tabs)", "js": "(active_idx + 1) % self.tabs.length"},
 {"code": "MeasureTime()", "js": "new MeasureTime()"},
 {"code": "browser.toggle_mute()", "js": "browser.toggle_mute()"},
-{"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
-{"code": "open('runtime14.js').read()", "js": "filesystem.open('runtime14.js').read()"},
-{"code": "open('browser14.css').read()", "js": "filesystem.open('browser14.css').read()"}
+{"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"}
 ]

--- a/src/lab15.hints
+++ b/src/lab15.hints
@@ -44,7 +44,5 @@
 {"code": "MeasureTime()", "js": "new MeasureTime()"},
 {"code": "len(self.tab.window_id_to_frame)", "js": "Object.keys(this.tab.window_id_to_frame).length"},
 {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
-{"code": "open('runtime15.js').read()", "js": "filesystem.open('runtime15.js').read()"},
-{"code": "open('browser15.css').read()", "js": "filesystem.open('browser15.css').read()"},
 {"code": "response.read()", "js": "response.read()"}
 ]

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -569,15 +569,15 @@ function patch_canvas(canvas) {
     };
 
     canvas.drawRRect = (rrect, paint) => {
-        oldDrawRect.call(canvas, rrect, paint["paint"].getPaint());
+        oldDrawRect.call(canvas, rrect, paint.getPaint());
     };
 
     canvas.drawString = (text, x, y, font, paint) => {
         canvas.drawText(text, x, y, paint.getPaint(), font.getFont())       
     };
 
-    canvas.saveLayer = (dict) => {
-        oldSaveLayer.call(canvas, dict["paint"].getPaint());
+    canvas.saveLayer = (paint) => {
+        oldSaveLayer.call(canvas, paint.getPaint());
     };
 
     canvas.clipRect = (rect) => {
@@ -831,6 +831,9 @@ function init_skia(canvasKit, robotoData) {
                     case "Style":
                         this.paint.setStyle(value);
                         continue;
+                    case "StrokeWidth":
+                        this.paint.setStrokeWidth(value);
+                        continue;
                     default:
                         throw "Unknown Skia Paint value: " + key;
                 }
@@ -839,18 +842,6 @@ function init_skia(canvasKit, robotoData) {
 
         getPaint() {
             return this.paint;
-        }
-
-        setStyle(style) {
-            this.paint.setStyle(style);
-        }
-
-        setStrokeWidth(width) {
-            this.paint.setStrokeWidth(width);
-        }
-
-        setColor(color) {
-            this.paint.setColor(color);
         }
     }, (obj) => {
         obj.kStroke_Style = CanvasKit.PaintStyle.Stroke;


### PR DESCRIPTION
This PR fixes all of the widgets so that they at least run without issue. The main issue is that we changed some of the Skia APIs to use positional not keyword arguments and that I fixed the handling of `open(x).read()` so needed to remove some hints.