### PR TITLE
Fix references in chapter 11 to colors when the book is in grayscale

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1338,7 +1338,7 @@ it on the [focus example](examples/example14-focus.html). Figure 5 shows what
 it looks like after I pressed tab to focus the "this is a link" element.
 
 ::: {.center}
-![Figure 5: Example of focus outline](examples/example14-focus-outline.png)
+![Figure 5: Example of focus outline.](examples/example14-focus-outline.png)
 :::
 
 But ideally, the focus indicator should be customizable, so that the web page

--- a/book/animations.md
+++ b/book/animations.md
@@ -1187,7 +1187,7 @@ The whole rendering cycle between the browser and main threads is summarized
 in Figure 2.
 
 ::: {.center}
-![Figure 2: The rendering cycle between the browser and main threads](im/multi-threaded-rendering-loop.jpg)
+![Figure 2: The rendering cycle between the browser and main threads.](im/multi-threaded-rendering-loop.jpg)
 :::
 
 However, it's not as simple as just setting `needs_render` any time an
@@ -1793,7 +1793,7 @@ The opacity transition example's composited layers should look like Figure 5
 :::
 
 ::: {.center}
-![Figure 5: Example of composited layers for an opacity transition](examples/example13-opacity-layers.png)
+![Figure 5: Example of composited layers for an opacity transition.](examples/example13-opacity-layers.png)
 :::
 
 [flag]: https://docs.python.org/3/library/argparse.html
@@ -1853,7 +1853,7 @@ Figure 6: Example of overlap that can lead to compositing draw errors.
 :::
 
 ::: {.print-only .center}
-![Figure 6: Example of overlap that can lead to compositing draw errors](examples/example13-overlap.png)
+![Figure 6: Example of overlap that can lead to compositing draw errors.](examples/example13-overlap.png)
 :::
 
 Now suppose we want to animate opacity on the blue square, but not the
@@ -2144,7 +2144,7 @@ www/examples/example13-transform-overlap.html
 It should look like Figure 7.
 
 ::: {.center}
-![Figure 7: Example of transformed overlap, clipping and blending](examples/example13-transform-overlap.png)
+![Figure 7: Example of transformed overlap, clipping and blending.](examples/example13-transform-overlap.png)
 :::
 
 Notice how this example exhibits *two* interesting features we had
@@ -2154,14 +2154,14 @@ to get right when implementing compositing:
 if this code were missing it would incorrectly render like Figure 8.
 
 ::: {.center}
-![Figure 8: Wrong rendering because overlap testing is missing](examples/example13-transform-overlap-wrong1.png)
+![Figure 8: Wrong rendering because overlap testing is missing.](examples/example13-transform-overlap-wrong1.png)
 :::
 
 * Reusing cloned effects (without it, blending and clipping would be wrong);
 if this code were missing it would incorrectly render like Figure 9.
 
 ::: {.center}
-![Figure 9: Wrong rendering because of incorrect blending](examples/example13-transform-overlap-wrong2.png)
+![Figure 9: Wrong rendering because of incorrect blending.](examples/example13-transform-overlap-wrong2.png)
 :::
 
 There's one more situation worth thinking about, though. Suppose we have a huge composited layer, containing a lot of text, except that only a small

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1173,7 +1173,7 @@ You should see something like Figure 1.
 :::
 
 ::: {.center}
-![Figure 1: Tracing for the timer script in single-threaded mode](examples/example12-trace-count-single-threaded.png)
+![Figure 1: Tracing for the timer script in single-threaded mode.](examples/example12-trace-count-single-threaded.png)
 :::
 
 In Chrome tracing, you can choose the cursor icon from the toolbar and
@@ -1185,7 +1185,7 @@ view in Figure 2. That clearly blows through our 33 ms budget. So, what can
 we do?
 
 ::: {.center}
-![Figure 2: Tracing for render and raster of one frame of the timer script](examples/example12-trace-count-render-raster.png)
+![Figure 2: Tracing for render and raster of one frame of the timer script.](examples/example12-trace-count-render-raster.png)
 :::
 
 ::: {.further}
@@ -1717,7 +1717,7 @@ into one of the tracing tools, you should see something like Figure 3.
 :::
 
 ::: {.center}
-![Figure 3: Tracing for the timer script in two-threads mode](examples/example12-trace-count-two-threads.png)
+![Figure 3: Tracing for the timer script in two-threads mode.](examples/example12-trace-count-two-threads.png)
 :::
 
 You can see how the render and raster tasks now happen on different
@@ -1957,7 +1957,7 @@ time as main-thread work).
 :::
 
 ::: {.center}
-![Figure 4: Trace output of threaded scrolling on the counting demo](examples/example12-count-with-scroll.png)
+![Figure 4: Trace output of threaded scrolling on the counting demo.](examples/example12-count-with-scroll.png)
 :::
 
 As you've seen, moving tasks to the

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -252,7 +252,7 @@ in Figure 1.
 
 ::: {.print-only}
 ![Figure 1: The browser can evaluate JavaScript and JavaScript code can call
-back into the browser](im/scripts-calls.png)
+back into the browser.](im/scripts-calls.png)
 :::
 
 We can call that JavaScript code our "JavaScript runtime"; we run it
