### PR TITLE
Ch 11: follow the Rect class introduced in #974

### DIFF
--- a/book/visual-effects.md
+++ b/book/visual-effects.md
@@ -441,8 +441,8 @@ documentation for more on the Skia API.
 ``` {.python replace=%2c%20scroll/,%20-%20scroll/}
 class DrawLine:
     def execute(self, canvas, scroll):
-        path = skia.Path().moveTo(self.x1 - scroll, self.y1) \
-                          .lineTo(self.x2 - scroll, self.y2)
+        path = skia.Path().moveTo(self.rect.left - scroll, self.rect.top) \
+                          .lineTo(self.rect.right - scroll, self.rect.bottom)
         paint = skia.Paint(
             Color=parse_color(self.color),
             StrokeWidth=self.thickness,
@@ -472,8 +472,8 @@ class DrawText:
             AntiAlias=True,
             Color=parse_color(self.color),
         )
-        baseline = self.top - scroll - self.font.getMetrics().fAscent
-        canvas.drawString(self.text, float(self.left), baseline,
+        baseline = self.rect.top - scroll - self.font.getMetrics().fAscent
+        canvas.drawString(self.text, float(self.rect.left), baseline,
             self.font, paint)
 ```
 
@@ -508,21 +508,17 @@ rectangle (e.g., `left`) were checked, replace them with the
 corresponding function on a Skia `Rect` (e.g., `left()`). Also replace
 calls to `containsPoint` with Skia's `contains`.
 
-While we're here, let's also add a `rect` field to the other drawing
-commands, replacing its `top`, `left`, `bottom`, and `right`
-fields:
-
 ``` {.python}
 class DrawText:
     def __init__(self, x1, y1, text, font, color):
+        self.rect = skia.Rect.MakeLTRB(
+            x1, y1, x1 + font.measure(text), y1 + font.metrics("linespace"))
         # ...
-        self.rect = \
-            skia.Rect.MakeLTRB(x1, y1, self.right, self.bottom)
 
 class DrawLine:
     def __init__(self, x1, y1, x2, y2, color, thickness):
-        # ...
         self.rect = skia.Rect.MakeLTRB(x1, y1, x2, y2)
+        # ...
 ```
 
 To create an outline, draw a rectangle but set the `Style` parameter of

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -137,12 +137,10 @@ class DrawRect:
 @wbetools.patch(DrawText)
 class DrawText:
     def __init__(self, x1, y1, text, font, color):
-        self.left = x1
-        self.top = y1
-        self.right = x1 + font.measureText(text)
-        self.bottom = y1 - font.getMetrics().fAscent + font.getMetrics().fDescent
-        self.rect = \
-            skia.Rect.MakeLTRB(x1, y1, self.right, self.bottom)
+        self.rect = skia.Rect.MakeLTRB(
+            x1, y1,
+            x1 + font.measureText(text),
+            y1 - font.getMetrics().fAscent + font.getMetrics().fDescent)
         self.font = font
         self.text = text
         self.color = color
@@ -152,8 +150,8 @@ class DrawText:
             AntiAlias=True,
             Color=parse_color(self.color),
         )
-        baseline = self.top - self.font.getMetrics().fAscent
-        canvas.drawString(self.text, float(self.left), baseline,
+        baseline = self.rect.top() - self.font.getMetrics().fAscent
+        canvas.drawString(self.text, float(self.rect.left()), baseline,
             self.font, paint)
 
 @wbetools.patch(DrawOutline)
@@ -175,16 +173,12 @@ class DrawOutline:
 class DrawLine:
     def __init__(self, x1, y1, x2, y2, color, thickness):
         self.rect = skia.Rect.MakeLTRB(x1, y1, x2, y2)
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
         self.color = color
         self.thickness = thickness
 
     def execute(self, canvas):
-        path = skia.Path().moveTo(self.x1, self.y1) \
-                          .lineTo(self.x2, self.y2)
+        path = skia.Path().moveTo(self.rect.left(), self.rect.top()) \
+                          .lineTo(self.rect.right(), self.rect.bottom())
         paint = skia.Paint(
             Color=parse_color(self.color),
             StrokeWidth=self.thickness,

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -119,16 +119,12 @@ class Transform(VisualEffect):
 class DrawLine(PaintCommand):
     def __init__(self, x1, y1, x2, y2, color, thickness):
         super().__init__(skia.Rect.MakeLTRB(x1, y1, x2, y2))
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
         self.color = color
         self.thickness = thickness
 
     def execute(self, canvas):
-        path = skia.Path().moveTo(self.x1, self.y1) \
-                          .lineTo(self.x2, self.y2)
+        path = skia.Path().moveTo(self.rect.left(), self.rect.top()) \
+                          .lineTo(self.rect.right(), self.rect.bottom())
         paint = skia.Paint(
             Color=parse_color(self.color),
             StrokeWidth=self.thickness,
@@ -139,7 +135,8 @@ class DrawLine(PaintCommand):
     @wbetools.js_hide
     def __repr__(self):
         return "DrawLine top={} left={} bottom={} right={}".format(
-            self.y1, self.x1, self.y2, self.x2)
+            self.rect.top(), self.rect.left(),
+            self.rect.bottom(), self.rect.right())
 
 class DrawRRect(PaintCommand):
     def __init__(self, rect, radius, color):
@@ -160,23 +157,21 @@ class DrawRRect(PaintCommand):
 
 class DrawText(PaintCommand):
     def __init__(self, x1, y1, text, font, color):
-        self.left = x1
-        self.top = y1
-        self.right = x1 + font.measureText(text)
-        self.bottom = y1 - font.getMetrics().fAscent + font.getMetrics().fDescent
         self.font = font
         self.text = text
         self.color = color
-        super().__init__(skia.Rect.MakeLTRB(x1, y1,
-            self.right, self.bottom))
+        super().__init__(skia.Rect.MakeLTRB(
+            x1, y1,
+            x1 + font.measureText(text),
+            y1 - font.getMetrics().fAscent + font.getMetrics().fDescent))
 
     def execute(self, canvas):
         paint = skia.Paint(
             AntiAlias=True,
             Color=parse_color(self.color)
         )
-        baseline = self.top - self.font.getMetrics().fAscent
-        canvas.drawString(self.text, float(self.left), baseline,
+        baseline = self.rect.top() - self.font.getMetrics().fAscent
+        canvas.drawString(self.text, float(self.rect.left()), baseline,
             self.font, paint)
 
     @wbetools.js_hide


### PR DESCRIPTION
In #974, the Rect class is introduced in Chapter 7 (chrome.md),
but it seems that visual-effects.md hasn't been updated accordingly.