### PR TITLE
Make Chapter 6 match Chapter 5's `flush()` method

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -909,7 +909,7 @@ def flush(self):
     # ...
     metrics = [font.metrics() for x, word, font, color in self.line]
     # ...
-    for x, word, font, color in self.line:
+    for rel_x, word, font, color in self.line:
         # ...
         self.display_list.append((x, y, word, font, color))
     # ...
@@ -921,8 +921,7 @@ That `display_list` is converted to drawing commands in `paint`:
 def paint(self):
     # ...
     for x, y, word, font, color in self.display_list:
-        cmds.append(DrawText(self.x + x, self.y + y,
-                                     word, font, color))
+        cmds.append(DrawText(x, y, word, font, color))
 ```
 
 `DrawText` now needs a `color` argument, and needs to pass it to

--- a/book/styles.md
+++ b/book/styles.md
@@ -920,8 +920,9 @@ That `display_list` is converted to drawing commands in `paint`:
 ``` {.python indent=4}
 def paint(self):
     # ...
-    for x, y, word, font, color in self.display_list:
-        cmds.append(DrawText(x, y, word, font, color))
+    if self.layout_mode() == "inline":
+        for x, y, word, font, color in self.display_list:
+            cmds.append(DrawText(x, y, word, font, color))
 ```
 
 `DrawText` now needs a `color` argument, and needs to pass it to

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -229,7 +229,8 @@ class BlockLayout:
         metrics = [font.metrics() for x, word, font, color in self.line]
         max_ascent = max([metric["ascent"] for metric in metrics])
         baseline = self.cursor_y + 1.25 * max_ascent
-        for x, word, font, color in self.line:
+        for rel_x, word, font, color in self.line:
+            x = self.x + rel_x
             y = baseline - font.metrics("ascent")
             self.display_list.append((x, y, word, font, color))
         self.cursor_x = self.x
@@ -247,8 +248,7 @@ class BlockLayout:
             cmds.append(rect)
 
         for x, y, word, font, color in self.display_list:
-            cmds.append(DrawText(self.x + x, self.y + y,
-                                         word, font, color))
+            cmds.append(DrawText(x, y, word, font, color))
         return cmds
 
     @wbetools.delete

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -247,8 +247,10 @@ class BlockLayout:
             rect = DrawRect(self.x, self.y, x2, y2, bgcolor)
             cmds.append(rect)
 
-        for x, y, word, font, color in self.display_list:
-            cmds.append(DrawText(x, y, word, font, color))
+        if self.layout_mode() == "inline":
+            for x, y, word, font, color in self.display_list:
+                cmds.append(DrawText(x, y, word, font, color))
+
         return cmds
 
     @wbetools.delete


### PR DESCRIPTION
Fixes #1249 by updating Chapter 6 to match Chapter 5. Unfortunately, this requires changes to the book, specifically to two code blocks:

- In the `flush` code block, the only change is renaming a variable from `x` to `rel_x`; I think this is fine for the typesetter.
- In the `paint` code block, the code changes more dramatically but line length goes down and line count doesn't change, so we're maybe OK.