### PR TITLE
Revert "Test full (inlined) modules against the normal tests (#1215)"

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,56 +6,47 @@
 
         "http.md": {
             "lab": "lab1.py",
-            "tests": "lab1-tests.md",
-            "full": "lab1-tests.md"
+            "tests": "lab1-tests.md"
         },
         "graphics.md": {
             "lab": "lab2.py",
-            "tests": "lab2-tests.md",
-            "full": "lab2-tests.md"
+            "tests": "lab2-tests.md"
         },
         "text.md": {
             "lab": "lab3.py",
-            "tests": "lab3-tests.md",
-            "full": "lab3-tests.md"
+            "tests": "lab3-tests.md"
         },
 
         "html.md": {
             "lab": "lab4.py",
-            "tests": "lab4-tests.md",
-            "full": "lab4-tests.md"
+            "tests": "lab4-tests.md"
         },
         "layout.md": {
             "lab": "lab5.py",
-            "tests": "lab5-tests.md",
-            "full": "lab5-tests.md"
+            "tests": "lab5-tests.md"
         },
         "styles.md": {
             "lab": "lab6.py",
             "stylesheet": "browser6.css",
-            "tests": "lab6-tests.md",
-            "full": "lab6-tests.md"
+            "tests": "lab6-tests.md"
         },
         "chrome.md": {
             "lab": "lab7.py",
             "lab6": "lab6.py",
-            "tests": "lab7-tests.md",
-            "full": "lab7-tests.md"
+            "tests": "lab7-tests.md"
         },
 
         "forms.md": {
             "lab": "lab8.py",
             "server": "server8.py",
             "stylesheet": "browser8.css",
-            "tests": "lab8-tests.md",
-            "full": "lab8-tests.md"
+            "tests": "lab8-tests.md"
         },
         "scripts.md": {
             "lab": "lab9.py",
             "server": "server9.py",
             "runtime": "runtime9.js",
             "tests": "lab9-tests.md",
-            "full": "lab9-tests.md",
             "comment.js": "comment9.js",
             "comment.css": "comment9.css"
         },
@@ -63,50 +54,43 @@
             "lab": "lab10.py",
             "server": "server10.py",
             "runtime": "runtime10.js",
-            "tests": "lab10-tests.md",
-            "full": "lab10-tests.md"
+            "tests": "lab10-tests.md"
         },
 
         "visual-effects.md": {
             "lab": "lab11.py",
             "examples": "examples11.py",
-            "tests": "lab11-tests.md",
-            "full": "lab11-tests.md"
+            "tests": "lab11-tests.md"
         },
         "scheduling.md": {
             "lab": "lab12.py",
             "server": "server12.py",
             "runtime": "runtime12.js",
             "eventloop": "eventloop12.js",
-            "tests": "lab12-tests.md",
-            "full": "lab12-tests.md"
+            "tests": "lab12-tests.md"
         },
         "animations.md": {
             "lab": "lab13.py",
             "runtime": "runtime13.js",
             "example-opacity-html": "example13-opacity-raf.html",
-            "tests": "lab13-tests.md",
-            "full": "lab13-tests.md"
+            "tests": "lab13-tests.md"
         },
         "accessibility.md": {
             "lab": "lab14.py",
             "stylesheet": "browser14.css",
             "runtime": "runtime14.js",
-            "tests": "lab14-tests.md",
-            "full": "lab14-tests.md"
+            "tests": "lab14-tests.md"
         },
         "embeds.md": {
             "lab": "lab15.py",
             "runtime": "runtime15.js",
             "tests": "lab15-tests.md",
-            "full": "lab15-tests.md",
             "stylesheet": "browser15.css"
         },
         "invalidation.md": {
             "lab": "lab16.py",
             "lab15": "lab15.py",
-            "tests": "lab16-tests.md",
-            "full": "lab16-tests.md"
+            "tests": "lab16-tests.md"
         },
 
         "skipped.md": { },

--- a/infra/runtests.py
+++ b/infra/runtests.py
@@ -4,9 +4,7 @@ import doctest
 import os, sys
 import json
 import compare
-import types
-import importlib, importlib.abc, importlib.machinery, importlib.util
-import asttools
+import importlib
 from unittest import mock
 from pathlib import Path
 
