### PR TITLE
Fix error when images don't load

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -171,7 +171,7 @@ class Tab:
             try:
                 # ...
             except Exception as e:
-                print("Image", image_img.attributes.get("src", ""),
+                print("Image", img.attributes.get("src", ""),
                     "crashed", e)
                 img.image = BROKEN_IMAGE
 ```

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -171,7 +171,8 @@ class Tab:
             try:
                 # ...
             except Exception as e:
-                print("Image", image_url, "crashed", e)
+                print("Image", image_img.attributes.get("src", ""),
+                    "crashed", e)
                 img.image = BROKEN_IMAGE
 ```
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -1130,7 +1130,8 @@ class Frame:
                 assert img.image, \
                     "Failed to recognize image format for " + str(image_url)
             except Exception as e:
-                print("Image", image_url, "crashed", e)
+                print("Image", img.attributes.get("src", ""),
+                    "crashed", e)
                 img.image = BROKEN_IMAGE
 
         iframes = [node

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1140,7 +1140,8 @@ class Frame:
                 assert img.image, \
                     "Failed to recognize image format for " + str(image_url)
             except Exception as e:
-                print("Image", image_url, "crashed", e)
+                print("Image", img.attributes.get("src", ""),
+                    "crashed", e)
                 img.image = BROKEN_IMAGE
 
         iframes = [node


### PR DESCRIPTION
the `image_url` variable was not set, leading to a crash in the JS widget for `lab15-browser.html` and `lab16-browser.html` on the website.