### PR TITLE
More fix widgets

### DIFF
--- a/infra/asttools.py
+++ b/infra/asttools.py
@@ -218,10 +218,5 @@ def inline(tree):
     tree3 = ResolvePatches().double_visit(tree2)
     return ast.fix_missing_locations(tree3)
 
-def resolve_patches_and_return_them(tree):
-    r = ResolvePatches()
-    tree2 = r.double_visit(tree)
-    return (ast.fix_missing_locations(tree2), r.patches, r.patchables)
-
 def unparse(tree, explain=False):
     return AST39.unparse(tree, explain=explain)

--- a/infra/compile.py
+++ b/infra/compile.py
@@ -1044,22 +1044,27 @@ def compile_module(tree, patches, patchables):
             patchables=patchables) \
         for item in tree.body])
 
+    patch_items = []
     for (name, patch) in patches.items():
-        items.append(compile(patch[0], indent=0, ctx=ctx, patches=patches,
+        patch_items.append(compile(patch[0], indent=0, ctx=ctx, patches=patches,
             patchables=patchables))
         if name[0].isupper():
-            items.append(
+            patch_items.append(
                 "patch_class({cls}, {cls}Patch)\n".format(
                 cls=name))
         else:
-            items.append(
+            patch_items.append(
                 "patch_{fun}({fun}_patch)\n".format(
                 fun=name))
         # Layout is renamed to BlockLayout in lab5. The Layout class is patched,
         # but we also need to declare BLockLayout an alias of this patched
         # class.
         if name == "Layout":
-            items.append("var BlockLayout = Layout")
+            patch_items.append("var BlockLayout = Layout")
+
+    # Patches go before definitions, in case a definition needs a patch
+    patch_items.extend(items)
+    items = patch_items
 
 
     for (name, patchable) in patchables.items():

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -36,6 +36,7 @@ from lab9 import EVENT_DISPATCH_JS
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, NAMED_COLORS, get_font, linespace, paint_tree
 from lab11 import parse_color, parse_blend_mode
+from lab11 import BlockLayout, DocumentLayout, TextLayout, LineLayout, InputLayout
 from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner, Chrome
 from lab12 import Task, REFRESH_RATE_SEC
 from lab13 import JSContext, diff_styles, add_parent_pointers, SETTIMEOUT_JS, \
@@ -47,7 +48,6 @@ from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import PaintCommand, DrawText, DrawCompositedLayer, DrawOutline, \
     DrawLine, DrawRRect, DrawRect
 from lab13 import VisualEffect, Blend, Transform, Tab, Browser, CSSParser
-from lab13 import BlockLayout, DocumentLayout, TextLayout, LineLayout, InputLayout
 
 @wbetools.patch(Element)
 class Element:

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -36,7 +36,7 @@ from lab9 import EVENT_DISPATCH_JS
 from lab10 import COOKIE_JAR, URL
 from lab11 import FONTS, NAMED_COLORS, get_font, linespace, paint_tree
 from lab11 import parse_color, parse_blend_mode
-from lab11 import BlockLayout, DocumentLayout, TextLayout, LineLayout, InputLayout
+from lab11 import DocumentLayout, LineLayout
 from lab12 import MeasureTime, SingleThreadedTaskRunner, TaskRunner, Chrome
 from lab12 import Task, REFRESH_RATE_SEC
 from lab13 import JSContext, diff_styles, add_parent_pointers, SETTIMEOUT_JS, \
@@ -48,6 +48,7 @@ from lab13 import CompositedLayer, paint_visual_effects
 from lab13 import PaintCommand, DrawText, DrawCompositedLayer, DrawOutline, \
     DrawLine, DrawRRect, DrawRect
 from lab13 import VisualEffect, Blend, Transform, Tab, Browser, CSSParser
+from lab13 import BlockLayout, TextLayout, InputLayout
 
 @wbetools.patch(Element)
 class Element:

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -27,9 +27,8 @@ from lab8 import INPUT_WIDTH_PX
 from lab10 import COOKIE_JAR
 from lab11 import FONTS, NAMED_COLORS, get_font, linespace
 from lab11 import parse_color, parse_blend_mode
-from lab12 import MeasureTime, REFRESH_RATE_SEC
+from lab12 import MeasureTime, REFRESH_RATE_SEC, SETTIMEOUT_JS, XHR_ONLOAD_JS
 from lab12 import Task, TaskRunner, SingleThreadedTaskRunner
-from lab12 import SETTIMEOUT_JS, XHR_ONLOAD_JS
 from lab13 import diff_styles, parse_transition, add_parent_pointers
 from lab13 import local_to_absolute, absolute_bounds_for_obj, absolute_to_local
 from lab13 import NumericAnimation

--- a/www/widgets/lab11-browser.html
+++ b/www/widgets/lab11-browser.html
@@ -11,38 +11,34 @@
 const ckLoaded = CanvasKitInit({
   locateFile: (file) => '/widgets/' + file});
 
-const loadFont = fetch(
+const robotoData = await fetch(
   'https://storage.googleapis.com/skia-cdn/misc/Roboto-Regular.ttf')
   .then((response) => response.arrayBuffer());
 
-Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
-    let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
-    let typeface = font_manager.matchFamilyStyle(
-      font_manager.getFamilyName(0), {})
+const CanvasKit = await ckLoaded;
 
-Promise.all([import("./rt.js"), import("./lab10.js"), import("./lab11.js"),
-    import("./server10.js")]).then(
-  ([rt, lab10, lab11, server10]) => {
-    let { init_skia, init_window, socket, Widget, rt_constants } = rt;
-    let { URL } = lab10;
-    let { Browser, constants } = lab11;
-    let { handle_connection } = server10;
+let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
+let typeface = font_manager.matchFamilyStyle(
+    font_manager.getFamilyName(0), {})
 
-    init_skia(CanvasKit, robotoData)
+import { init_skia, init_window, socket, Widget, rt_constants} from "./rt.js";
+import { URL } from "./lab10.js";
+import { Browser, constants } from "./lab11.js";
+import { handle_connection } from "./server10.js";
 
-    socket.accept(8000, handle_connection);
-    rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+init_skia(CanvasKit, robotoData)
 
-    let widget = new Widget(document.querySelector("#controls"));
-    widget.run(async function() {
-        constants.WIDTH = window.innerWidth;
-        let url = "http://browser.engineering/";
-        let b = await (new Browser()).init();
-        init_window(b);
-        await b.new_tab(await (new URL().init(url)));
-    });
-    widget.next();
-  });
+socket.accept(8000, handle_connection);
+rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+widget.run(async function() {
+    constants.WIDTH = window.innerWidth;
+    let url = "http://browser.engineering/";
+    let b = await (new Browser()).init();
+    init_window(b);
+    await b.new_tab(await (new URL().init(url)));
 });
+widget.next();
 </script>
 

--- a/www/widgets/lab12-browser.html
+++ b/www/widgets/lab12-browser.html
@@ -11,49 +11,45 @@
 const ckLoaded = CanvasKitInit({
   locateFile: (file) => '/widgets/' + file});
 
-const loadFont = fetch(
+const robotoData = await fetch(
   'https://storage.googleapis.com/skia-cdn/misc/Roboto-Regular.ttf')
   .then((response) => response.arrayBuffer());
 
-Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
-    let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
-    let typeface = font_manager.matchFamilyStyle(
-      font_manager.getFamilyName(0), {})
+const CanvasKit = await ckLoaded;
 
-  Promise.all([import("./rt.js"), import("./lab10.js"), import("./lab12.js"),
-    import("./server10.js")]).then(
-  ([rt, lab10, lab12, server10]) => {
-    let { init_skia, init_window, socket, Widget, rt_constants } = rt;
-    let { URL } = lab10;
-    let { Browser, constants } = lab12;
-    let { handle_connection } = server10;
+let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
+let typeface = font_manager.matchFamilyStyle(
+  font_manager.getFamilyName(0), {})
 
-    init_skia(CanvasKit, robotoData)
-    socket.accept(8000, handle_connection);
-    rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+import { init_skia, init_window, socket, Widget, rt_constants} from "./rt.js";
+import { URL } from "./lab10.js";
+import { Browser, constants } from "./lab12.js";
+import { handle_connection } from "./server10.js";
 
-    let widget = new Widget(document.querySelector("#controls"));
-    let interval;
-    widget.run(async function() {
-        if (interval)
-          clearInterval(interval)
-        constants.WIDTH = window.innerWidth;
-        let url = "http://browser.engineering/";
-        let b = await (new Browser()).init();
-        init_window(b);
-        await b.new_tab(await (new URL().init(url)));
+init_skia(CanvasKit, robotoData)
+socket.accept(8000, handle_connection);
+rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+let interval;
+widget.run(async function() {
+    if (interval)
+      clearInterval(interval)
+    constants.WIDTH = window.innerWidth;
+    let url = "http://browser.engineering/";
+    let b = await (new Browser()).init();
+    init_window(b);
+    await b.new_tab(await (new URL().init(url)));
+    await b.render();
+    interval = setInterval(async function() {
+      if (b.needs_animation_frame) {
         await b.render();
-        interval = setInterval(async function() {
-          if (b.needs_animation_frame) {
-            await b.render();
-            b.needs_animation_frame = false;
-          }
-          await b.raster_and_draw();
-          await b.schedule_animation_frame();
-        }, 20);
-    });
-    widget.next();
-  });
+        b.needs_animation_frame = false;
+      }
+      await b.raster_and_draw();
+      await b.schedule_animation_frame();
+    }, 20);
 });
+widget.next();
 </script>
 

--- a/www/widgets/lab13-browser.html
+++ b/www/widgets/lab13-browser.html
@@ -11,49 +11,45 @@
 const ckLoaded = CanvasKitInit({
   locateFile: (file) => '/widgets/' + file});
 
-const loadFont = fetch(
+const robotoData = await fetch(
   'https://storage.googleapis.com/skia-cdn/misc/Roboto-Regular.ttf')
   .then((response) => response.arrayBuffer());
 
-Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
-    let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
-    let typeface = font_manager.matchFamilyStyle(
-      font_manager.getFamilyName(0), {})
+const CanvasKit = await ckLoaded;
 
-  Promise.all([import("./rt.js"), import("./lab10.js"), import("./lab13.js"),
-    import("./server10.js")]).then(
-  ([rt, lab10, lab13, server10]) => {
-    let { init_skia, init_window, socket, Widget, rt_constants} = rt;
-    let { URL } = lab10;
-    let { Browser, constants } = lab13;
-    let { handle_connection } = server10;
+let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
+let typeface = font_manager.matchFamilyStyle(
+  font_manager.getFamilyName(0), {})
 
-    init_skia(CanvasKit, robotoData)
-    socket.accept(8000, handle_connection);
-    rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+import { init_skia, init_window, socket, Widget, rt_constants} from "./rt.js";
+import { URL } from "./lab10.js";
+import { Browser, constants } from "./lab13.js";
+import { handle_connection } from "./server10.js";
 
-    let widget = new Widget(document.querySelector("#controls"));
-    let interval;
-    widget.run(async function() {
-        if (interval)
-          clearInterval(interval);
-        constants.WIDTH = window.innerWidth;
-        let url = "http://browser.engineering";
-        let b = await (new Browser()).init();
-        init_window(b);
-        await b.new_tab(await (new URL().init(url)));
+init_skia(CanvasKit, robotoData)
+socket.accept(8000, handle_connection);
+rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+let interval;
+widget.run(async function() {
+    if (interval)
+      clearInterval(interval);
+    constants.WIDTH = window.innerWidth;
+    let url = "http://browser.engineering";
+    let b = await (new Browser()).init();
+    init_window(b);
+    await b.new_tab(await (new URL().init(url)));
+    await b.render();
+    interval = setInterval(async function() {
+      if (b.needs_animation_frame) {
         await b.render();
-        interval = setInterval(async function() {
-          if (b.needs_animation_frame) {
-            await b.render();
-            b.needs_animation_frame = false;
-          }
-          await b.composite_raster_and_draw();
-          await b.schedule_animation_frame();
-        }, 20);
-    });
-    widget.next();
-  });
+        b.needs_animation_frame = false;
+      }
+      await b.composite_raster_and_draw();
+      await b.schedule_animation_frame();
+    }, 20);
 });
+widget.next();
 </script>
 

--- a/www/widgets/lab14-browser.html
+++ b/www/widgets/lab14-browser.html
@@ -11,49 +11,45 @@
 const ckLoaded = CanvasKitInit({
   locateFile: (file) => '/widgets/' + file});
 
-const loadFont = fetch(
+const robotoData = await fetch(
   'https://storage.googleapis.com/skia-cdn/misc/Roboto-Regular.ttf')
   .then((response) => response.arrayBuffer());
 
-Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
-    let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
-    let typeface = font_manager.matchFamilyStyle(
-      font_manager.getFamilyName(0), {})
+const CanvasKit = await ckLoaded;
 
-  Promise.all([import("./rt.js"), import("./lab10.js"), import("./lab14.js"),
-    import("./server10.js")]).then(
-  ([rt, lab10, lab14, server10]) => {
-    let { init_skia, init_window, socket, Widget, rt_constants} = rt;
-    let { URL } = lab10;
-    let { Browser, constants } = lab14;
-    let { handle_connection } = server10;
+let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
+let typeface = font_manager.matchFamilyStyle(
+  font_manager.getFamilyName(0), {})
 
-    init_skia(CanvasKit, robotoData)
-    socket.accept(8000, handle_connection);
-    rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+import { init_skia, init_window, socket, Widget, rt_constants} from "./rt.js";
+import { URL } from "./lab10.js";
+import { Browser, constants } from "./lab14.js";
+import { handle_connection } from "./server10.js";
 
-    let widget = new Widget(document.querySelector("#controls"));
-    let interval;
-    widget.run(async function() {
-        if (interval)
-          clearInterval(interval);
-        constants.WIDTH = window.innerWidth;
-        let url = "http://browser.engineering";
-        let b = await (new Browser()).init();
-        init_window(b);
-        await b.new_tab(await (new URL().init(url)));
+init_skia(CanvasKit, robotoData)
+socket.accept(8000, handle_connection);
+rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+let interval;
+widget.run(async function() {
+    if (interval)
+      clearInterval(interval);
+    constants.WIDTH = window.innerWidth;
+    let url = "http://browser.engineering";
+    let b = await (new Browser()).init();
+    init_window(b);
+    await b.new_tab(await (new URL().init(url)));
+    await b.render();
+    interval = setInterval(async function() {
+      if (b.needs_animation_frame) {
         await b.render();
-        interval = setInterval(async function() {
-          if (b.needs_animation_frame) {
-            await b.render();
-            b.needs_animation_frame = false;
-          }
-          await b.composite_raster_and_draw();
-          await b.schedule_animation_frame();
-        }, 20);
-    });
-    widget.next();
-  });
+        b.needs_animation_frame = false;
+      }
+      await b.composite_raster_and_draw();
+      await b.schedule_animation_frame();
+    }, 20);
 });
+widget.next();
 </script>
 

--- a/www/widgets/lab15-browser.html
+++ b/www/widgets/lab15-browser.html
@@ -11,48 +11,44 @@
 const ckLoaded = CanvasKitInit({
   locateFile: (file) => '/widgets/' + file});
 
-const loadFont = fetch(
+const robotoData = await fetch(
   'https://storage.googleapis.com/skia-cdn/misc/Roboto-Regular.ttf')
   .then((response) => response.arrayBuffer());
 
-Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
-    let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
-    let typeface = font_manager.matchFamilyStyle(
-      font_manager.getFamilyName(0), {})
+const CanvasKit = await ckLoaded;
 
-  Promise.all([import("./rt.js"), import("./lab10.js"), import("./lab15.js"),
-    import("./server10.js")]).then(
-  ([rt, lab10, lab15, server10]) => {
-    let { init_skia, init_window, socket, Widget, rt_constants} = rt;
-    let { URL } = lab10;
-    let { Browser, constants } = lab15;
-    let { handle_connection } = server10;
+let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
+let typeface = font_manager.matchFamilyStyle(
+  font_manager.getFamilyName(0), {})
 
-    init_skia(CanvasKit, robotoData)
-    socket.accept(8000, handle_connection);
-    rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+import { init_skia, init_window, socket, Widget, rt_constants} from "./rt.js";
+import { URL } from "./lab10.js";
+import { Browser, constants } from "./lab15.js";
+import { handle_connection } from "./server10.js";
 
-    let widget = new Widget(document.querySelector("#controls"));
-    let interval;
-    widget.run(async function() {
-        if (interval)
-          clearInterval(interval);
-        constants.WIDTH = window.innerWidth;
-        let url = "http://browser.engineering";
-        let b = await (new Browser()).init();
-        init_window(b);
-        await b.new_tab(await (new URL().init(url)));
+init_skia(CanvasKit, robotoData)
+socket.accept(8000, handle_connection);
+rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+let interval;
+widget.run(async function() {
+    if (interval)
+      clearInterval(interval);
+    constants.WIDTH = window.innerWidth;
+    let url = "http://browser.engineering";
+    let b = await (new Browser()).init();
+    init_window(b);
+    await b.new_tab(await (new URL().init(url)));
+    await b.render();
+    interval = setInterval(async function() {
+      if (b.needs_animation_frame) {
         await b.render();
-        interval = setInterval(async function() {
-          if (b.needs_animation_frame) {
-            await b.render();
-            b.needs_animation_frame = false;
-          }
-          await b.composite_raster_and_draw();
-          await b.schedule_animation_frame();
-        }, 20);
-    });
-    widget.next();
-  });
+        b.needs_animation_frame = false;
+      }
+      await b.composite_raster_and_draw();
+      await b.schedule_animation_frame();
+    }, 20);
 });
+widget.next();
 </script>

--- a/www/widgets/lab16-browser.html
+++ b/www/widgets/lab16-browser.html
@@ -11,49 +11,45 @@
 const ckLoaded = CanvasKitInit({
   locateFile: (file) => '/widgets/' + file});
 
-const loadFont = fetch(
+const robotoData = await fetch(
   'https://storage.googleapis.com/skia-cdn/misc/Roboto-Regular.ttf')
   .then((response) => response.arrayBuffer());
 
-Promise.all([ckLoaded, loadFont]).then(([CanvasKit, robotoData]) => {
-    let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
-    let typeface = font_manager.matchFamilyStyle(
-      font_manager.getFamilyName(0), {})
+const CanvasKit = await ckLoaded;
 
-  Promise.all([import("./rt.js"), import("./lab10.js"), import("./lab15.js"),
-    import("./lab16.js"), import("./server10.js")]).then(
-  ([rt, lab10, lab15, lab16, server10]) => {
-    let { init_skia, init_window, socket, Widget, rt_constants} = rt;
-    let { URL } = lab10;
-    let { Browser } = lab15;
-    let { constants } = lab16;
-    let { handle_connection } = server10;
+let font_manager = CanvasKit.FontMgr.FromData([robotoData]);
+let typeface = font_manager.matchFamilyStyle(
+  font_manager.getFamilyName(0), {})
 
-    init_skia(CanvasKit, robotoData)
-    socket.accept(8000, handle_connection);
-    rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+import { init_skia, init_window, socket, Widget, rt_constants} from "./rt.js";
+import { URL } from "./lab10.js";
+import { Browser } from "./lab15.js";
+import { constants } from "./lab16.js";
+import { handle_connection } from "./server10.js";
 
-    let widget = new Widget(document.querySelector("#controls"));
-    let interval;
-    widget.run(async function() {
-        if (interval)
-          clearInterval(interval);
-        constants.WIDTH = window.innerWidth;
-        let url = "http://browser.engineering";
-        let b = await (new Browser()).init();
-        init_window(b);
-        await b.new_tab(await (new URL().init(url)));
+init_skia(CanvasKit, robotoData)
+socket.accept(8000, handle_connection);
+rt_constants.ROOT_CANVAS = document.querySelector("#canvas");
+
+let widget = new Widget(document.querySelector("#controls"));
+let interval;
+widget.run(async function() {
+    if (interval)
+      clearInterval(interval);
+    constants.WIDTH = window.innerWidth;
+    let url = "http://browser.engineering";
+    let b = await (new Browser()).init();
+    init_window(b);
+    await b.new_tab(await (new URL().init(url)));
+    await b.render();
+    interval = setInterval(async function() {
+      if (b.needs_animation_frame) {
         await b.render();
-        interval = setInterval(async function() {
-          if (b.needs_animation_frame) {
-            await b.render();
-            b.needs_animation_frame = false;
-          }
-          await b.composite_raster_and_draw();
-          await b.schedule_animation_frame();
-        }, 20);
-    });
-    widget.next();
-  });
+        b.needs_animation_frame = false;
+      }
+      await b.composite_raster_and_draw();
+      await b.schedule_animation_frame();
+    }, 20);
 });
+widget.next();
 </script>

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -564,8 +564,8 @@ function patch_canvas(canvas) {
         canvas.drawText(text, x, y, paint.getPaint(), font.getFont())       
     };
 
-    canvas.saveLayer = (paint) => {
-        oldSaveLayer.call(canvas, paint.getPaint());
+    canvas.saveLayer = (rect, paint) => {
+        oldSaveLayer.call(canvas, (paint ?? rect).getPaint());
     };
 
     canvas.clipRect = (rect) => {


### PR DESCRIPTION
Fixes broken widgets across all three browsers. The issues all seem to cluster around the order of imports and patch applications, so there were two big parts of the PR:

**Patch compilation**: The biggest part of this PR is a rewrite of how patches are handled in the compiler. Basically, we now handle patches in the same pass as non-patched methods, instead of doing them separately like before. This means we can generate patches in the right place in the source code, which is important to Safari for inscrutible reasons.

**New drivers**: The drivers now use `import` as a statement, which it looks like Safari is somehow happier about. Look—do not ask me why, I do not know, it is a weird bug in Safari that seems to have to do to import timing. But the new code is shorter, nicer, only slightly slower (oh well), and works in Safari and all other browsers too.

As of my just-now careful check, the all widgets now work in all browsers. Yay!
