### PR TITLE
Classify what is an example and what isn't

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -579,6 +579,7 @@ we also need to set dark mode when changing tabs, since all tabs should
 be either dark or light:
 
 ``` {.python}
+class Browser:
    def set_active_tab(self, tab):
         # ...
         task = Task(self.active_tab.set_dark_mode, self.dark_mode)
@@ -1135,7 +1136,7 @@ If you print out `focusable_nodes` for the
 [focus example](examples/example14-focus.html), you should
 get this:
 
-``` {.python .example}
+``` {.python .output}
 [<a tabindex="1" href="/">,
  <button tabindex="2">,
  <div tabindex="3">,
@@ -1353,7 +1354,9 @@ means you can write a selector like this:
 
 [pseudoclass]: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
 
-    div:focus { ... }
+``` {.css .example}
+div:focus { ... }
+```
 
 And then that selector applies only to `<div>` elements that are
 currently focused.[^why-pseudoclass]
@@ -1422,7 +1425,9 @@ customize the focus outline itself and not just the element. That can be done
 by adding support for the CSS [`outline` property][outline], which looks like
 this (for a 3-pixel-thick red outline):[^outline-syntax]
 
-    outline: 3px solid red;
+``` {.css .example}
+outline: 3px solid red;
+```
 
 [outline]: https://developer.mozilla.org/en-US/docs/Web/CSS/outline
 
@@ -1695,7 +1700,7 @@ class AccessibilityNode:
 Here is the accessibility tree for the
 [focus example](examples/example14-focus.html):
 
-``` {.text .example}
+``` {.output}
  role=document
    role=button
      role=focusable text
@@ -1965,7 +1970,7 @@ This text construction logic is, of course, pretty naive, but it's
 enough to demonstrate the idea. Here is how it works out for the
 [focus example](examples/example14-focus.html):
 
-``` {.text .example}
+``` {.output}
  role=document text=Document
    role=button text=Button
      role=focusable text text=Focusable text: This is a button

--- a/book/animations.md
+++ b/book/animations.md
@@ -268,9 +268,9 @@ browser is using; this will help you verify that it's actually using
 your GPU. I'm using a Chromebook to write this chapter, so for me it
 says:[^virgl]
 
-::: {.example}
-    OpenGL initialized: vendor=b'Red Hat', renderer=b'virgl'
-:::
+``` {.output}
+OpenGL initialized: vendor=b'Red Hat', renderer=b'virgl'
+```
 
 [^virgl]: The `virgl` renderer stands for "virtual GL", a way of
 hardware-accelerating the Linux subsystem of ChromeOS that works with
@@ -448,21 +448,21 @@ class Tab:
 For our opacity example, the (key part of) the display list for one frame
 might look like this:
 
-::: {.example}
-    Blend(alpha=0.119866666667)
-      DrawText(text=This)
-      DrawText(text=text)
-      DrawText(text=fades)
-:::
+``` {.output}
+Blend(alpha=0.119866666667)
+  DrawText(text=This)
+  DrawText(text=text)
+  DrawText(text=fades)
+```
 
 On the next frame, it instead might like this:
 
-::: {.example}
-    Blend(alpha=0.112375)
-      DrawText(text=This)
-      DrawText(text=text)
-      DrawText(text=fades)
-:::
+``` {.output}
+Blend(alpha=0.112375)
+  DrawText(text=This)
+  DrawText(text=text)
+  DrawText(text=fades)
+```
 
 In each case, rastering this display list means first rastering the three words
 to a Skia surface created by `Blend`, and then copying that to the root
@@ -473,29 +473,29 @@ The idea is to first raster the three words to a separate surface (but this time
 owned by us, not Skia), which we'll call a *composited layer*, that is saved
 for future use:
 
-::: {.example}
-    Composited Layer:
-      DrawText(text=This)
-      DrawText(text=text)
-      DrawText(text=fades)
-:::
+``` {.output}
+Composited Layer:
+  DrawText(text=This)
+  DrawText(text=text)
+  DrawText(text=fades)
+```
 
 Now instead of rastering those three words, we can just copy over the
 composited layer with a `DrawCompositedLayer` command:
 
-::: {.example}
-    Blend(alpha=0.112375)
-      DrawCompositedLayer()
-:::
+``` {.output}
+Blend(alpha=0.112375)
+  DrawCompositedLayer()
+```
 
 Importantly, on the next frame, the `Blend` changes but the
 `DrawText`s don't, so on that frame all we need to do is re-run the
 `Blend`:
 
-::: {.example}
-    Blend(alpha=0.119866666667)
-      DrawCompositedLayer()
-:::
+``` {.output}
+Blend(alpha=0.119866666667)
+  DrawCompositedLayer()
+```
 
 In other words, the idea behind compositing is to split the display
 list into two pieces: a set of composited layers, which are rastered

--- a/book/chrome.md
+++ b/book/chrome.md
@@ -30,7 +30,7 @@ contain a `TextLayout` for each word in that line. These new classes
 can make the layout tree look different from the HTML tree. So to
 avoid surprises, let's look at a simple example:
 
-``` {.html}
+``` {.html .example}
 <html>
   <body>
     Here is some text that is
@@ -43,21 +43,23 @@ avoid surprises, let's look at a simple example:
 The text in the `body` element wraps across two lines (because of the
 `br` element), so the layout tree will have this structure:
 
-    DocumentLayout
-      BlockLayout[block] (html element)
-        BlockLayout[inline] (body element)
-          LineLayout (first line of text)
-            TextLayout ("Here")
-            TextLayout ("is")
-            TextLayout ("some")
-            TextLayout ("text")
-            TextLayout ("that")
-            TextLayout ("is")
-          LineLayout (second line of text)
-            TextLayout ("spread")
-            TextLayout ("across")
-            TextLayout ("multiple")
-            TextLayout ("lines")
+``` {.output}
+DocumentLayout
+  BlockLayout[block] (html element)
+    BlockLayout[inline] (body element)
+      LineLayout (first line of text)
+        TextLayout ("Here")
+        TextLayout ("is")
+        TextLayout ("some")
+        TextLayout ("text")
+        TextLayout ("that")
+        TextLayout ("is")
+      LineLayout (second line of text)
+        TextLayout ("spread")
+        TextLayout ("across")
+        TextLayout ("multiple")
+        TextLayout ("lines")
+```
 
 Note how one `body` element corresponds to a `BlockLayout` with two
 `LineLayout`s inside, and how two text nodes turn into a total of ten

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1688,12 +1688,12 @@ window.Node = function(handle) { this.handle = handle; }
 Do the same for every function or variable in the `runtime.js` file.
 If you miss one, you'll get errors like this:
 
-::: {.example}
-    dukpy.JSRuntimeError: ReferenceError: identifier 'Node'
-        undefined
-    	duk_js_var.c:1258
-    	eval src/pyduktape.c:1 preventsyield
-:::
+``` {.example}
+dukpy.JSRuntimeError: ReferenceError: identifier 'Node'
+    undefined
+	duk_js_var.c:1258
+	eval src/pyduktape.c:1 preventsyield
+```
 
 If you see this error, it means you need to find where you need
 to write `window.Node` instead of `Node`. You'll also need to modify

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1688,11 +1688,11 @@ window.Node = function(handle) { this.handle = handle; }
 Do the same for every function or variable in the `runtime.js` file.
 If you miss one, you'll get errors like this:
 
-``` {.example}
+``` {.output}
 dukpy.JSRuntimeError: ReferenceError: identifier 'Node'
     undefined
-	duk_js_var.c:1258
-	eval src/pyduktape.c:1 preventsyield
+    duk_js_var.c:1258
+    eval src/pyduktape.c:1 preventsyield
 ```
 
 If you see this error, it means you need to find where you need

