### PR TITLE
Avoid JS syntax errors when visiting our site from our browser

### DIFF
--- a/src/wbetools.py
+++ b/src/wbetools.py
@@ -8,7 +8,7 @@ def patch(existing_cls):
         if isinstance(new_cls, type): # Patching classes
             assert isinstance(existing_cls, type), f"Can't patch {existing_cls} with {new_cls}"
             for attr, obj in new_cls.__dict__.items():
-                if attr in ["__module__", "__dict__", "__weakref__", "__doc__"]: continue
+                if attr in ["__module__", "__dict__", "__weakref__", "__doc__", "__firstlineno__", "__static_attributes__"]: continue
                 assert isinstance(obj, type(record)), f"Can't patch attribute {attr} of {new_cls} to be {obj}"
                 setattr(existing_cls, attr, obj)
         elif isinstance(new_cls, type(record)): # Patching functions

--- a/www/feedback.js
+++ b/www/feedback.js
@@ -2,6 +2,9 @@
 
 // Thanks for reading the code! You can hit Ctrl-E / Cmd-E to access the feedback tools.
 
+// This code is written in a bit of an odd style to avoid error
+// messages in the WBE browser. There's a lot of old-school JS.
+
 var chapter_overlay;
 
 function ctrl_key_pressed(e) {
@@ -20,6 +23,7 @@ function ctrl_key_name() {
     }  
 }
 
+if (document.addEventListener)
 document.addEventListener("DOMContentLoaded", function() {
     if (window.localStorage["edit"] == "true") {
         typo_mode();
@@ -36,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function() {
         }
     });
 
-    let feedback_button = document.querySelector("#feedback-button");
+    var feedback_button = document.querySelector("#feedback-button");
     if (feedback_button) {
         feedback_button.addEventListener("click", function(e) {
             setup_chapter_feedback();
@@ -239,7 +243,7 @@ function submit_chapter_comment(comment, email) {
     }));
 }
 
-let previous_comment = null;
+var previous_comment = null;
 
 function setup_chapter_feedback() {
     var submit = Element("button", { type: "submit" }, "Submit feedback");
@@ -294,11 +298,11 @@ function setup_chapter_feedback() {
             this.querySelector("input[name='email']").value)
         e.preventDefault();
         this.querySelector(".confirm-feedback").classList.add("active");
-        setTimeout(() => chapter_overlay.remove(), 2000);
+        setTimeout(function() { chapter_overlay.remove(); }, 2000);
     }
     
     function do_cancel(e) {
-        let result = this.querySelector("textarea");
+        var result = this.querySelector("textarea");
         if (result)
             previous_comment = result.value;
         chapter_overlay.remove();


### PR DESCRIPTION
This PR rewrites the JavaScript files `book.js` and `feedback.js` so that they don't raise errors in our own browser. That involved:

- Rewrite `let`, `for of`, and arrow functions into old-school JavaScript
- Use IIFEs for callbacks in loops, just like we did in the 00s
- Test for the existence of `window`, `window.addEventListener`, and `document.addEventListener` before using them
- Only loosely related, but also update the patcher to work in Python 3.13