### PR TITLE
Write about fixing iframe scrolling

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1452,9 +1452,6 @@ class Tab:
         # ...
 ```
 
-It's possible to composite or even thread iframe scrolling, but for
-the sake of expediency we won't do it here.
-
 There's one more subtlety to scrolling. After we scroll, we want to
 *clamp* the scroll position, to prevent the user scrolling past the
 last thing on the page. Right now `clamp_scroll` uses the window

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1437,6 +1437,24 @@ class Tab:
         self.set_needs_paint()
 ```
 
+If a frame other than the root frame is scrolled, we'll just set
+`needs_composite` so the browser has to reraster from scratch:
+
+``` {.python}
+class Tab:
+    def run_animation_frame(self, scroll):
+        # ...
+        for (window_id, frame) in self.window_id_to_frame.items():
+            if frame == self.root_frame: continue
+            if frame.scroll_changed_in_frame:
+                needs_composite = True
+                frame.scroll_changed_in_frame = False
+        # ...
+```
+
+It's possible to composite or even thread iframe scrolling, but for
+the sake of expediency we won't do it here.
+
 There's one more subtlety to scrolling. After we scroll, we want to
 *clamp* the scroll position, to prevent the user scrolling past the
 last thing on the page. Right now `clamp_scroll` uses the window

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1438,7 +1438,7 @@ class Tab:
 ```
 
 If a frame other than the root frame is scrolled, we'll just set
-`needs_composite` so the browser has to reraster from scratch:
+`needs_composite` so the browser has to re-raster from scratch:
 
 ``` {.python}
 class Tab:

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1436,7 +1436,6 @@ class Frame:
     def scrolldown(self):
         self.scroll = self.clamp_scroll(self.scroll + SCROLL_STEP)
         self.scroll_changed_in_frame = True
-        self.tab.set_needs_paint()
 
     def scroll_to(self, elt):
         assert not (self.needs_style or self.needs_layout)


### PR DESCRIPTION
This PR adds two paragraphs and a code block to describe the iframe scrolling bug fixed in #1264. Also I remove a line that I added in #1264 which isn't needed (the `Tab`, not the `Frame`, sets needs paint).