### PR TITLE
Fix a typo in Chapter 13

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -162,7 +162,7 @@ after all, [Chapter 12](scheduling.md#profiling-rendering) showed
 that raster and draw was about 62`\,`{=latex}` `{=html}ms for simple pages, and render
 was 23`\,`{=latex}` `{=html}ms.
 
-Even with just 62\,{=latex} {=html}ms per frame, our browser is barely doing 15 frames per
+Even with just 62`\,`{=latex}` `{=html}ms per frame, our browser is barely doing 15 frames per
 second; for smooth animations we want 30! So we need to speed up
 raster and draw.
 


### PR DESCRIPTION
This PR fixes a simple typo in chapter 13 :)

https://browser.engineering/animations.html#gpu-acceleration

<img width="831" alt="Screenshot 2024-09-09 at 21 20 12" src="https://github.com/user-attachments/assets/78bda3bc-4736-43a2-a4c5-16785fd7b460">
