### PR TITLE
Add support for the `noargs` flag in the outline template

### DIFF
--- a/book/outline.txt
+++ b/book/outline.txt
@@ -335,7 +335,7 @@ class JSContext:
     def setAttribute(handle, attr, value, window_id)
     def innerHTML_set(handle, s, window_id)
     def style_set(handle, s, window_id)
-    def XMLHttpRequest_send(method, url, body, isasync, handle, window_id)
+    def XMLHttpRequest_send(method, url, body, isasync, handle, window_id) # noargs
     def setTimeout(handle, time, window_id)
     def requestAnimationFrame()
     def parent(window_id)
@@ -409,7 +409,7 @@ class Chrome:
 # Mainloop
 def load(url)
 class CommitData:
-    def __init__
+    def __init__() # noargs
 class Browser:
     def __init__()
     # --


### PR DESCRIPTION
This flag replaces the argument list on a function with `...` and is useful for `CommitData` (which has a huge number of arguments) and `XMLHttpRequest_send` (which has a largish number). The `ProtectedField` constructor also has a couple but it only stretches 63 characters so I think will be safe once the publisher restyles the code blocks to be a bit smaller.