### PR TITLE
Restyle headers a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ outlines: $(patsubst %,src/outline%.txt,$(shell seq 1 16))
 
 CHAPTER=all
 
-PANDOC=pandoc --number-sections --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json --highlight-style=infra/wbecode.theme $(FLAGS)
+PANDOC=pandoc --from markdown --to html --lua-filter=infra/filter.lua --fail-if-warnings --metadata-file=config.json --highlight-style=infra/wbecode.theme $(FLAGS)
 
 PANDOC_LATEX=pandoc --number-sections --standalone --from markdown --to latex --fail-if-warnings --metadata-file=config.json --lua-filter=infra/filter.lua --highlight-style=infra/wbecode.theme $(FLAGS)
 

--- a/www/book.css
+++ b/www/book.css
@@ -32,11 +32,13 @@ header, h1, strong {
 }
 h1 { font-size: 105%; margin: 1.5em 0 0; }
 
+/* Auto-number section headings, but not on the main page. */
+/* Also, on hover over section headings, show a "#" to indicate permalinks. */
+body > h1 { counter-increment: section; }
+body > h1::before { content: counter(section) ". "; color: #888; }
 .main h1::before { content: none !important; }
 h1:not(.title):hover { cursor: pointer; }
 h1:not(.title):hover::after { content: " #"; color: #888; }
-body > h1 { counter-increment: section; }
-body > h1::before { content: counter(section) ". "; color: #888; }
 
 header { text-align: center; margin: 3em 0 1em; }
 header h1 { font-size: 200%; font-weight: bold; }
@@ -54,6 +56,8 @@ a:active { color: #f64; }
 
 li { margin: 1em 0; }
 
+/* On the main page, <ol> contains chapter names and <hi> contains
+ * Part names; all should be big. */
 .main ol, .main h1 { font-size: 120%; }
 .main header { margin-bottom: 3em; }
 .main > h1 { margin: 0; }

--- a/www/book.css
+++ b/www/book.css
@@ -48,7 +48,7 @@ a:active { color: #f64; }
 
 li { margin: 1em 0; }
 
-.main ol, .main > h1 { font-size: 120%; }
+.main ol, .main h1 { font-size: 120%; }
 .main header { margin-bottom: 3em; }
 .main > h1 { margin: 0; }
 .main ol { margin: 0; }

--- a/www/book.css
+++ b/www/book.css
@@ -51,7 +51,7 @@ li { margin: 1em 0; }
 .main ol, .main > h1 { font-size: 120%; }
 .main header { margin-bottom: 3em; }
 .main > h1 { margin: 0; }
-.main ol { margin: 0; padding-left: 0}
+.main ol { margin: 0; }
 @media (prefers-color-scheme: light) {
 .main ol { color: black; }
 }

--- a/www/book.css
+++ b/www/book.css
@@ -31,6 +31,11 @@ header, h1, strong {
 }
 }
 h1 { font-size: 105%; margin: 1.5em 0 0; }
+
+.main h1::before { content: none !important; }
+body > h1 { counter-increment: section; }
+body > h1::before { content: counter(section) ". "; color: #888; }
+
 header { text-align: center; margin: 3em 0 1em; }
 header h1 { font-size: 200%; font-weight: bold; }
 h1:not(.title):hover{ cursor: pointer; text-decoration: underline }

--- a/www/book.css
+++ b/www/book.css
@@ -33,12 +33,13 @@ header, h1, strong {
 h1 { font-size: 105%; margin: 1.5em 0 0; }
 
 .main h1::before { content: none !important; }
+h1:not(.title):hover { cursor: pointer; }
+h1:not(.title):hover::after { content: " #"; color: #888; }
 body > h1 { counter-increment: section; }
 body > h1::before { content: counter(section) ". "; color: #888; }
 
 header { text-align: center; margin: 3em 0 1em; }
 header h1 { font-size: 200%; font-weight: bold; }
-h1:not(.title):hover{ cursor: pointer; text-decoration: underline }
 .main header * { margin: 0; }
 header .author { font-style: italic; }
 header .author:before { content: "By "; }


### PR DESCRIPTION
This PR makes three big changes to styling. In each pair of screenshots below, I show "before" first, than "after".

# First: move the chapter numbers on the main page so they're within the page bounds. This makes them visible on mobile.

Before:
<img width="208" alt="image" src="https://github.com/browserengineering/book/assets/30707/5a3ab926-c8cb-4763-ac88-b0169208e573">

After:
<img width="245" alt="Screenshot 2024-06-06 at 3 50 56 PM" src="https://github.com/browserengineering/book/assets/30707/beb2fe86-3b41-4753-8714-f9a1ee0baa47">

# Second: Use CSS counters to number sections, instead of Pandoc. This allows us to style the section number:

Before:
<img width="315" alt="Screenshot 2024-06-06 at 3 51 51 PM" src="https://github.com/browserengineering/book/assets/30707/b9dafdb6-31ce-4e04-8b13-ac51cb2e2989">

After:
<img width="243" alt="image" src="https://github.com/browserengineering/book/assets/30707/3726f8c0-e9a3-4390-8054-5809429b132b">

Also we don't need to put the counter into the table of contents:

Before:
<img width="199" alt="image" src="https://github.com/browserengineering/book/assets/30707/226ad679-a343-43e3-8bd8-513d5d4194af">

After:
<img width="199" alt="Screenshot 2024-06-06 at 3 52 54 PM" src="https://github.com/browserengineering/book/assets/30707/af63251b-2958-4024-a163-42a7ba47d727">

# Third: Use a pseudoelement "#" instead of an underline to suggest clicking a header for a permalink. This has bothered me for a while, the underlines look bad.

Before:
<img width="304" alt="image" src="https://github.com/browserengineering/book/assets/30707/2c7dae87-53dd-4fef-a8c6-bd7a859e1816">

After:
<img width="334" alt="Screenshot 2024-06-06 at 3 54 00 PM" src="https://github.com/browserengineering/book/assets/30707/dd10747a-481b-43cc-81cd-41f646fd2ea4">