@@ -482,7 +482,7 @@ indirection. I'll use simple numeric identifier, which I'll call a
 ::: {.center}
 ![Figure 2: The relationship between `Node` objects in JavaScript and
 `Element`/`Text` objects in the browser is maintained through
-handles](im/scripts-handles.png)
+handles.](im/scripts-handles.png)
 :::
 
 We'll need to keep track of the handle to node mapping. Let's create a
@@ -646,7 +646,7 @@ It's basically Tk's `bind`, but in the browser---see Figure 3.
 Let's implement it.
 
 ::: {.center}
-![Figure 3: The browser calls into JavaScript when events happen](im/scripts-events.png)
+![Figure 3: The browser calls into JavaScript when events happen.](im/scripts-events.png)
 :::
 
 Let's start with generating events. I'll create a `dispatch_event`

--- a/book/security.md
+++ b/book/security.md
@@ -66,7 +66,7 @@ as shown in Figure 1 is the core principle.
 ::: {.center}
 ![Figure 1: The server assigns cookies to the browser with the `Set-Cookie`
 header, and the browser thereafter identifies itself with the `Cookie`
-header](im/security-cookies.png)
+header.](im/security-cookies.png)
 :::
 
 Let's use cookies to write a login system for our guest book. Each

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -930,9 +930,11 @@ Figure 2: Example of black semi-transparent text blending into an orange backgro
 
 ::: {.print-only}
 
-![Figure 2: Example of black semi-transparent text blending into an orange background](examples/example11-opacity-blend.png)
-
+![Figure 2: Example of black semi-transparent text blending into an orange background.
+(See [the website][figure2-website] for a full color image.)](examples/example11-opacity-blend.png)
 :::
+
+[figure2-website]: https://browser.engineering/visual-effects.html
 
 Note that the text is a kind of dark orange, because its color is
 a mix of 50% black and 50% orange.
@@ -983,7 +985,7 @@ Figure 3: Example of black text on an orange background, then blended semi-trans
 
 ::: {.print-only}
 
-![Figure 3: Example of black text on an orange background, then blended semi-transparently into its ancestor](examples/example11-text-blending.png)
+![Figure 3: Example of black text on an orange background, then blended semi-transparently into its ancestor. (See [the website][figure2-website] for a full color image.)](examples/example11-text-blending.png)
 
 :::    
 
@@ -1047,7 +1049,7 @@ contents need to be blended together into the parent.[^stacking-context-disc]
     
 ::: {.center}
 ![Figure 4: A rendered web page is actually the result of stacking and blending
-a series of different surfaces](im/visual-effects-surfaces.jpg)
+a series of different surfaces.](im/visual-effects-surfaces.jpg)
 :::
 
 [^stacking-context-disc]: This tree of surfaces is an implementation strategy
@@ -1332,11 +1334,11 @@ Parent
 :::
 
 ::: {.web-only}
-Figure 5: Example of the `difference` value for `mix-blend-mode` with a blue child and orange parent, resulting in pink
+Figure 5: Example of the `difference` value for `mix-blend-mode` with a blue child and orange parent, resulting in pink.
 :::
 
 ::: {.print-only}
-![Figure 5: Example of the `difference` value for `mix-blend-mode` with a blue child and orange parent, resulting in pink](examples/example11-difference-blend-mode.png)
+![Figure 5: Example of the `difference` value for `mix-blend-mode` with a blue child and orange parent, resulting in pink.](examples/example11-difference-blend-mode.png)
 :::
 
 Here, when blue overlaps with orange, we see pink: blue has (red,
@@ -1493,7 +1495,7 @@ an example.] Consider this example:
 [longword]: examples/example11-longword.html
 
 ::: {.center}
-![Figure 6: An example of overflowing text not being clipped by rounded corners \label{longword-example}](examples/example11-longword.png)
+![Figure 6: An example of overflowing text not being clipped by rounded corners. \label{longword-example}](examples/example11-longword.png)
 :::
 
 ``` {.html .example}
@@ -1520,7 +1522,7 @@ Figure 7: An example of overflow from text children of a div with
 
 ::: {.print-only}
 ![Figure 7: An example of overflow from text children of a div with
-`overflow:clip` and `border-radius` being clipped out](examples/example11-overflow-clip.png)
+`overflow:clip` and `border-radius` being clipped out.](examples/example11-overflow-clip.png)
 :::
 
 Observe that the letters near the corner are cut off to maintain a sharp rounded

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -931,7 +931,7 @@ Figure 2: Example of black semi-transparent text blending into an orange backgro
 ::: {.print-only}
 
 ![Figure 2: Example of black semi-transparent text blending into an orange background.
-(See [the website][figure2-website] for a full color image.)](examples/example11-opacity-blend.png)
+(See [the website][figure2-website] for a full-color image.)](examples/example11-opacity-blend.png)
 :::
 
 [figure2-website]: https://browser.engineering/visual-effects.html
@@ -985,7 +985,7 @@ Figure 3: Example of black text on an orange background, then blended semi-trans
 
 ::: {.print-only}
 
-![Figure 3: Example of black text on an orange background, then blended semi-transparently into its ancestor. (See [the website][figure2-website] for a full color image.)](examples/example11-text-blending.png)
+![Figure 3: Example of black text on an orange background, then blended semi-transparently into its ancestor. (See [the website][figure2-website] for a full-color image.)](examples/example11-text-blending.png)
 
 :::    
 


### PR DESCRIPTION
I also fixed all of the figures that didn't end in a period across all chapters.