### PR TITLE
Fix examples involving script for the JS browser in chapter 9+

### DIFF
--- a/src/lab12.hints
+++ b/src/lab12.hints
@@ -14,6 +14,5 @@
  {"code": "callback", "js": "callback"},
  {"code": "self.file.flush()", "js": "self.file.flush()"},
  {"code": "self.node_to_handle = {}", "js": "    this.node_to_handle = new Map();"},
- {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
- {"code": "open('runtime12.js').read()", "js": "filesystem.open('runtime12.js').read()"}
+ {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"}
 ]

--- a/src/lab13.hints
+++ b/src/lab13.hints
@@ -3,12 +3,7 @@
  {"code": "b'Browser'", "js": "'Browser'"},
  {"code": "MeasureTime()", "js": "new MeasureTime()"},
  {"code": "print", "js": "console.log"},
- {"code": "elt not in self.node_to_handle", "type": "map"},
  {"code": "self.node_to_handle = {}", "js": "    this.node_to_handle = new Map();"},
- {"code": "self.node_to_handle.get(elt, -1)", "js": "this.node_to_handle.get(elt) ?? -1"},
- {"code": "self.node_to_handle[elt]", "js": "this.node_to_handle.get(elt)"},
- {"code": "len(self.node_to_handle)", "js": "this.node_to_handle.size"},
- {"code": "self.node_to_handle[elt] = handle", "js": "      this.node_to_handle.set(elt, handle);"},
  {"code": "('OpenGL initialized: vendor={},' + 'renderer={}').format(OpenGL.GL.glGetString(OpenGL.GL.GL_VENDOR), OpenGL.GL.glGetString(OpenGL.GL.GL_RENDERER))", "js": ""},
  {"code": "self.s[self.i] not in chars", "type": "str"},
  {"code": "property not in old_style", "type": "dict"},
@@ -17,6 +12,5 @@
  {"code": "node not in self.composited_updates", "type": "list"},
  {"code": "new_parent in new_effects", "type": "dict"},
  {"code": "rect.outset(1, 1)", "js": "rect.outset(1, 1)"},
- {"code": "sys.exit()", "js": ""},
- {"code": "open('runtime13.js').read()", "js": "filesystem.open('runtime13.js').read()"}
+ {"code": "sys.exit()", "js": ""}
 ]

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -473,21 +473,6 @@ class JSContext:
         self.node_to_handle = {}
         self.handle_to_node = {}
 
-    def dispatch_event(self, type, elt):
-        handle = self.node_to_handle.get(elt, -1)
-        do_default = self.interp.evaljs(
-            EVENT_DISPATCH_JS, type=type, handle=handle)
-        return not do_default
-
-    def get_handle(self, elt):
-        if elt not in self.node_to_handle:
-            handle = len(self.node_to_handle)
-            self.node_to_handle[elt] = handle
-            self.handle_to_node[handle] = elt
-        else:
-            handle = self.node_to_handle[elt]
-        return handle
-
     def style_set(self, handle, s):
         elt = self.handle_to_node[handle]
         elt.attributes["style"] = s;

--- a/src/lab9.hints
+++ b/src/lab9.hints
@@ -10,6 +10,5 @@
  {"code": "self.node_to_handle[elt]", "js": "this.node_to_handle.get(elt)"},
  {"code": "len(self.node_to_handle)", "js": "this.node_to_handle.size"},
  {"code": "self.node_to_handle[elt] = handle", "js": "      this.node_to_handle.set(elt, handle);"},
