### PR TITLE
Fix `CSSParser` differences between Chapters 13 & 14

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -698,7 +698,7 @@ class CSSParser:
         self.whitespace()
         self.literal("(")
         self.whitespace()
-        prop, val = self.pair()
+        prop, val = self.pair([")"])
         self.whitespace()
         self.literal(")")
         return prop, val
@@ -1423,46 +1423,7 @@ this to show a 3px red outline:[^outline-syntax]
 [^outline-syntax]: We'll only implement this syntax, but `outline` can
     also take a few other forms.
 
-The first challenge in implementing `outline` is that, annoyingly, at the moment
-our CSS parser doesn't recognize the line above as a valid property/value pair,
-since it parses values as a single word. Let's upgrade the parser to recognize
-any string of characters except one of a specified set of `chars`:
-
-``` {.python}
-class CSSParser:
-    def until_chars(self, chars):
-        start = self.i
-        while self.i < len(self.s) and self.s[self.i] not in chars:
-            self.i += 1
-        return self.s[start:self.i]
-
-    def pair(self, until):
-        # ...
-        val = self.until_chars(until)
-        # ...
-        return prop.casefold(), val.strip()
-```
-
-Inside a CSS rule body, a property value continues until a semicolon
-or a close curly brace, but inside a media query it continues until a
-close parenthesis:
-
-``` {.python}
-class CSSParser:
-    def body(self):
-        while self.i < len(self.s) and self.s[self.i] != "}":
-            try:
-                prop, val = self.pair([";", "}"])
-                # ...
-
-    def media_query(self):
-        # ...
-        prop, val = self.pair(")")
-        # ...
-```
-
-Now we have `outline`'s value in the relevant element's `style`. We can
-parse that into a thickness and a color:
+We can parse that into a thickness and a color:
 
 ``` {.python}
 def parse_outline(outline_str):

--- a/src/lab13.hints
+++ b/src/lab13.hints
@@ -10,7 +10,7 @@
  {"code": "len(self.node_to_handle)", "js": "this.node_to_handle.size"},
  {"code": "self.node_to_handle[elt] = handle", "js": "      this.node_to_handle.set(elt, handle);"},
  {"code": "('OpenGL initialized: vendor={},' + 'renderer={}').format(OpenGL.GL.glGetString(OpenGL.GL.GL_VENDOR), OpenGL.GL.glGetString(OpenGL.GL.GL_RENDERER))", "js": ""},
- {"code": "self.s[self.i] in chars", "js": "chars.find((c) => c == this.s[this.i])"},
+ {"code": "self.s[self.i] not in chars", "type": "str"},
  {"code": "property not in old_style", "type": "dict"},
  {"code": "property not in new_style", "type": "dict"},
  {"code": "'style' in node.attributes", "type": "dict"},

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -306,22 +306,6 @@ def parse_transform(transform_str):
 
 @wbetools.patch(CSSParser)
 class CSSParser:
-    def word(self):
-        start = self.i
-        in_quote = False
-        while self.i < len(self.s):
-            cur = self.s[self.i]
-            if cur == "'":
-                in_quote = not in_quote
-            elif cur.isalnum() or cur in ",/#-.%()\"'" \
-                or (in_quote and cur == ':'):
-                self.i += 1
-            else:
-                break
-        if not (self.i > start):
-            raise Exception("Parsing error")
-        return self.s[start:self.i]
-
     def until_chars(self, chars):
         start = self.i
         while self.i < len(self.s) and self.s[self.i] not in chars:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -306,19 +306,6 @@ def parse_transform(transform_str):
 
 @wbetools.patch(CSSParser)
 class CSSParser:
-    def __init__(self, s):
-        self.s = s
-        self.i = 0
-
-    def whitespace(self):
-        while self.i < len(self.s) and self.s[self.i].isspace():
-            self.i += 1
-
-    def literal(self, literal):
-        if not (self.i < len(self.s) and self.s[self.i] == literal):
-            raise Exception("Parsing error")
-        self.i += 1
-
     def word(self):
         start = self.i
         in_quote = False
@@ -326,7 +313,7 @@ class CSSParser:
             cur = self.s[self.i]
             if cur == "'":
                 in_quote = not in_quote
-            if cur.isalnum() or cur in ",/#-.%()\"'" \
+            elif cur.isalnum() or cur in ",/#-.%()\"'" \
                 or (in_quote and cur == ':'):
                 self.i += 1
             else:
@@ -335,35 +322,25 @@ class CSSParser:
             raise Exception("Parsing error")
         return self.s[start:self.i]
 
-    def until_semicolon(self):
+    def until_chars(self, chars):
         start = self.i
-        while self.i < len(self.s):
-            cur = self.s[self.i]
-            if cur == ";":
-                break
+        while self.i < len(self.s) and self.s[self.i] not in chars:
             self.i += 1
         return self.s[start:self.i]
 
-    def pair(self):
+    def pair(self, until):
         prop = self.word()
         self.whitespace()
         self.literal(":")
         self.whitespace()
-        val = self.until_semicolon()
-        return prop.casefold(), val
-
-    def ignore_until(self, chars):
-        while self.i < len(self.s):
-            if self.s[self.i] in chars:
-                return self.s[self.i]
-            else:
-                self.i += 1
+        val = self.until_chars(until)
+        return prop.casefold(), val.strip()
 
     def body(self):
         pairs = {}
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
-                prop, val = self.pair()
+                prop, val = self.pair([";", "}"])
                 pairs[prop.casefold()] = val
                 self.whitespace()
                 self.literal(";")
@@ -376,36 +353,6 @@ class CSSParser:
                 else:
                     break
         return pairs
-
-    def selector(self):
-        out = TagSelector(self.word().casefold())
-        self.whitespace()
-        while self.i < len(self.s) and self.s[self.i] != "{":
-            tag = self.word()
-            descendant = TagSelector(tag.casefold())
-            out = DescendantSelector(out, descendant)
-            self.whitespace()
-        return out
-
-    def parse(self):
-        rules = []
-        while self.i < len(self.s):
-            try:
-                self.whitespace()
-                selector = self.selector()
-                self.literal("{")
-                self.whitespace()
-                body = self.body()
-                self.literal("}")
-                rules.append((selector, body))
-            except Exception:
-                why = self.ignore_until(["}"])
-                if why == "}":
-                    self.literal("}")
-                    self.whitespace()
-                else:
-                    break
-        return rules
 
 class BlockLayout:
     def __init__(self, node, parent, previous):

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -306,6 +306,22 @@ def parse_transform(transform_str):
 
 @wbetools.patch(CSSParser)
 class CSSParser:
+    def word(self):
+        start = self.i
+        in_quote = False
+        while self.i < len(self.s):
+            cur = self.s[self.i]
+            if cur == "'":
+                in_quote = not in_quote
+            if cur.isalnum() or cur in ",/#-.%()\"'" \
+                or (in_quote and cur == ':'):
+                self.i += 1
+            else:
+                break
+        if not (self.i > start):
+            raise Exception("Parsing error")
+        return self.s[start:self.i]
+
     def until_chars(self, chars):
         start = self.i
         while self.i < len(self.s) and self.s[self.i] not in chars:

--- a/src/lab14.hints
+++ b/src/lab14.hints
@@ -4,8 +4,6 @@
 {"code": "b'Browser'", "js": "'Browser'"},
  {"code": "'href' in elt.attributes", "type": "dict"},
 {"code": "'content-security-policy' in headers", "type": "dict"},
-{"code": "self.s[self.i] in chars", "type": "list"},
-{"code": "self.s[self.i] not in chars", "type": "list"},
 {"code": "'value' in self.node.attributes", "type": "dict"},
 {"code": "'tabindex' in node.attributes", "type": "dict"},
 {"code": "'src' in node.attributes", "type": "dict"},

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -46,7 +46,7 @@ from lab13 import map_translation, parse_transform, parse_transition
 from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import PaintCommand, DrawText, DrawCompositedLayer, DrawOutline, \
     DrawLine, DrawRRect, DrawRect
-from lab13 import VisualEffect, Blend, Transform, Tab, Browser
+from lab13 import VisualEffect, Blend, Transform, Tab, Browser, CSSParser
 
 @wbetools.patch(Element)
 class Element:
@@ -644,20 +644,8 @@ class PseudoclassSelector:
     def __repr__(self):
         return "PseudoclassSelector({}, {})".format(self.pseudoclass, self.base)
 
+@wbetools.patch(CSSParser)
 class CSSParser:
-    def __init__(self, s):
-        self.s = s
-        self.i = 0
-
-    def whitespace(self):
-        while self.i < len(self.s) and self.s[self.i].isspace():
-            self.i += 1
-
-    def literal(self, literal):
-        if not (self.i < len(self.s) and self.s[self.i] == literal):
-            raise Exception("Parsing error")
-        self.i += 1
-
     def word(self):
         start = self.i
         in_quote = False
@@ -665,56 +653,14 @@ class CSSParser:
             cur = self.s[self.i]
             if cur == "'":
                 in_quote = not in_quote
-            if cur == "(":
-                in_parens = True
-            if cur.isalnum() or cur in ",/#-.%()\"'" \
+            elif cur.isalnum() or cur in ",/#-.%()\"'" \
                 or (in_quote and cur == ':'):
                 self.i += 1
             else:
                 break
         if not (self.i > start):
             raise Exception("Parsing error")
-
         return self.s[start:self.i]
-
-    def until_chars(self, chars):
-        start = self.i
-        while self.i < len(self.s) and self.s[self.i] not in chars:
-            self.i += 1
-        return self.s[start:self.i]
-
-    def pair(self, until):
-        prop = self.word()
-        self.whitespace()
-        self.literal(":")
-        self.whitespace()
-        val = self.until_chars(until)
-        return prop.casefold(), val.strip()
-
-    def ignore_until(self, chars):
-        while self.i < len(self.s):
-            if self.s[self.i] in chars:
-                return self.s[self.i]
-            else:
-                self.i += 1
-
-    def body(self):
-        pairs = {}
-        while self.i < len(self.s) and self.s[self.i] != "}":
-            try:
-                prop, val = self.pair([";", "}"])
-                pairs[prop.casefold()] = val
-                self.whitespace()
-                self.literal(";")
-                self.whitespace()
-            except Exception:
-                why = self.ignore_until([";", "}"])
-                if why == ";":
-                    self.literal(";")
-                    self.whitespace()
-                else:
-                    break
-        return pairs
 
     def simple_selector(self):
         out = TagSelector(self.word().casefold())
@@ -739,7 +685,7 @@ class CSSParser:
         self.whitespace()
         self.literal("(")
         self.whitespace()
-        prop, val = self.pair(")")
+        prop, val = self.pair([")"])
         self.whitespace()
         self.literal(")")
         return prop, val

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -646,22 +646,6 @@ class PseudoclassSelector:
 
 @wbetools.patch(CSSParser)
 class CSSParser:
-    def word(self):
-        start = self.i
-        in_quote = False
-        while self.i < len(self.s):
-            cur = self.s[self.i]
-            if cur == "'":
-                in_quote = not in_quote
-            elif cur.isalnum() or cur in ",/#-.%()\"'" \
-                or (in_quote and cur == ':'):
-                self.i += 1
-            else:
-                break
-        if not (self.i > start):
-            raise Exception("Parsing error")
-        return self.s[start:self.i]
-
     def simple_selector(self):
         out = TagSelector(self.word().casefold())
         if self.i < len(self.s) and self.s[self.i] == ":":


### PR DESCRIPTION
This PR is pretty nasty, sorry. It includes a bunch of linked changes, ultimately to fix #1221:

- Change Chapter 13 to parse CSS values with `until_chars`, like in Chapter 14, instead of `until_semicolon`
- Move the corresponding text from Chapter 14 to Chapter 13, with what changes are necessary to preserve continuity
- No longer change `word` in Chapter 13 or 14, because those changes are unnecessary (those changes were there to accommodate complex CSS values in `word`, but we now parse CSS values with `until_chars`, so `word` can stay unchanged)
- Eliminate various other random changes between Chapters 6, 13, and 14 by deduplicating `CSSParser` methods with `wbetools.patch`.