### PR TITLE
Fix padding around go-further/quirk/example/etc blocks

### DIFF
--- a/www/book.css
+++ b/www/book.css
@@ -196,7 +196,9 @@ body.main { padding: 0 4ex; }
   .note form { display: inline; }
 }
 
-.todo, .quirk, .warning, .installation, .further, .demo, .example, .output { padding: 1em 1em 0; margin: 1em 0; }
+.todo, .quirk, .warning, .installation, .further, .demo, .example, .output {
+    padding: 1em 1em 0.5em; margin: 1em 0;
+}
 .quirk:before, .warning:before, .installation:before {
     font-weight: bold; font-family: 'Vollkorn', 'Garamond', serif;
     text-align: center;
@@ -212,8 +214,8 @@ img { max-width: 100%; }
 .installation:before { content: "Installation"; color: blue; }
 .demo { outline: 2px solid gray; }
 .demo:before { content: "Demonstration"; color: gray; }
-.further { outline: 2px solid green; padding-top: 0; }
-.further > :first-child:before { content: "Go further: "; font-weight: bold; color: green; }
+.further { outline: 2px solid green; }
+.further:before { content: "Go further"; font-weight: bold; color: green; }
 .widget { width: 100%; border: 2px solid navy; }
 .center { text-align: center }
 .example, .output { outline: 2px solid lightgray; padding: 1em }


### PR DESCRIPTION
The change to use outlines made the padding between the text and the outline box too small. This PR fixes that.

I also changed the go further title to look the same as quirk, example etc. I don't think there is a good reason to have it look different?