### PR TITLE
Tag names are lower-case

### DIFF
--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -285,6 +285,14 @@ Rendering will read out the accessibility instructions:
     >>> document.children[0].children[0].attributes
     {'src': 'my-url', 'alt': 'This is alt text'}
 
+    Tag and attribute names are lower-cased:
+    >>> parser = lab15.HTMLParser('<IMG SRC=my-url alt="This is alt text">')
+    >>> document = parser.parse()
+    >>> lab15.print_tree(document)
+     <html>
+       <body>
+         <img src="my-url" alt="This is alt text">
+
 Here are some brief tests for the attribute parser. First, that it allows
 spaces:
 

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -643,7 +643,7 @@ class AttributeParser:
         attributes = {}
         tag = None
 
-        tag = self.word()
+        tag = self.word().casefold()
         while self.i < len(self.s):
             self.whitespace()
             key = self.word()

--- a/src/lab4-tests.md
+++ b/src/lab4-tests.md
@@ -68,6 +68,14 @@ Attributes can be set on tags:
 	     <div name1="value1" name2="value2">
 	       'text'
 
+    Tag and attribute names are lower-cased:
+    >>> parser = lab4.HTMLParser('<A HREF=my-url attr=my-attr>')
+    >>> document = parser.parse()
+    >>> lab4.print_tree(document)
+     <html>
+       <body>
+         <a href="my-url" attr="my-attr">
+
 Testing Layout
 ==============
 


### PR DESCRIPTION
(note: this code is not referenced in the actual book at the moment)

Fixes #1293.