### PR TITLE
Align code for add_entries to agree with that in server10

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -1104,7 +1104,6 @@ the length on the server side too:
 def add_entry(params):
     if 'guest' in params and len(params['guest']) <= 100:
         ENTRIES.append(params['guest'])
-    return show_comments()
 ```
 
 Note that we shouldn't---can't---rely on JavaScript being executed by

--- a/src/server9.py
+++ b/src/server9.py
@@ -37,7 +37,8 @@ def do_request(method, url, headers, body):
             return "200 OK", f.read()
     elif method == "POST" and url == "/add":
         params = form_decode(body)
-        return "200 OK", add_entry(params)
+        add_entry(params)
+        return "200 OK", show_comments()
     
     return "404 Not Found", not_found(url, method)
 
@@ -71,7 +72,6 @@ def not_found(url, method):
 def add_entry(params):
     if 'guest' in params and len(params['guest']) <= 100:
         ENTRIES.append(params['guest'])
-    return show_comments()
 
 if __name__ == "__main__":
     s = socket.socket(


### PR DESCRIPTION
`server10.py`'s code calls show_comments separately from add_entry; this changes `server9.py` to match. (reported by a reader on the website)

Rationale: no good reason to differ.