### PR TITLE
Fix `iframe` scrolling

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1102,7 +1102,7 @@ And we can set those when the parent frame is laid out:
 class IframeLayout(EmbedLayout):
     def layout(self):
         # ...
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             self.node.frame.frame_height = \
                 self.height - dpx(2, self.zoom)
             self.node.frame.frame_width = \

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -2030,7 +2030,7 @@ change:[^or-protect-them]
 ``` {.python}
 class IframeLayout(EmbedLayout):
     def layout(self):
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             # ...
             self.node.frame.document.width.mark()
 ```

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1600,6 +1600,7 @@ class Tab:
             self.focused_frame.needs_focus_scroll = False
 
         for (window_id, frame) in self.window_id_to_frame.items():
+            if frame == self.root_frame: continue
             if frame.scroll_changed_in_frame:
                 needs_composite = True
                 frame.scroll_changed_in_frame = False

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1436,6 +1436,7 @@ class Frame:
     def scrolldown(self):
         self.scroll = self.clamp_scroll(self.scroll + SCROLL_STEP)
         self.scroll_changed_in_frame = True
+        self.tab.set_needs_paint()
 
     def scroll_to(self, elt):
         assert not (self.needs_style or self.needs_layout)
@@ -1451,7 +1452,7 @@ class Frame:
         new_scroll = obj.y - SCROLL_STEP
         self.scroll = self.clamp_scroll(new_scroll)
         self.scroll_changed_in_frame = True
-        self.set_needs_render()
+        self.tab.set_needs_paint()
 
     def click(self, x, y):
         self.focus_element(None)
@@ -1597,6 +1598,11 @@ class Tab:
         if self.focus and self.focused_frame.needs_focus_scroll:
             self.focused_frame.scroll_to(self.focus)
             self.focused_frame.needs_focus_scroll = False
+
+        for (window_id, frame) in self.window_id_to_frame.items():
+            if frame.scroll_changed_in_frame:
+                needs_composite = True
+                frame.scroll_changed_in_frame = False
 
         scroll = None
         if self.root_frame.scroll_changed_in_frame:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -636,7 +636,7 @@ class IframeLayout(EmbedLayout):
         else:
             self.height = dpx(IFRAME_HEIGHT_PX + 2, self.zoom)
 
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             self.node.frame.frame_height = \
                 self.height - dpx(2, self.zoom)
             self.node.frame.frame_width = \

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1380,6 +1380,24 @@ class Tab:
 
         self.browser.measure.stop('render')
 
+@wbetools.patch(AccessibilityNode)
+class AccessibilityNode:
+    def compute_bounds(self):
+        if self.node.layout_object:
+            return [absolute_bounds_for_obj(self.node.layout_object)]
+        if isinstance(self.node, Text):
+            return []
+        inline = self.node.parent
+        bounds = []
+        while not inline.layout_object: inline = inline.parent
+        for line in inline.layout_object.children.get():
+            line_bounds = skia.Rect.MakeEmpty()
+            for child in line.children:
+                if child.node.parent == self.node:
+                    line_bounds.join(skia.Rect.MakeXYWH(
+                        child.x.get(), child.y.get(), child.width.get(), child.height.get()))
+            bounds.append(line_bounds)
+        return bounds
 
 if __name__ == "__main__":
     wbetools.parse_flags()

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1359,7 +1359,8 @@ class Tab:
         self.browser.measure.time('render')
 
         for id, frame in self.window_id_to_frame.items():
-            frame.render()
+            if frame.loaded:
+                frame.render()
 
         if self.needs_accessibility:
             self.accessibility_tree = AccessibilityNode(self.root_frame.nodes)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -891,7 +891,7 @@ class IframeLayout(EmbedLayout):
         else:
             self.height.set(dpx(IFRAME_HEIGHT_PX + 2, zoom)) 
 
-        if self.node.frame:
+        if self.node.frame and self.node.frame.loaded:
             self.node.frame.frame_height = \
                 self.height.get() - dpx(2, self.zoom.get())
             self.node.frame.frame_width = \
@@ -1304,6 +1304,9 @@ class Tab:
 
         needs_composite = False
         for (window_id, frame) in self.window_id_to_frame.items():
+            if not frame.loaded:
+                continue
+
             self.browser.measure.time('script-runRAFHandlers')
             frame.js.dispatch_RAF(frame.window_id)
             self.browser.measure.stop('script-runRAFHandlers')

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1333,6 +1333,7 @@ class Tab:
             self.focused_frame.needs_focus_scroll = False
 
         for (window_id, frame) in self.window_id_to_frame.items():
+            if frame == self.root_frame: continue
             if frame.scroll_changed_in_frame:
                 needs_composite = True
                 frame.scroll_changed_in_frame = False

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1227,7 +1227,7 @@ class Frame:
         new_scroll = obj.y.get() - SCROLL_STEP
         self.scroll = self.clamp_scroll(new_scroll)
         self.scroll_changed_in_frame = True
-        self.set_needs_render()
+        self.set_needs_paint()
 
     def clamp_scroll(self, scroll):
         height = math.ceil(self.document.height.get() + 2*VSTEP)
@@ -1331,6 +1331,11 @@ class Tab:
         if self.focus and self.focused_frame.needs_focus_scroll:
             self.focused_frame.scroll_to(self.focus)
             self.focused_frame.needs_focus_scroll = False
+
+        for (window_id, frame) in self.window_id_to_frame.items():
+            if frame.scroll_changed_in_frame:
+                needs_composite = True
+                frame.scroll_changed_in_frame = False
 
         scroll = None
         if self.root_frame.scroll_changed_in_frame:


### PR DESCRIPTION
Basically, the issue we were having is that, if you scrolled an iframe without doing anything else on that frame, then neither layout nor style is necessary, in which case we were committing a frame with no changes required. (An empty list of composited updates.) The solution in this PR is to detect, in `run_animation_frame`, if any frame has scrolled and, if so, mark the frame as not a composited update. This isn't perfect (it means scrolling isn't composited) and I haven't updated the book yet—I fear it will require changes, probably at least a paragraph more of text. Posting the PR to sanity-check the approach.