@@ -50,37 +48,6 @@ def reload_module(mod):
         if attr not in ('__name__', '__file__'):
             delattr(mod, attr)
     importlib.reload(mod)
-    
-class StringLoader(importlib.abc.Loader):
-    def __init__(self, source):
-        self.source = source
-
-    # Based on https://gist.github.com/moreati/44bce66fe0c4febc8d80e064532d4b49
-    def create_module(self, spec):
-        module = types.ModuleType(spec.name)
-        module.__spec__ = spec
-        module.__loader__ = spec.loader
-        module.__file__ = spec.origin
-        return module
-
-    def exec_module(self, module):
-        code = compile(self.source, module.__file__, 'exec')
-        exec(code, module.__dict__)
-
-def import_text_as(source, module_name):
-    """Import the string/AST `source` as a module named `module_name`"""
-
-    # Based on https://gist.github.com/moreati/44bce66fe0c4febc8d80e064532d4b49
-    spec = importlib.machinery.ModuleSpec(
-        module_name,
-        loader=StringLoader(source),
-        origin="inliner",
-    )
-
-    # Based on importlib documentation
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
 
 def run_tests(chapter, file_name):
     failure, count = doctest.testfile(os.path.abspath(file_name), module_relative=False)
@@ -124,16 +91,6 @@ if __name__ == "__main__":
             if key == "tests":
                 print(f"  {t.bold(value)}: Testing {chapter}...", end=" ")
                 results[value] = run_tests(chapter, value)
-                if not results[value][0]: print(t.green("pass"))
-            elif key == "full":
-                print(f"  {t.bold(value)}: Testing inlined {chapter}...", end=" ")
-                source_file = value.replace("-tests.md", ".py")
-                with open(source_file) as f:
-                    tree = asttools.parse(f.read(), f.name)
-                mod_name = value.replace("-tests.md", "")
-                import_text_as(asttools.inline(tree), mod_name)
-                results[value] = run_tests(chapter, value)
-                del sys.modules[mod_name]
                 if not results[value][0]: print(t.green("pass"))
             elif key == "lab":
                 print(f"  {t.bold(value)}: Comparing {chapter}'s python...", end=" ")

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -24,6 +24,7 @@ from lab14 import Text, Element
 from lab6 import TagSelector, DescendantSelector
 from lab6 import tree_to_list, INHERITED_PROPERTIES
 from lab8 import INPUT_WIDTH_PX
+from lab9 import EVENT_DISPATCH_JS
 from lab10 import COOKIE_JAR
 from lab11 import FONTS, NAMED_COLORS, get_font, linespace
 from lab11 import parse_color, parse_blend_mode
@@ -48,7 +49,7 @@ from lab15 import URL, HTMLParser, AttributeParser, DrawImage, \
     IframeLayout, JSContext, AccessibilityNode, FrameAccessibilityNode, Frame, Tab, \
     CommitData, Browser, BROKEN_IMAGE, font, \
     IFRAME_WIDTH_PX, IFRAME_HEIGHT_PX, parse_image_rendering, DEFAULT_STYLE_SHEET, \
-    EVENT_DISPATCH_JS, RUNTIME_JS, POST_MESSAGE_DISPATCH_JS
+    RUNTIME_JS, POST_MESSAGE_DISPATCH_JS
 
 
 class ProtectedField:


### PR DESCRIPTION
This reverts commit ffa164aa294b8d2876ffa7162671f139afe631a2.

Reason:

Breaks the outliner:

```
$ python3 infra/outlines.py src/lab16.py --template book/outline.txt
Traceback (most recent call last):
  File "/home/chrishtr/git/browserbook/infra/outlines.py", line 241, in <module>
    ol = sort_outline(ol, template, debug=args.debug)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chrishtr/git/browserbook/infra/outlines.py", line 208, in sort_outline
    new_fns = sort_outline(cls.fns, item.fns, indent=indent+"  ", debug=debug)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chrishtr/git/browserbook/infra/outlines.py", line 224, in sort_outline
    "\n".join(["  " + item.str() for item in ol])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chrishtr/git/browserbook/infra/outlines.py", line 224, in <listcomp>
    "\n".join(["  " + item.str() for item in ol])
                      ^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'str'
```