### PR TITLE
Bump pandoc CI version

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -15,5 +15,5 @@ jobs:
         run: python -m pip install -r requirements.txt --no-deps
       - uses: r-lib/actions/setup-pandoc@v2
         with:
-          pandoc-version: 2.11.4
+          pandoc-version: 3.2.1
       - run: make book draft lint

--- a/config.json
+++ b/config.json
@@ -136,7 +136,7 @@
             "show_toc": true,
             "show_disabled": true,
             "show_quiz": true,
-            "show_todos": true,
+            "show_todos": true
         },
         "blog": {
             "base": "../",


### PR DESCRIPTION
Fix pandoc version and dumb typo I introduced into `config.json`; CI script runs fine on my end now.

Pandoc is now at most recent release version (v3.2.1). This is needed so that the `pandoc.json` module is available in Lua filters.