### PR TITLE
Fix is_focused invalidation for chapters 8-10

### DIFF
--- a/book/forms.md
+++ b/book/forms.md
@@ -360,8 +360,9 @@ sheets[^update-styles] every time you type!
     area definitely can't make such changes, so let's skip this in our
     browser.
     
-Now when we click an `input` element and clear its contents, we can
-call `render` to redraw the page with the `input` cleared:
+Now when we click an `input` element and clear its contents, we should
+call `render` to redraw the page with the `input` cleared. To make things
+easier, I'm just always calling `render` regardless of whether things changed:
 
 ``` {.python}
 class Tab:
@@ -369,7 +370,8 @@ class Tab:
         while elt:
             elif elt.tag == "input":
                 elt.attributes["value"] = ""
-                return self.render()
+                break
+        self.render()
 ```
 
 So that's clicking in an `input` area. But typing is harder. Think
@@ -510,14 +512,13 @@ element:
 ``` {.python}
 class Tab:
     def click(self, x, y):
+        if self.focus:
+            self.focus.is_focused = False
         while elt:
             elif elt.tag == "input":
                 elt.attributes["value"] = ""
-                if self.focus:
-                    self.focus.is_focused = False
                 self.focus = elt
                 elt.is_focused = True
-                return self.render()
 ```
 
 Note that we have to un-focus the currently focused element,

--- a/src/lab8-tests.md
+++ b/src/lab8-tests.md
@@ -172,6 +172,7 @@ Testing focus
 
     Clicking back on the content area unfocuses it
     >>> browser.handle_click(test.Event(200, 200))
+    Ignoring HTML contents inside button
     >>> browser.focus
     'content'
     >>> browser.chrome.focus
@@ -183,6 +184,7 @@ Testing focus
     >>> browser.chrome.focus
 
     >>> browser.handle_click(test.Event(200, 200))
+    Ignoring HTML contents inside button
     >>> browser.focus
     'content'
     >>> browser.chrome.focus

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -279,12 +279,14 @@ class Tab:
         paint_tree(self.document, self.display_list)
 
     def click(self, x, y):
+        if self.focus:
+            self.focus.is_focused = False
         self.focus = None
         y += self.scroll
         objs = [obj for obj in tree_to_list(self.document, [])
                 if obj.x <= x < obj.x + obj.width
                 and obj.y <= y < obj.y + obj.height]
-        if not objs: return
+        if not objs: return self.render()
         elt = objs[-1].node
         while elt:
             if isinstance(elt, Text):
@@ -294,17 +296,16 @@ class Tab:
                 return self.load(url)
             elif elt.tag == "input":
                 elt.attributes["value"] = ""
-                if self.focus:
-                    self.focus.is_focused = False
                 self.focus = elt
                 elt.is_focused = True
-                return self.render()
+                break
             elif elt.tag == "button":
                 while elt:
                     if elt.tag == "form" and "action" in elt.attributes:
                         return self.submit_form(elt)
                     elt = elt.parent
             elt = elt.parent
+        self.render()
 
     def submit_form(self, elt):
         inputs = [node for node in tree_to_list(elt, [])

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -125,12 +125,14 @@ class Tab:
         self.render()
 
     def click(self, x, y):
+        if self.focus:
+            self.focus.is_focused = False
         self.focus = None
         y += self.scroll
         objs = [obj for obj in tree_to_list(self.document, [])
                 if obj.x <= x < obj.x + obj.width
                 and obj.y <= y < obj.y + obj.height]
-        if not objs: return
+        if not objs: return self.render()
         elt = objs[-1].node
         while elt:
             if isinstance(elt, Text):
@@ -146,7 +148,7 @@ class Tab:
                     self.focus.is_focused = False
                 self.focus = elt
                 elt.is_focused = True
-                return self.render()
+                break
             elif elt.tag == "button":
                 if self.js.dispatch_event("click", elt): return
                 while elt.parent:
@@ -154,6 +156,7 @@ class Tab:
                         return self.submit_form(elt)
                     elt = elt.parent
             elt = elt.parent
+        self.render()
 
     def submit_form(self, elt):
         if self.js.dispatch_event("submit", elt): return


### PR DESCRIPTION
A reader found this bug. Previously the is_focused code would do nothing because focus was set to `None` right at the beginning of `click`.