--- a/book/forms.md
+++ b/book/forms.md
@@ -26,7 +26,7 @@ form might be written like this (see results in Figure 1):
     represent different kinds of user controls, like dropdowns and
     multi-line inputs.
 
-``` {.html}
+``` {.html .example}
 <form action="/submit" method="post">
     <p>Name: <input name=name value=1></p>
     <p>Comment: <input name=comment value=2></p>
@@ -47,7 +47,7 @@ to the URL given by the `form` element's `action` attribute, with the
 usual rules of relative URLs---so in this case, `/submit`. The `POST`
 request looks like this:
 
-``` {.example}
+``` {.output}
 POST /submit HTTP/1.0
 Host: example.org
 Content-Length: 16

--- a/book/html.md
+++ b/book/html.md
@@ -310,7 +310,7 @@ print_tree(nodes)
 
 You'll see something like this at the beginning:
 
-``` {.example}
+``` {.output}
  <!doctype html>
    '\n'
    <html lang="en-US" xml:lang="en-US">
@@ -366,7 +366,7 @@ def add_text(self, text):
 The first part of the parsed HTML tree for the `browser.engineering` home page now
 looks something like this:
 
-``` {.example}
+``` {.output}
  <html lang="en-US" xml:lang="en-US">
    <head>
      <meta charset="utf-8" /="">
