### PR TITLE
Add LaTeX macros that seem to be used by the latest `pandoc`

### DIFF
--- a/infra/template-book.tex
+++ b/infra/template-book.tex
@@ -300,6 +300,16 @@ $if(graphics)$
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
 \makeatother
 % Scale images if necessary, so that they will not overflow the page
 % margins by default, and it is still possible to overwrite the defaults

--- a/latex/macros.tex
+++ b/latex/macros.tex
@@ -27,6 +27,7 @@
 \defbox{further}{Go Further}{ForestGreen}
 \defbox{example}{Example}{Gray}
 \defbox{notcode}{}{Black}
+\defbox{author-picture}{}{Black}
 
 % Finally we define the actual "bookblock" environment that our
 % Markdown will expand divs into


### PR DESCRIPTION
At some point I must have updated Pandoc and when I tried to build the LaTeX version it needed these macros. Not sure what `\pandocbounded` does, I got the source by asking Pandoc to compile a random thing to LaTeX and copying them over. The `author-picture` stuff we added.