### PR TITLE
Fix saveLayer calls

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1066,7 +1066,7 @@ that that effect will be applied to, like this:
 
 ``` {.python .example}
 # draw parent
-canvas.saveLayer(skia.Paint(Alphaf=0.5))
+canvas.saveLayer(None, skia.Paint(Alphaf=0.5))
 # draw children
 canvas.restore()
 ```
@@ -1075,7 +1075,7 @@ Here, the `saveLayer` call asks Skia[^layer-surface] to draw all the
 children to a separate
 surface before blending them into the parent once
 `restore` is called.
-The `paint` option to `saveLayer` specifies the specific type of
+The secondc parameter to `saveLayer` specifies the specific type of
 blending, here with the `Alphaf` parameter requesting 50% opacity.
 
 [^layer-surface]: It's called `saveLayer` instead of `createSurface` because
@@ -1385,7 +1385,7 @@ class Blend:
         paint = skia.Paint(
             BlendMode=parse_blend_mode(self.blend_mode),
         )
-        canvas.saveLayer(paint)
+        canvas.saveLayer(none, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         canvas.restore()
@@ -1648,7 +1648,7 @@ class Opacity:
             Alphaf=self.opacity,
         )
         if self.opacity < 1:
-            canvas.saveLayer(paint)
+            canvas.saveLayer(None, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.opacity < 1:
@@ -1692,7 +1692,7 @@ class Blend:
             BlendMode=parse_blend_mode(self.blend_mode),
         )
         if self.blend_mode:
-            canvas.saveLayer(paint)
+            canvas.saveLayer(None, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.blend_mode:
@@ -1729,7 +1729,7 @@ class Blend:
             BlendMode=parse_blend_mode(self.blend_mode),
         )
         if self.should_save:
-            canvas.saveLayer(paint)
+            canvas.saveLayer(None, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.should_save:

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1385,7 +1385,7 @@ class Blend:
         paint = skia.Paint(
             BlendMode=parse_blend_mode(self.blend_mode),
         )
-        canvas.saveLayer(none, paint)
+        canvas.saveLayer(None, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         canvas.restore()

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -1075,7 +1075,7 @@ Here, the `saveLayer` call asks Skia[^layer-surface] to draw all the
 children to a separate
 surface before blending them into the parent once
 `restore` is called.
-The secondc parameter to `saveLayer` specifies the specific type of
+The second parameter to `saveLayer` specifies the specific type of
 blending, here with the `Alphaf` parameter requesting 50% opacity.
 
 [^layer-surface]: It's called `saveLayer` instead of `createSurface` because

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -110,7 +110,7 @@ class Blend:
             BlendMode=parse_blend_mode(self.blend_mode),
         )
         if self.should_save:
-            canvas.saveLayer(paint)
+            canvas.saveLayer(None, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.should_save:

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -245,7 +245,7 @@ class Blend(VisualEffect):
             BlendMode=parse_blend_mode(self.blend_mode)
         )
         if self.should_save:
-            canvas.saveLayer(paint)
+            canvas.saveLayer(None, paint)
         for cmd in self.children:
             cmd.execute(canvas)
         if self.should_save:

--- a/src/test.py
+++ b/src/test.py
@@ -325,7 +325,7 @@ class MockCanvas:
     def save(self):
         self.commands.append("save()")
 
-    def saveLayer(self, paint):
+    def saveLayer(self, ignored, paint):
         format_str = "saveLayer(" + MockCanvas.format_paint(paint, False)
         self.commands.append((format_str + ")").format(
             color=paint.getColor(),


### PR DESCRIPTION
A commit [a few weeks ago](https://github.com/browserengineering/book/commit/91a0762c243e471f8e033d1743b1fe482931fd02) changed `saveLayer(paint=my_paint)` to `saveLayer(my_paint`), which is wrong because `paint` is the second parameter. This caused browse15.py to crash loading our website.