### PR TITLE
Use http link for testing the browser in chapter 1

### DIFF
--- a/book/http.md
+++ b/book/http.md
@@ -735,7 +735,7 @@ python3 browser.py http://example.org/
 ```
 
 You should see some short text welcoming you to the official example
-web page. You can also try using it on [this chapter](https://browser.engineering/http.html)!
+web page. You can also try using it on [this chapter](http://browser.engineering/http.html)!
 
 ::: {.further}
 HTML, just like URLs and HTTP, is designed to be very easy to parse and


### PR DESCRIPTION
At the end of section 6, the reader is invited to test their browser by loading this chapter.

The link currently uses https, but support for https is not introduced until section 7. At this point the browser will still have an assertion that `self.scheme` is http, which fails:

```
$ python3 browser.py https://browser.engineering/http.html
Traceback (most recent call last):
  File "/Users/oliverbyford/Code/browser/browser.py", line 68, in <module>
    load(URL(sys.argv[1]))
         ^^^^^^^^^^^^^^^^
  File "/Users/oliverbyford/Code/browser/browser.py", line 6, in __init__
    assert self.scheme == "http"
           ^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

Update the link to use http rather than https, which means the URL will load successfully.