### PR TITLE
Ch 12: Improve the sentence about copying CommitData

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1527,8 +1527,9 @@ it was sent and call `set_needs_raster_and_draw` as needed. Because this call
 will come from another thread, we'll need to acquire a lock. Another important
 step is to not clear the `animation_timer` object until *after* the next
 commit occurs. Otherwise multiple rendering tasks could be queued at the same
-time. Finally, save `scroll` in `active_tab_scroll` and `url` in
-`active_tab_url`:
+time. Finally, store all the CommitData: save the `scroll` in `active_tab_scroll`,
+the `url` in `active_tab_url`, and additionally store the `height` and, if available,
+the `display_list`:
 
 ``` {.python}
 class Browser:

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -1527,7 +1527,7 @@ it was sent and call `set_needs_raster_and_draw` as needed. Because this call
 will come from another thread, we'll need to acquire a lock. Another important
 step is to not clear the `animation_timer` object until *after* the next
 commit occurs. Otherwise multiple rendering tasks could be queued at the same
-time. Finally, store all the CommitData: save the `scroll` in `active_tab_scroll`,
+time. Finally, store all the `CommitData`: save the `scroll` in `active_tab_scroll`,
 the `url` in `active_tab_url`, and additionally store the `height` and, if available,
 the `display_list`:
 


### PR DESCRIPTION
Please let me know if I am wrong.

In my understanding,
this sentence only mentioned two items of CommitData, while we are also copying data.height and data.display_list.

This patch rewrites the sentence to explain the missing fields.