### PR TITLE
Fix JavaScript version of `Font.metrics`

### DIFF
--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -363,9 +363,6 @@ class tkinter {
                     ctx.font = this.string;
                     let m = ctx.measureText("Hxy");
 
-                    // Only Safari provides emHeight properties as of 2021-04
-                    // We fake them in the other browsers by guessing that emHeight = font.size
-                    // This is not quite right but is close enough for many fonts...
                     let asc = ctx.measureText("Hxy").fontBoundingBoxAscent / rt_constants.ZOOM;
                     let desc = ctx.measureText("Hxy").fontBoundingBoxDescent / rt_constants.ZOOM;
                     this.$metrics = { ascent: asc, descent: desc, linespace: asc + desc, fixed: 0 };

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -362,21 +362,12 @@ class tkinter {
                     ctx.textBaseline = "alphabetic";
                     ctx.font = this.string;
                     let m = ctx.measureText("Hxy");
-                    let asc, desc;
 
                     // Only Safari provides emHeight properties as of 2021-04
                     // We fake them in the other browsers by guessing that emHeight = font.size
                     // This is not quite right but is close enough for many fonts...
-                    if (m.emHeightAscent && m.emHeightDescent) {
-                        asc = ctx.measureText("Hxy").emHeightAscent / rt_constants.ZOOM;
-                        desc = ctx.measureText("Hxy").emHeightDescent / rt_constants.ZOOM;
-                    } else {
-                        asc = ctx.measureText("Hxy").actualBoundingBoxAscent / rt_constants.ZOOM;
-                        desc = ctx.measureText("Hxy").actualBoundingBoxDescent / rt_constants.ZOOM;
-                        let gap = this.size - (asc + desc)
-                        asc += gap / 2;
-                        desc += gap / 2;
-                    }
+                    let asc = ctx.measureText("Hxy").fontBoundingBoxAscent / rt_constants.ZOOM;
+                    let desc = ctx.measureText("Hxy").fontBoundingBoxDescent / rt_constants.ZOOM;
                     this.$metrics = { ascent: asc, descent: desc, linespace: asc + desc, fixed: 0 };
                 }
                 if (field) return this.$metrics[field]


### PR DESCRIPTION
When we first wrote this code, different browsers implemented different Canvas TextMetrics fields, so we had some browser-specific code. Moreover, different browsers have different values for the same fields. That's all still the case, but it *has* gotten a bit better: all browsers implement `fontAscentBoundingBox` and give it the same value. So this PR switches to using that for font metrics. This makes the UI look a little uglier in Chrome (because the spacing of that UI depends on font metrics, and the use of `fontXXXBoundingBox` is a little larger meaning more whitespace than what we had before) but on the other hand it totally fixes the `lab3-baselines` widget, which I think makes this a clear win.

Before:
<img width="348" alt="image" src="https://github.com/browserengineering/book/assets/30707/9c409f91-6289-4d2c-a835-0e367cd048bf">

Note that the text is not actually on the baseline! It's not actually on any baseline.

After:
<img width="339" alt="image" src="https://github.com/browserengineering/book/assets/30707/b567de66-2ab8-4efb-8aff-7ff66e583aa7">

The text is now lined up nicely on the baseline.
