### PR TITLE
Add version tests to support both old (m87) and new (m124) Skia

### DIFF
--- a/src/lab13.py
+++ b/src/lab13.py
@@ -1123,6 +1123,13 @@ class Browser:
                 sdl2.SDL_WINDOWPOS_CENTERED,
                 WIDTH, HEIGHT,
                 sdl2.SDL_WINDOW_SHOWN | sdl2.SDL_WINDOW_OPENGL)
+
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, 3)
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MINOR_VERSION, 2)
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG, True)
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_PROFILE_MASK,
+                                     sdl2.SDL_GL_CONTEXT_PROFILE_CORE)
+
             self.gl_context = sdl2.SDL_GL_CreateContext(
                 self.sdl_window)
             print(("OpenGL initialized: vendor={}," + \

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -1132,6 +1132,13 @@ class Browser:
                 sdl2.SDL_WINDOWPOS_CENTERED,
                 WIDTH, HEIGHT,
                 sdl2.SDL_WINDOW_SHOWN | sdl2.SDL_WINDOW_OPENGL)
+
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MAJOR_VERSION, 3)
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_MINOR_VERSION, 2)
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG, True)
+            sdl2.SDL_GL_SetAttribute(sdl2.SDL_GL_CONTEXT_PROFILE_MASK,
+                                     sdl2.SDL_GL_CONTEXT_PROFILE_CORE)
+
             self.gl_context = sdl2.SDL_GL_CreateContext(
                 self.sdl_window)
             print(("OpenGL initialized: vendor={}," + \

--- a/src/lab15.hints
+++ b/src/lab15.hints
@@ -44,5 +44,6 @@
 {"code": "MeasureTime()", "js": "new MeasureTime()"},
 {"code": "len(self.tab.window_id_to_frame)", "js": "Object.keys(this.tab.window_id_to_frame).length"},
 {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
-{"code": "response.read()", "js": "response.read()"}
+{"code": "response.read()", "js": "response.read()"},
+{"code": "skia.CubicResampler.Mitchell()", "js": "skia.CubicResampler.Mitchell()"}
 ]


### PR DESCRIPTION
The code is basically `porting.md` implement using explicit version tests. I only tested 87 and 124 and so all of my version tests are testing `version > 87`; I'm sure I could browse the release notes more carefully to support more Skia versions but I don't think there's much point in that.

I'm going to keep my local machine on 87, so that I'm always testing against the correct version, but merging this would maybe be somewhat convenient in case I switch between to help out HinTak (right now I have to manually copy code around). Also, it would potentially allow us to test the code in `porting.md`, though I haven't set that up yet.