### PR TITLE
add footnote referencing color on the website

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -970,9 +970,18 @@ Check that your browser renders dark-orange text for the example
 above. That shows that it's actually mixing the black color with the
 existing orange color from the background.
 
+::: {.web-only}
 However, there's another, subtly different way to create transparency
 with CSS. Here, 50% transparency is applied to the whole element using
 the `opacity` property, as in Figure 3.
+:::
+
+::: {.print-only}
+However, there's another, subtly different way to create transparency
+with CSS. Here^[See the website for the example and how it reflects in colors],
+50% transparency is applied to the whole element using
+the `opacity` property, as in Figure 3.
+:::
 
 ::: {.web-only}
 <div style="font-size: 50px; padding: 15px; text-align: center;

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -979,7 +979,7 @@ the `opacity` property, as in Figure 3.
 ::: {.print-only}
 However, there's another, subtly different way to create transparency
 with CSS. Here^[See the `browser.engineering` website for the example and
-how it reflects in colors.], 50% transparency is applied to the whole element
+how it looks in color.], 50% transparency is applied to the whole element
 using the `opacity` property, as in Figure 3.
 :::
 

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -978,9 +978,9 @@ the `opacity` property, as in Figure 3.
 
 ::: {.print-only}
 However, there's another, subtly different way to create transparency
-with CSS. Here^[See the website for the example and how it reflects in colors.],
-50% transparency is applied to the whole element using
-the `opacity` property, as in Figure 3.
+with CSS. Here^[See the `browser.engineering` website for the example and
+how it reflects in colors.], 50% transparency is applied to the whole element
+using the `opacity` property, as in Figure 3.
 :::
 
 ::: {.web-only}

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -978,7 +978,7 @@ the `opacity` property, as in Figure 3.
 
 ::: {.print-only}
 However, there's another, subtly different way to create transparency
-with CSS. Here^[See the website for the example and how it reflects in colors],
+with CSS. Here^[See the website for the example and how it reflects in colors.],
 50% transparency is applied to the whole element using
 the `opacity` property, as in Figure 3.
 :::


### PR DESCRIPTION
The opacity example is not possible to understand without reference to the website. I added a footnote as the most minimal fix; in any case looking at the website will be necessary to see the colors.