### PR TITLE
Update `lab16.py` to sync with `lab15.py` bug fixes

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1102,7 +1102,7 @@ And we can set those when the parent frame is laid out:
 class IframeLayout(EmbedLayout):
     def layout(self):
         # ...
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             self.node.frame.frame_height = \
                 self.height - dpx(2, self.zoom)
             self.node.frame.frame_width = \

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -2030,7 +2030,7 @@ change:[^or-protect-them]
 ``` {.python}
 class IframeLayout(EmbedLayout):
     def layout(self):
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             # ...
             self.node.frame.document.width.mark()
 ```

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -636,7 +636,7 @@ class IframeLayout(EmbedLayout):
         else:
             self.height = dpx(IFRAME_HEIGHT_PX + 2, self.zoom)
 
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             self.node.frame.frame_height = \
                 self.height - dpx(2, self.zoom)
             self.node.frame.frame_width = \

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1380,6 +1380,24 @@ class Tab:
 
         self.browser.measure.stop('render')
 
+@wbetools.patch(AccessibilityNode)
+class AccessibilityNode:
+    def compute_bounds(self):
+        if self.node.layout_object:
+            return [absolute_bounds_for_obj(self.node.layout_object)]
+        if isinstance(self.node, Text):
+            return []
+        inline = self.node.parent
+        bounds = []
+        while not inline.layout_object: inline = inline.parent
+        for line in inline.layout_object.children.get():
+            line_bounds = skia.Rect.MakeEmpty()
+            for child in line.children:
+                if child.node.parent == self.node:
+                    line_bounds.join(skia.Rect.MakeXYWH(
+                        child.x.get(), child.y.get(), child.width.get(), child.height.get()))
+            bounds.append(line_bounds)
+        return bounds
 
 if __name__ == "__main__":
     wbetools.parse_flags()

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1359,7 +1359,8 @@ class Tab:
         self.browser.measure.time('render')
 
         for id, frame in self.window_id_to_frame.items():
-            frame.render()
+            if frame.loaded:
+                frame.render()
 
         if self.needs_accessibility:
             self.accessibility_tree = AccessibilityNode(self.root_frame.nodes)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -891,7 +891,7 @@ class IframeLayout(EmbedLayout):
         else:
             self.height.set(dpx(IFRAME_HEIGHT_PX + 2, zoom)) 
 
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             self.node.frame.frame_height = \
                 self.height.get() - dpx(2, self.zoom.get())
             self.node.frame.frame_width = \
@@ -1304,6 +1304,9 @@ class Tab:
 
         needs_composite = False
         for (window_id, frame) in self.window_id_to_frame.items():
+            if not frame.loaded:
+                continue
+
             self.browser.measure.time('script-runRAFHandlers')
             frame.js.dispatch_RAF(frame.window_id)
             self.browser.measure.stop('script-runRAFHandlers')


### PR DESCRIPTION
This PR makes a few cleanups to `lab16.py` by synchronizing it with `lab15.py`:

- Remove some unneeded patch methods (that are identical to lab15)
- Load tabs asynchronously
- Avoid running JavaScript on discarded tabs
- Fix self_rect for `DocumentLayout`s