### PR TITLE
Fix interaction of rAF with wrap

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -963,7 +963,7 @@ In this code I used a new `dispatch_RAF` method:
 ``` {.python expected=False}
 class JSContext:
     def dispatch_RAF(self):
-        self.interp.evaljs(code)
+        self.interp.evaljs("window.__runRAFHandlers()")
 ```
 
 Note that the `needs_accessibility`, `pending_hover`, and other flags

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -959,11 +959,11 @@ class Tab:
 ```
 
 In this code I used a new `dispatch_RAF` method, which is just like the
-pre-iframe code but wraps the call for the specified `window_id`:
+pre-iframe code:
 
 ``` {.python}
 class JSContext:
-    def dispatch_RAF(self, window_id):
+    def dispatch_RAF(self):
         self.interp.evaljs(code)
 ```
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -961,10 +961,9 @@ class Tab:
 In this code I used a new `dispatch_RAF` method, which is just like the
 pre-iframe code but wraps the call for the specified `window_id`:
 
-``` {.python}
+``` {.python expected=False}
 class JSContext:
     def dispatch_RAF(self, window_id):
-        code = self.wrap("window.__runRAFHandlers()", window_id)
         self.interp.evaljs(code)
 ```
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -960,7 +960,7 @@ class Tab:
 
 In this code I used a new `dispatch_RAF` method:
 
-``` {.python}
+``` {.python expected=False}
 class JSContext:
     def dispatch_RAF(self):
         self.interp.evaljs(code)

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -958,8 +958,7 @@ class Tab:
         # ...
 ```
 
-In this code I used a new `dispatch_RAF` method, which is just like the
-pre-iframe code:
+In this code I used a new `dispatch_RAF` method:
 
 ``` {.python}
 class JSContext:

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -961,7 +961,7 @@ class Tab:
 In this code I used a new `dispatch_RAF` method, which is just like the
 pre-iframe code but wraps the call for the specified `window_id`:
 
-``` {.python expected=False}
+``` {.python}
 class JSContext:
     def dispatch_RAF(self, window_id):
         self.interp.evaljs(code)


### PR DESCRIPTION
`wrap` is not defined until later, after a discussion of the global window object. For now we can just skip that line
and get the point across. The section that defines `wrap` says also "We'll need to call `wrap` any time we use `evaljs`", which implies rAF also.