- {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
- {"code": "open('runtime9.js').read()", "js": "filesystem.open('runtime9.js').read()"}
+ {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"}
 ]

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -57,7 +57,7 @@ class JSContext:
         return not do_default
 
     def get_handle(self, elt):
-        elt not in self.node_to_handle:
+        if elt not in self.node_to_handle:
             handle = len(self.node_to_handle)
             self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -39,8 +39,7 @@ class JSContext:
         self.interp.export_function("getAttribute",
             self.getAttribute)
         self.interp.export_function("innerHTML_set", self.innerHTML_set)
-        with open("runtime9.js") as f:
-            self.interp.evaljs(RUNTIME_JS)
+        self.interp.evaljs(RUNTIME_JS)
 
         self.node_to_handle = {}
         self.handle_to_node = {}
@@ -58,7 +57,7 @@ class JSContext:
         return not do_default
 
     def get_handle(self, elt):
-        if elt not in self.node_to_handle:
+        elt not in self.node_to_handle:
             handle = len(self.node_to_handle)
             self.node_to_handle[elt] = handle
             self.handle_to_node[handle] = elt

--- a/www/widgets/dukpy.js
+++ b/www/widgets/dukpy.js
@@ -16,6 +16,7 @@ addEventListener("message", (e) => {
             val = eval?.(e.data.body);
         } catch (e) {
             console.log('Script crashed');
+            console.log(e);
         }
         if (val instanceof Function || val instanceof Object) val = null;
         $$POSTMESSAGE({"type": "return", "data": val});

--- a/www/widgets/lab12-browser.html
+++ b/www/widgets/lab12-browser.html
@@ -43,8 +43,8 @@ widget.run(async function() {
     await b.render();
     interval = setInterval(async function() {
       if (b.needs_animation_frame) {
-        await b.render();
         b.needs_animation_frame = false;
+        await b.render();
       }
       await b.raster_and_draw();
       await b.schedule_animation_frame();

--- a/www/widgets/lab13-browser.html
+++ b/www/widgets/lab13-browser.html
@@ -43,8 +43,8 @@ widget.run(async function() {
     await b.render();
     interval = setInterval(async function() {
       if (b.needs_animation_frame) {
-        await b.render();
         b.needs_animation_frame = false;
+        await b.render();
       }
       await b.composite_raster_and_draw();
       await b.schedule_animation_frame();

--- a/www/widgets/lab14-browser.html
+++ b/www/widgets/lab14-browser.html
@@ -43,8 +43,8 @@ widget.run(async function() {
     await b.render();
     interval = setInterval(async function() {
       if (b.needs_animation_frame) {
-        await b.render();
         b.needs_animation_frame = false;
+        await b.render();
       }
       await b.composite_raster_and_draw();
       await b.schedule_animation_frame();

--- a/www/widgets/lab15-browser.html
+++ b/www/widgets/lab15-browser.html
@@ -43,8 +43,8 @@ widget.run(async function() {
     await b.render();
     interval = setInterval(async function() {
       if (b.needs_animation_frame) {
-        await b.render();
         b.needs_animation_frame = false;
+        await b.render();
       }
       await b.composite_raster_and_draw();
       await b.schedule_animation_frame();

--- a/www/widgets/lab16-browser.html
+++ b/www/widgets/lab16-browser.html
@@ -44,8 +44,8 @@ widget.run(async function() {
     await b.render();
     interval = setInterval(async function() {
       if (b.needs_animation_frame) {
-        await b.render();
         b.needs_animation_frame = false;
+        await b.render();
       }
       await b.composite_raster_and_draw();
       await b.schedule_animation_frame();

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -117,7 +117,8 @@ class socket {
             let [line1] = this.input.split("\r\n", 1);
             let [method, path, protocol] = line1.split(" ");
             this.url = this.scheme + "://" + this.host + path;
-            if (this.host == "localhost" && rt_constants.URLS["local://" + this.port]) {
+            if (this.host == "localhost" && rt_constants.URLS["local://" + this.port] &&
+                path.indexOf("example") == -1) {
                 let s = new socket({family: "inet", type: "stream", proto: "tcp"});
                 s.is_proxy_socket = true;
                 s.output = this.input;
@@ -129,7 +130,7 @@ class socket {
                 this.output = typeof response === "function" ? response() : response;
                 this.idx = 0;
                 this.closed = false;
-            } else if (this.host == "browser.engineering") {
+            } else if (this.host == "browser.engineering" || this.host == "localhost") {
                 let response = await fetch(path);
                 this.output = "HTTP/1.0 " + response.status + " " + response.statusText + "\r\n";
                 for (let [header, value] of response.headers.entries()) {


### PR DESCRIPTION
There were several bugs:

1. The lab*.hints files for certain chapters unnecessarily hinted that `open` should map to `filesystem.open`. While that is correct, it caused code in `compiler.py` to detect calls to `open` and insert files on disk into the top of the JS file.
2. lab13.hints had incorrect hints for dispatching JS. Since the code was unchanged from lab9, I just deleted it.
3. lab*-browser.html for chapters 12+ reset needs_animation_frame after calling `render` rather than before. This is incorrect if rAF callbacks set it during `render`'s callouts to JS.
4. localhost was not whitelisted for allowing direct fetching from `rt.js` (only affects debugging flows).

For good measure, I modified rt.js to special-case URLs with "example" in them so that they didn't cause localhost URLs to end up going to `server*.js`. (Alternatively one could run the localhost server at a port other than 8000.)

Now `examples/lab13-opacity-raf.html` works correctly in the JS cross-compiled browser.