@@ -514,16 +514,16 @@ def add_tag(self, tag):
 Remember to use `tag` and `attribute` instead of `text` in `add_tag`,
 and try your parser again:
 
-``` {.example}
-<html>
-   <head>
-     <meta>
-     <link>
-     <link>
-     <link>
-     <link>
-     <link>
-     <meta>
+``` {.output}
+ <html>
+    <head>
+      <meta>
+      <link>
+      <link>
+      <link>
+      <link>
+      <link>
+      <meta>
 ```
 
 It's close! Yes, if you print the attributes, you'll see that
@@ -649,7 +649,7 @@ with dozens of ever-more-special cases forming a taxonomy of human
 error, but one of its nicer features is *implicit* tags. Normally, an
 HTML document starts with a familiar boilerplate:
 
-``` {.html}
+``` {.html .example}
 <!doctype html>
 <html>
   <head>

--- a/book/http.md
+++ b/book/http.md
@@ -109,9 +109,11 @@ manager, usually from packages called `telnet` and `netcat`.
 
 You'll get output that looks like this:
 
-    Trying 93.184.216.34...
-    Connected to example.org.
-    Escape character is '^]'.
+``` {.output}
+Trying 93.184.216.34...
+Connected to example.org.
+Escape character is '^]'.
+```
 
 This means that the OS converted the host name `example.org` into the
 IP address `93.184.216.34` and was able to connect to it.[^10] You can
@@ -513,7 +515,7 @@ types to text and to bytes:
     character encoding and will work on many pages, but in the real
     world you would need to be more careful.
 
-``` {.python .example}
+``` {.python .output}
 >>> type("text")
 <class 'str'>
 >>> type("text".encode("utf8"))
@@ -880,7 +882,9 @@ class URL:
 Custom ports are handy for debugging. Python has a built-in web server
 you can use to serve files on your computer. For example, if you run
 
-    python3 -m http.server 8000 -d /some/directory
+``` {.sh}
+python3 -m http.server 8000 -d /some/directory
+```
 
 then going to `http://localhost:8000/` should show you all the files
 in that directory. This is a good way to test your browser.
@@ -897,7 +901,7 @@ Here is what it should output for [a simple example][example-simple]:
 
 [example-simple]: examples/example1-simple.html
 
-``` {.example}
+``` {.output}
 
   
     This is a simple

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -1780,31 +1780,31 @@ class DocumentLayout:
 If you look at your output again, you should now see two phases.
 First, there's a lot of `style` re-computation:
     
-::: {.example}
-    Change ProtectedField(<body>, style)
-    Change ProtectedField(<header>, style)
-    Change ProtectedField(<h1 class="title">, style)
-    Change ProtectedField('Reusing Previous Computations', style)
-    Change ProtectedField(<a href="...">, style)
-    Change ProtectedField('Twitter', style)
-    Change ProtectedField(' ·\n', style)
-    ...
-:::
+``` {.output}
+Change ProtectedField(<body>, style)
+Change ProtectedField(<header>, style)
+Change ProtectedField(<h1 class="title">, style)
+Change ProtectedField('Reusing Previous Computations', style)
+Change ProtectedField(<a href="...">, style)
+Change ProtectedField('Twitter', style)
+Change ProtectedField(' ·\n', style)
+...
+```
 
 Then, we recompute four layout fields repeatedly:
 
