### PR TITLE
Remove duplicate imports, this helps Safari somehow

### DIFF
--- a/www/widgets/lab10-browser.html
+++ b/www/widgets/lab10-browser.html
@@ -7,8 +7,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab10.js"></script>
 <script type="module">
 import { rt_constants, socket, Widget } from "./rt.js";
 import { constants } from "./lab10.js";

--- a/www/widgets/lab2-browser.html
+++ b/www/widgets/lab2-browser.html
@@ -17,8 +17,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab2.js"></script>
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab2.js";

--- a/www/widgets/lab3-browser.html
+++ b/www/widgets/lab3-browser.html
@@ -17,8 +17,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab3.js"></script>
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab3.js";

--- a/www/widgets/lab4-browser.html
+++ b/www/widgets/lab4-browser.html
@@ -17,8 +17,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab4.js"></script>
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab4.js";

--- a/www/widgets/lab5-browser.html
+++ b/www/widgets/lab5-browser.html
@@ -17,8 +17,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab5.js"></script>
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab5.js";

--- a/www/widgets/lab6-browser.html
+++ b/www/widgets/lab6-browser.html
@@ -17,8 +17,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab6.js"></script>
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab6.js";

--- a/www/widgets/lab7-browser.html
+++ b/www/widgets/lab7-browser.html
@@ -7,8 +7,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab7.js"></script>
 <script type="module">
 import { rt_constants, Widget } from "./rt.js";
 import { Browser, constants } from "./lab7.js";

--- a/www/widgets/lab8-browser.html
+++ b/www/widgets/lab8-browser.html
@@ -7,8 +7,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab8.js"></script>
 <script type="module">
 import { rt_constants, socket, Widget } from "./rt.js";
 import { Browser, constants } from "./lab8.js";

--- a/www/widgets/lab9-browser.html
+++ b/www/widgets/lab9-browser.html
@@ -7,8 +7,6 @@
   <canvas id="canvas" width="352" height="160"></canvas>
 </figure>
 
-<script type="module" src="rt.js"></script>
-<script type="module" src="lab9.js"></script>
 <script type="module">
 import { rt_constants, socket, Widget } from "./rt.js";
 import { constants } from "./lab9.js";


### PR DESCRIPTION
This PR helps #1257 somehow, though I'm not sure how. But these duplicate imports seem to mess up, for some reason, the order in which patches are applied, and that results in broken widgets.