-::: {.example}
-    Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
-    Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
-    Change ProtectedField(<head>, zoom)
-    Change ProtectedField(<head>, children)
-    Change ProtectedField(<head>, height)
-    Change ProtectedField(<body>, zoom)
-    Change ProtectedField(<body>, y)
-    Change ProtectedField(<header>, zoom)
-    Change ProtectedField(<header>, y)
-    ...
-:::
+``` {.output}
+Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
+Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
+Change ProtectedField(<head>, zoom)
+Change ProtectedField(<head>, children)
+Change ProtectedField(<head>, height)
+Change ProtectedField(<body>, zoom)
+Change ProtectedField(<body>, y)
+Change ProtectedField(<header>, zoom)
+Change ProtectedField(<header>, y)
+...
+```
 
 Let's fix these. First, let's tackle `style`. The reason `style` is
 being recomputed repeatedly is just that we recompute it even if
@@ -1853,11 +1853,11 @@ value, any downstream computations don't actually need to change. This
 small tweak should reduce the number of field changes down to the
 minimum:
 
-::: {.example}
-    Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
-    Change ProtectedField(<div class="demo" ...>, children)
-    Change ProtectedField(<div class="demo" ...>, height)
-:::
+``` {.output}
+Change ProtectedField(<html lang="en-US" xml:lang="en-US">, zoom)
+Change ProtectedField(<div class="demo" ...>, children)
+Change ProtectedField(<div class="demo" ...>, height)
+```
 
 All that's happening here is recreating the `contenteditable`
 element's `children` (which we have to do, to incorporate the new

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -170,7 +170,7 @@ we'll implement `setTimeout` by saving the callback in a JavaScript
 variable and creating a handle by which the Python-side code can call
 it:
 
-``` {.javascript file=runtime}
+``` {.javascript}
 SET_TIMEOUT_REQUESTS = {}
 
 function setTimeout(callback, time_delta) {
@@ -192,7 +192,7 @@ callback. That last part will happen via `__runSetTimeout`:[^mem-leak]
     between the browser and the browser application takes a lot of
     care and this book doesn't attempt to do it right.
 
-``` {.javascript file=runtime}
+``` {.javascript}
 function __runSetTimeout(handle) {
     var callback = SET_TIMEOUT_REQUESTS[handle]
     callback();
@@ -403,7 +403,7 @@ send the response back to the script.
 Like with `setTimeout`, we'll store the callback on the
 JavaScript side and refer to it with a handle:
 
-``` {.javascript file=runtime}
+``` {.javascript}
 XHR_REQUESTS = {}
 
 function XMLHttpRequest() {
@@ -418,7 +418,7 @@ we'll now allow the `is_async` flag to be true:[^async-default]
 [^async-default]: In browsers, the `is_async` parameter is optional
     and defaults to `true`, but our browser doesn't implement that.
 
-``` {.javascript file=runtime}
+``` {.javascript}
 XMLHttpRequest.prototype.open = function(method, url, is_async) {
     this.is_async = is_async;
     this.method = method;
@@ -429,7 +429,7 @@ XMLHttpRequest.prototype.open = function(method, url, is_async) {
 The `send` method will need to send over the `is_async` flag and the
 handle:
 
-``` {.javascript file=runtime}
+``` {.javascript}
 XMLHttpRequest.prototype.send = function(body) {
     this.responseText = call_python("XMLHttpRequest_send",
         this.method, this.url, body, this.is_async, this.handle);
@@ -842,7 +842,7 @@ be confident that it will be rendered right away.
 The implementation of this JavaScript API is straightforward. Like
 before, we store the callbacks on the JavaScript side:
 
-``` {.javascript file=runtime}
+``` {.javascript}
 RAF_LISTENERS = [];
 
 function requestAnimationFrame(fn) {
@@ -881,7 +881,7 @@ class Tab:
 
 This `__runRAFHandlers` function is a little tricky:
 
-``` {.javascript file=runtime}
+``` {.javascript}
 function __runRAFHandlers() {
     var handlers_copy = RAF_LISTENERS;
     RAF_LISTENERS = [];
@@ -1747,7 +1747,7 @@ much. But it's still possible for really slow JavaScript to slow the
 browser down. For example, imagine our counter adds the following
 artificial slowdown:
 
-``` {.javascript file=eventloop .example}
+``` {.javascript file=eventloop}
 function callback() {
     for (var i = 0; i < 5e6; i++);
     // ...

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -60,11 +60,8 @@ the `duktape` library that `dukpy` uses.
 
 To test whether you installed DukPy correctly, execute this:
 
-``` {.python}
-import dukpy
-```
-
 ``` {.python .example}
+import dukpy
 dukpy.evaljs("2 + 2")
 ```
 
@@ -131,7 +128,7 @@ def load(self, url, payload=None):
 This should run before styling and layout. To try it out, create a
 simple web page with a `script` tag:
 
-``` {.html}
+``` {.html .example}
 <script src=test.js></script>
 ```
 
@@ -144,7 +141,9 @@ x + x
 
 Point your browser at that page, and you should see:
 
-    Script returned: 4
+``` {.output}
+Script returned: 4
+```
 
 That's your browser running its first bit of JavaScript!
 
@@ -200,7 +199,7 @@ As a side benefit of using one `JSContext` for all scripts, it is now
 possible to run two scripts and have one of them define a variable
 that the other uses, say on a page like this:
 
-``` {.html}
+``` {.html .example}
 <script src=a.js></script>
 <script src=b.js></script>
 ```
@@ -462,9 +461,11 @@ def querySelectorAll(self, selector_text):
 
 However, this throws an error:[^7]
 
-    _dukpy.JSRuntimeError: EvalError:
-    Error while calling Python Function:
-    TypeError('Object of type Element is not JSON serializable')
+``` {.output}
+_dukpy.JSRuntimeError: EvalError:
+Error while calling Python Function:
+TypeError('Object of type Element is not JSON serializable')
+```
 
 [^7]: Yes, that's a confusing error message. Is it a `JSRuntimeError`,
     an `EvalError`, or a `TypeError`? The confusion is a consequence

--- a/book/security.md
+++ b/book/security.md
@@ -47,17 +47,17 @@ Here are the technical details. An HTTP response can contain a
 example, the following header sets the value of the `foo` cookie to
 `bar`:
 
-::: {.example}
-    Set-Cookie: foo=bar
-:::
+``` {.example}
+Set-Cookie: foo=bar
+```
     
 The browser remembers this key–value pair, and the next time it makes
 a request to the same server (cookies are site-specific), the browser
 echoes it back in the `Cookie` header:
 
-::: {.example}
-    Cookie: foo=bar
-:::
+``` {.example}
+Cookie: foo=bar
+```
 
 Servers can set multiple cookies, and also set parameters like
 expiration dates, but this `Set-Cookie` / `Cookie` transaction
@@ -654,7 +654,7 @@ called *cross-site request forgery*, often shortened to CSRF.
 In cross-site request forgery, instead of using `XMLHttpRequest`, the
 attacker uses a form that submits to the guest book:
 
-``` {.html}
+``` {.html .example}
 <form action="http://localhost:8000/add" method=post>
   <p><input name=guest></p>
   <p><button>Sign the book!</button></p>
@@ -781,9 +781,9 @@ will not send them in cross-site form submissions.[^in-progress]
 
 A cookie is marked `SameSite` in the `Set-Cookie` header like this:
 
-::: {.example}
-    Set-Cookie: foo=bar; SameSite=Lax
-:::
+``` {.example}
+Set-Cookie: foo=bar; SameSite=Lax
+```
 
 The `SameSite` attribute can take the value `Lax`, `Strict`, or
 `None`, and as I write, browsers have and plan different defaults. Our
@@ -992,7 +992,7 @@ Hi! <script src="http://my-server/evil.js"></script>
 
 The server would then output this HTML:
 
-``` {.html .example}
+``` {.html .output}
 <p>Hi! <script src="http://my-server/evil.js"></script>
 <i>by crashoverride</i></p>
 ```
@@ -1065,9 +1065,9 @@ specification for this header is quite complex, but in the simplest
 case, the header is set to the keyword `default-src` followed by a
 space-separated list of servers:
 
-::: {.example}
-    Content-Security-Policy: default-src http://example.org
-:::
+``` {.example}
+Content-Security-Policy: default-src http://example.org
+```
 
 This header asks the browser not to load any resources (including CSS,
 JavaScript, images, and so on) except from the listed origins. If our

--- a/book/text.md
+++ b/book/text.md
@@ -131,7 +131,7 @@ Measuring Text
 Text takes up space vertically and horizontally, and the font object's
 `metrics` and `measure` methods measure that space:[^spacing]
 
-``` {.python .example}
+``` {.python .output}
 >>> bi_times.metrics()
 {'ascent': 15, 'descent': 4, 'linespace': 19, 'fixed': 0}
 >>> bi_times.measure("Hi!")
@@ -191,7 +191,7 @@ varying heights:[^varying-times]
     specified a bold, italic Times font. The bold, italic Times font
     is taller, at least on my current macOS system!
 
-``` {.python .example}
+``` {.python .output}
 >>> tkinter.font.Font(family="Courier", size=16).metrics()
 {'fixed': 1, 'ascent': 13, 'descent': 4, 'linespace': 17}
 >>> tkinter.font.Font(family="Times", size=16).metrics()
@@ -204,7 +204,7 @@ The `measure()` method is more direct: it tells you how much
 *horizontal* space text takes up, in pixels. This depends on the text,
 of course, since different letters have different widths:[^widths]
 
-``` {.python .example}
+``` {.python .output}
 >>> bi_times.measure("Hi!")
 24
 >>> bi_times.measure("H")

--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -39,7 +39,9 @@ graphics cards and GPUs became widespread.
 ::: {.installation}
 Start by installing [Skia][skia-python] and [SDL][sdl-python]:
 
-    python3 -m pip install 'skia-python==87.*' pysdl2 pysdl2-dll
+``` {.sh}
+python3 -m pip install 'skia-python==87.*' pysdl2 pysdl2-dll
+```
 
 As elsewhere in this book, you may need to install the `pip` package
 first, or use your IDE's package installer. If you're on Linux, you'll

--- a/infra/compare.py
+++ b/infra/compare.py
@@ -131,6 +131,7 @@ def compare_files(book, code, language, file):
                 print(f"{block.loc}:", error)
                 failure += 1
             continue
+        if "output" in block.classes: continue
         if "example" in block.classes and not block.file: continue
         if language and language not in block.classes: continue
         if block.file != file: continue

--- a/src/runtime12.js
+++ b/src/runtime12.js
@@ -93,10 +93,7 @@ function requestAnimationFrame(fn) {
 }
 
 function __runRAFHandlers() {
-    var handlers_copy = [];
-    for (var i = 0; i < RAF_LISTENERS.length; i++) {
-        handlers_copy.push(RAF_LISTENERS[i]);
-    }
+    var handlers_copy = RAF_LISTENERS;
     RAF_LISTENERS = [];
     for (var i = 0; i < handlers_copy.length; i++) {
         handlers_copy[i]();

--- a/www/book.css
+++ b/www/book.css
@@ -175,7 +175,7 @@ body.main { padding: 0 4ex; }
   .note form { display: inline; }
 }
 
-.todo, .quirk, .warning, .installation, .further, .demo, .example { padding: 1em 1em 0; margin: 1em 0; }
+.todo, .quirk, .warning, .installation, .further, .demo, .example, .output { padding: 1em 1em 0; margin: 1em 0; }
 .quirk:before, .warning:before, .installation:before {
     font-weight: bold; font-family: 'Vollkorn', 'Garamond', serif;
     text-align: center;
@@ -197,7 +197,7 @@ img { max-width: 100%; }
 .further > :first-child:before { content: "Go further: "; font-weight: bold; color: green; }
 .widget { width: 100%; border: 2px solid navy; }
 .center { text-align: center }
-.example { border: 2px solid lightgray; padding: 1em }
+.example, .output { border: 2px solid lightgray; padding: 1em }
 
 @media (prefers-color-scheme: dark) {
 .quirk { border: 2px solid #CBC3E3; }


### PR DESCRIPTION
This PR marks some code blocks as examples that incorrectly weren't marked that way. It also marks some example tags as `.output` instead; this is an idea from #1161 that I thought made marking code blocks easier. All of the marks were cross-referenced with the printed book. I think of this both as superseding #1161 and also as preparation for trying to make the style of the online book look more like the printed book.