### PR TITLE
Rename the nodes field on browser/tab to node

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -601,7 +601,7 @@ class Tab:
                 INHERITED_PROPERTIES["color"] = "white"
             else:
                 INHERITED_PROPERTIES["color"] = "black"
-            style(self.nodes,
+            style(self.node,
                 sorted(self.rules, key=cascade_priority))
 ```
 
@@ -950,7 +950,7 @@ def is_focusable(node):
 class Tab:
     def advance_tab(self):
         focusable_nodes = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element) and is_focusable(node)]
 ```
 
@@ -1107,7 +1107,7 @@ we can sort by `get_tabindex` in `advance_tab`:
 class Tab:
     def advance_tab(self):
         focusable_nodes = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element) and is_focusable(node)]
         focusable_nodes.sort(key=get_tabindex)
         # ...
@@ -1623,7 +1623,7 @@ class Tab:
             self.needs_layout = False
 
         if self.needs_accessibility:
-            self.accessibility_tree = AccessibilityNode(self.nodes)
+            self.accessibility_tree = AccessibilityNode(self.node)
             self.accessibility_tree.build()
             self.needs_accessibility = False
 ```

--- a/book/animations.md
+++ b/book/animations.md
@@ -1160,7 +1160,7 @@ class Tab:
         # ...
         self.js.interp.evaljs("__runRAFHandlers()")
 
-        for node in tree_to_list(self.nodes, []):
+        for node in tree_to_list(self.node, []):
             for (property_name, animation) in \
                 node.animations.items():
                 # ...
@@ -1194,7 +1194,7 @@ style---the computed style and the animated style---to solve issues like this.
 ``` {.python}
 class Tab:
     def run_animation_frame(self, scroll):
-        for node in tree_to_list(self.nodes, []):
+        for node in tree_to_list(self.node, []):
             for (property_name, animation) in \
                 node.animations.items():
                 value = animation.animate()
@@ -1340,7 +1340,7 @@ class Tab:
         self.composited_updates = []
 
     def run_animation_frame(self, scroll):
-        for node in tree_to_list(self.nodes, []):
+        for node in tree_to_list(self.node, []):
             for (property_name, animation) in \
                 node.animations.items():
                 value = animation.animate()

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -116,7 +116,7 @@ class Tab:
     def load(self, url, payload=None):
         # ...
         images = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element)
             and node.tag == "img"]
         for img in images:
@@ -831,7 +831,7 @@ class Frame:
     def load(self, url, payload=None):
         # ...
         iframes = [node
-                   for node in tree_to_list(self.nodes, [])
+                   for node in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "iframe"
                    and "src" in node.attributes]
@@ -1235,13 +1235,13 @@ class AccessibilityNode:
 
 To `build` such a node, we just recurse into the frame:
 
-``` {.python replace=AccessibilityNode(child_node.frame.nodes)/FrameAccessibilityNode(child_node%2C%20self)}
+``` {.python replace=AccessibilityNode(child_node.frame.node)/FrameAccessibilityNode(child_node%2C%20self)}
 class AccessibilityNode:
    def build_internal(self, child_node):
         if isinstance(child_node, Element) \
             and child_node.tag == "iframe" and child_node.frame \
             and child_node.frame.loaded:
-            child = AccessibilityNode(child_node.frame.nodes)
+            child = AccessibilityNode(child_node.frame.node)
         # ... 
 ```
 
@@ -1858,7 +1858,7 @@ class JSContext:
         frame = self.tab.window_id_to_frame[window_id]
         selector = CSSParser(selector_text).selector()
         nodes = [node for node
-                 in tree_to_list(frame.nodes, [])
+                 in tree_to_list(frame.node, [])
                  if selector.matches(node)]
         return [self.get_handle(node) for node in nodes]
 ```

--- a/book/forms.md
+++ b/book/forms.md
@@ -339,14 +339,14 @@ class Tab:
         self.render()
 
     def render(self):
-        style(self.nodes, sorted(self.rules, key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
+        style(self.node, sorted(self.rules, key=cascade_priority))
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)
 ```
 
-For this code to work, you'll also need to change `nodes` and `rules`
+For this code to work, you'll also need to change `node` and `rules`
 from local variables in the `load` method to new fields on a `Tab`.
 Note that styling moved from `load` to `render`, but downloading the
 style sheets didn't---we don't re-download the style

--- a/book/html.md
+++ b/book/html.md
@@ -595,8 +595,8 @@ the node tree, like this:
 class Browser:
     def load(self, url):
         body = url.request()
-        self.nodes = HTMLParser(body).parse()
-        self.display_list = Layout(self.nodes).display_list
+        self.node = HTMLParser(body).parse()
+        self.display_list = Layout(self.node).display_list
         self.draw()
 ```
 

--- a/book/invalidation.md
+++ b/book/invalidation.md
@@ -263,7 +263,7 @@ every time the layout phase runs:
 class Frame:
     def render(self):
         if self.needs_layout:
-            self.document = DocumentLayout(self.nodes, self)
+            self.document = DocumentLayout(self.node, self)
             self.document.layout(self.frame_width, self.tab.zoom)
             # ...
 ```
@@ -301,7 +301,7 @@ time.[^side-effects] That's wasteful; let's create the
 class Frame:
     def load(self, url, payload=None):
         # ...
-        self.document = DocumentLayout(self.nodes, self)
+        self.document = DocumentLayout(self.node, self)
         self.set_needs_render()
 
     def render(self):
@@ -2301,7 +2301,7 @@ invalidate just the animating property when handling animations:
 class Tab:
     def run_animation_frame(self, scroll):
         for (window_id, frame) in self.window_id_to_frame.items():
-            for node in tree_to_list(frame.nodes, []):
+            for node in tree_to_list(frame.node, []):
                 for (property_name, animation) in \
                     node.animations.items():
                     value = animation.animate()

--- a/book/scripts.md
+++ b/book/scripts.md
@@ -103,7 +103,7 @@ class Tab:
     def load(self, url, payload=None):
         # ...
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -446,7 +446,7 @@ Now `querySelectorAll` will find all nodes matching the selector:
 def querySelectorAll(self, selector_text):
     # ...
     nodes = [node for node
-             in tree_to_list(self.tab.nodes, [])
+             in tree_to_list(self.tab.node, [])
              if selector.matches(node)]
 ```
 

--- a/book/styles.md
+++ b/book/styles.md
@@ -583,7 +583,7 @@ comprehension to grab the URL of each linked style sheet:[^crazy]
 def load(self, url):
     # ...
     links = [node.attributes["href"]
-             for node in tree_to_list(self.nodes, [])
+             for node in tree_to_list(self.node, [])
              if isinstance(node, Element)
              and node.tag == "link"
              and node.attributes.get("rel") == "stylesheet"
@@ -716,7 +716,7 @@ Now when we call `style`, we need to sort the rules, like this:
 ``` {.python indent=4}
 def load(self, url):
     # ...
-    style(self.nodes, sorted(rules, key=cascade_priority))
+    style(self.node, sorted(rules, key=cascade_priority))
     # ...
 ```
 

--- a/src/lab10.py
+++ b/src/lab10.py
@@ -142,11 +142,11 @@ class Tab:
                 for origin in csp[1:]:
                     self.allowed_origins.append(URL(origin).origin())
 
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         self.js = JSContext(self)
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -163,7 +163,7 @@ class Tab:
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"

--- a/src/lab11.py
+++ b/src/lab11.py
@@ -414,8 +414,8 @@ class DocumentLayout:
 @wbetools.patch(Tab)
 class Tab:
     def render(self):
-        style(self.nodes, sorted(self.rules, key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
+        style(self.node, sorted(self.rules, key=cascade_priority))
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/lab12.py
+++ b/src/lab12.py
@@ -213,12 +213,12 @@ class Tab:
            if len(csp) > 0 and csp[0] == "default-src":
                self.allowed_origins = csp[1:]
 
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         if self.js: self.js.discarded = True
         self.js = JSContext(self)
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -237,7 +237,7 @@ class Tab:
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -287,9 +287,9 @@ class Tab:
     def render(self):
         if not self.needs_render: return
         self.browser.measure.time('render')
-        style(self.nodes, sorted(self.rules,
+        style(self.node, sorted(self.rules,
             key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/lab13-tests.md
+++ b/src/lab13-tests.md
@@ -49,7 +49,7 @@ Testing CSS transtions
                  DrawCompositedLayer()
              DrawCompositedLayer()
     >>> tab = browser.active_tab
-    >>> div = tab.nodes.children[1].children[0]
+    >>> div = tab.node.children[1].children[0]
 
 There is a transition defined for opacity, for a duration of 2 seconds. This is
 about 60 animation frames, so `parse_transition` should return 60.
@@ -102,7 +102,7 @@ Animations work:
     >>> browser.render()
     >>> browser.composite_raster_and_draw()
     >>> tab = browser.active_tab
-    >>> div = tab.nodes.children[1].children[0]
+    >>> div = tab.node.children[1].children[0]
     >>> lab13.parse_transition(div.style.get("transition"))
     {'transform': 60}
     >>> div.animations

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -699,7 +699,7 @@ class Tab:
         self.js.interp.evaljs("__runRAFHandlers()")
         self.browser.measure.stop('script-runRAFHandlers')
 
-        for node in tree_to_list(self.nodes, []):
+        for node in tree_to_list(self.node, []):
             for (property_name, animation) in \
                 node.animations.items():
                 value = animation.animate()
@@ -740,12 +740,12 @@ class Tab:
         self.browser.measure.time('render')
 
         if self.needs_style:
-            style(self.nodes, sorted(self.rules, key=cascade_priority), self)
+            style(self.node, sorted(self.rules, key=cascade_priority), self)
             self.needs_layout = True
             self.needs_style = False
 
         if self.needs_layout:
-            self.document = DocumentLayout(self.nodes)
+            self.document = DocumentLayout(self.node)
             self.document.layout()
             self.needs_paint = True
             self.needs_layout = False

--- a/src/lab14-tests.md
+++ b/src/lab14-tests.md
@@ -151,12 +151,12 @@ are:
 
 The first `div` is not focusable.
 
-    >>> lab14.is_focusable(browser.tabs[0].nodes.children[0].children[0])
+    >>> lab14.is_focusable(browser.tabs[0].node.children[0].children[0])
     False
 
 But the second one is, because it has a `tabindex` attribute.
 
-    >>> lab14.is_focusable(browser.tabs[0].nodes.children[0].children[1])
+    >>> lab14.is_focusable(browser.tabs[0].node.children[0].children[1])
     True
 
 Accessibility

--- a/src/lab14.py
+++ b/src/lab14.py
@@ -686,12 +686,12 @@ class Tab:
            if len(csp) > 0 and csp[0] == "default-src":
                self.allowed_origins = csp[1:]
 
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         if self.js: self.js.discarded = True
         self.js = JSContext(self)
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -710,7 +710,7 @@ class Tab:
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -735,7 +735,7 @@ class Tab:
         self.js.interp.evaljs("__runRAFHandlers()")
         self.browser.measure.stop('script-runRAFHandlers')
 
-        for node in tree_to_list(self.nodes, []):
+        for node in tree_to_list(self.node, []):
             for (property_name, animation) in \
                 node.animations.items():
                 value = animation.animate()
@@ -785,20 +785,20 @@ class Tab:
                 INHERITED_PROPERTIES["color"] = "white"
             else:
                 INHERITED_PROPERTIES["color"] = "black"
-            style(self.nodes,
+            style(self.node,
                 sorted(self.rules, key=cascade_priority), self)
             self.needs_layout = True
             self.needs_style = False
 
         if self.needs_layout:
-            self.document = DocumentLayout(self.nodes)
+            self.document = DocumentLayout(self.node)
             self.document.layout(self.zoom)
             self.needs_accessibility = True
             self.needs_paint = True
             self.needs_layout = False
 
         if self.needs_accessibility:
-            self.accessibility_tree = AccessibilityNode(self.nodes)
+            self.accessibility_tree = AccessibilityNode(self.node)
             self.accessibility_tree.build()
             self.needs_accessibility = False
 
@@ -890,7 +890,7 @@ class Tab:
 
     def advance_tab(self):
         focusable_nodes = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element) and is_focusable(node)]
         focusable_nodes.sort(key=get_tabindex)
 

--- a/src/lab15-tests.md
+++ b/src/lab15-tests.md
@@ -44,7 +44,7 @@ Let's verify that we can request the image:
 
 The browser has now downloaded a Skia `Image` object:
 
-    >>> img = frame.nodes.children[0].children[0].image
+    >>> img = frame.node.children[0].children[0].image
     >>> img # doctest: +ELLIPSIS
     Image(5, 5, ..., AlphaType.kPremul_AlphaType)
     >>> img.width()
@@ -215,7 +215,7 @@ Clicking the sub-frame focuses it:
     >>> e = Event(50, browser.chrome.bottom + 670)
     >>> browser.handle_click(e)
     >>> browser.render()
-    >>> child_frame = browser.tabs[0].root_frame.nodes.children[0].children[-1].frame
+    >>> child_frame = browser.tabs[0].root_frame.node.children[0].children[-1].frame
     >>> browser.tabs[0].focused_frame == child_frame
     True
     >>> browser.root_frame_focused
@@ -223,13 +223,13 @@ Clicking the sub-frame focuses it:
 
 And now scrolling affects just the child frame:
 
-    >>> browser.tabs[0].root_frame.nodes.children[0].children[-1].frame.scroll
+    >>> browser.tabs[0].root_frame.node.children[0].children[-1].frame.scroll
     0
     >>> browser.handle_down()
     >>> browser.render()
     >>> browser.active_tab_scroll > 0
     False
-    >>> browser.tabs[0].root_frame.nodes.children[0].children[-1].frame.scroll
+    >>> browser.tabs[0].root_frame.node.children[0].children[-1].frame.scroll
     18.0
 
 Accessibility
@@ -323,7 +323,7 @@ resizing is dramatic:
     >>> browser.render()
     >>> frame1 = browser.tabs[0].root_frame
     >>> iframe = [
-    ...    n for n in lab15.tree_to_list(frame1.nodes, [])
+    ...    n for n in lab15.tree_to_list(frame1.node, [])
     ...    if isinstance(n, lab15.Element) and n.tag == "iframe"][0]
     >>> frame2 = iframe.frame
     >>> lab15.print_tree(frame1.document)

--- a/src/lab15.py
+++ b/src/lab15.py
@@ -745,7 +745,7 @@ class JSContext:
         self.throw_if_cross_origin(frame)
         selector = CSSParser(selector_text).selector()
         nodes = [node for node
-                in tree_to_list(frame.nodes, [])
+                in tree_to_list(frame.node, [])
                  if selector.matches(node)]
         return [self.get_handle(node) for node in nodes]
 
@@ -991,7 +991,7 @@ class FrameAccessibilityNode(AccessibilityNode):
         self.zoom = self.node.layout_object.zoom
 
     def build(self):
-        self.build_internal(self.node.frame.nodes)
+        self.build_internal(self.node.frame.node)
 
     def hit_test(self, x, y):
         bounds = self.bounds[0]
@@ -1029,7 +1029,7 @@ class Frame:
         self.scroll = 0
         self.scroll_changed_in_frame = True
         self.needs_focus_scroll = False
-        self.nodes = None
+        self.node = None
         self.url = None
         self.js = None
         self.loaded = False
@@ -1069,14 +1069,14 @@ class Frame:
            if len(csp) > 0 and csp[0] == "default-src":
                self.allowed_origins = csp[1:]
 
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         if self.js: self.js.discarded = True
         self.js = self.tab.get_js(url)
         self.js.add_window(self)
 
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -1097,7 +1097,7 @@ class Frame:
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -1114,7 +1114,7 @@ class Frame:
             self.rules.extend(CSSParser(body.decode("utf8", "replace")).parse())
 
         images = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element)
             and node.tag == "img"]
         for img in images:
@@ -1135,7 +1135,7 @@ class Frame:
                 img.image = BROKEN_IMAGE
 
         iframes = [node
-                   for node in tree_to_list(self.nodes, [])
+                   for node in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "iframe"
                    and "src" in node.attributes]
@@ -1158,14 +1158,14 @@ class Frame:
                 INHERITED_PROPERTIES["color"] = "white"
             else:
                 INHERITED_PROPERTIES["color"] = "black"
-            style(self.nodes,
+            style(self.node,
                   sorted(self.rules,
                          key=cascade_priority), self)
             self.needs_layout = True
             self.needs_style = False
 
         if self.needs_layout:
-            self.document = DocumentLayout(self.nodes, self)
+            self.document = DocumentLayout(self.node, self)
             self.document.layout(self.frame_width, self.tab.zoom)
             self.tab.needs_accessibility = True
             self.needs_paint = True
@@ -1178,7 +1178,7 @@ class Frame:
 
     def advance_tab(self):
         focusable_nodes = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element) and is_focusable(node)                          
             and get_tabindex(node) >= 0]
         focusable_nodes.sort(key=get_tabindex)
@@ -1396,7 +1396,7 @@ class Tab:
             frame.js.dispatch_RAF(frame.window_id)
             self.browser.measure.stop('script-runRAFHandlers')
 
-            for node in tree_to_list(frame.nodes, []):
+            for node in tree_to_list(frame.node, []):
                 for (property_name, animation) in \
                     node.animations.items():
                     value = animation.animate()
@@ -1457,7 +1457,7 @@ class Tab:
                 frame.render()
 
         if self.needs_accessibility:
-            self.accessibility_tree = AccessibilityNode(self.root_frame.nodes)
+            self.accessibility_tree = AccessibilityNode(self.root_frame.node)
             self.accessibility_tree.build()
             self.needs_accessibility = False
             self.needs_paint = True

--- a/src/lab16-tests.md
+++ b/src/lab16-tests.md
@@ -30,7 +30,7 @@ Here's a simple editable web page:
     >>> browser = lab16.Browser()
     >>> browser.new_tab(url)
     >>> browser.render()
-    >>> lab16.print_tree(browser.tabs[0].root_frame.nodes)
+    >>> lab16.print_tree(browser.tabs[0].root_frame.node)
      <html>
        <body>
          <p contenteditable="">
@@ -50,7 +50,7 @@ Now that we're focused on the element, we can type into it:
     >>> tab.keypress("H")
     >>> tab.keypress("i")
     >>> tab.keypress("!")
-    >>> lab16.print_tree(browser.tabs[0].root_frame.nodes)
+    >>> lab16.print_tree(browser.tabs[0].root_frame.node)
      <html>
        <body>
          <p contenteditable="">
@@ -169,7 +169,7 @@ resizing is dramatic:
     >>> browser.render()
     >>> frame1 = browser.tabs[0].root_frame
     >>> iframe = [
-    ...    n for n in lab16.tree_to_list(frame1.nodes, [])
+    ...    n for n in lab16.tree_to_list(frame1.node, [])
     ...    if isinstance(n, lab16.Element) and n.tag == "iframe"][0]
     >>> frame2 = iframe.frame
     >>> lab16.print_tree(frame1.document)

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -1079,14 +1079,14 @@ class Frame:
            if len(csp) > 0 and csp[0] == "default-src":
                self.allowed_origins = csp[1:]
 
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         if self.js: self.js.discarded = True
         self.js = self.tab.get_js(url)
         self.js.add_window(self)
 
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -1107,7 +1107,7 @@ class Frame:
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -1124,7 +1124,7 @@ class Frame:
             self.rules.extend(CSSParser(body.decode("utf8", "replace")).parse())
 
         images = [node
-            for node in tree_to_list(self.nodes, [])
+            for node in tree_to_list(self.node, [])
             if isinstance(node, Element)
             and node.tag == "img"]
         for img in images:
@@ -1145,7 +1145,7 @@ class Frame:
                 img.image = BROKEN_IMAGE
 
         iframes = [node
-                   for node in tree_to_list(self.nodes, [])
+                   for node in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "iframe"
                    and "src" in node.attributes]
@@ -1159,7 +1159,7 @@ class Frame:
             task = Task(iframe.frame.load, document_url)
             self.tab.task_runner.schedule_task(task)
 
-        self.document = DocumentLayout(self.nodes, self)
+        self.document = DocumentLayout(self.node, self)
         self.set_needs_render()
         self.loaded = True
 
@@ -1169,7 +1169,7 @@ class Frame:
                 INHERITED_PROPERTIES["color"] = "white"
             else:
                 INHERITED_PROPERTIES["color"] = "black"
-            style(self.nodes,
+            style(self.node,
                   sorted(self.rules,
                          key=cascade_priority), self)
             self.needs_layout = True
@@ -1313,7 +1313,7 @@ class Tab:
             frame.js.dispatch_RAF(frame.window_id)
             self.browser.measure.stop('script-runRAFHandlers')
     
-            for node in tree_to_list(frame.nodes, []):
+            for node in tree_to_list(frame.node, []):
                 for (property_name, animation) in \
                     node.animations.items():
                     value = animation.animate()
@@ -1374,7 +1374,7 @@ class Tab:
                 frame.render()
 
         if self.needs_accessibility:
-            self.accessibility_tree = AccessibilityNode(self.root_frame.nodes)
+            self.accessibility_tree = AccessibilityNode(self.root_frame.node)
             self.accessibility_tree.build()
             self.needs_accessibility = False
             self.needs_paint = True

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -198,8 +198,8 @@ class Layout:
 class Browser:
     def load(self, url):
         body = url.request()
-        self.nodes = HTMLParser(body).parse()
-        self.display_list = Layout(self.nodes).display_list
+        self.node = HTMLParser(body).parse()
+        self.display_list = Layout(self.node).display_list
         self.draw()
 
 if __name__ == "__main__":

--- a/src/lab5-tests.md
+++ b/src/lab5-tests.md
@@ -82,7 +82,7 @@ Testing the layout tree
     >>> url = lab5.URL(test.socket.serve(sample_html))
     >>> browser = lab5.Browser()
     >>> browser.load(url)
-    >>> lab5.print_tree(browser.nodes)
+    >>> lab5.print_tree(browser.node)
      <html>
        <body>
          <div>
@@ -120,7 +120,7 @@ Testing background painting
     >>> url = lab5.URL(test.socket.serve("<pre>pre text</pre>"))
     >>> browser = lab5.Browser()
     >>> browser.load(url)
-    >>> lab5.print_tree(browser.nodes)
+    >>> lab5.print_tree(browser.node)
      <html>
        <body>
          <pre>

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -204,8 +204,8 @@ def paint_tree(layout_object, display_list):
 class Browser:
     def load(self, url):
         body = url.request()
-        self.nodes = HTMLParser(body).parse()
-        self.document = DocumentLayout(self.nodes)
+        self.node = HTMLParser(body).parse()
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/lab6-tests.md
+++ b/src/lab6-tests.md
@@ -19,7 +19,7 @@ We need to make sure we didn't break layout with all of these changes:
     >>> url = lab6.URL(test.socket.serve(sample_html))
     >>> browser = lab6.Browser()
     >>> browser.load(url)
-    >>> lab6.print_tree(browser.nodes)
+    >>> lab6.print_tree(browser.node)
      <html>
        <body>
          <div>

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -298,11 +298,11 @@ class Browser:
 
     def load(self, url):
         body = url.request()
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -314,9 +314,9 @@ class Browser:
             except:
                 continue
             rules.extend(CSSParser(body).parse())
-        style(self.nodes, sorted(rules, key=cascade_priority))
+        style(self.node, sorted(rules, key=cascade_priority))
 
-        self.document = DocumentLayout(self.nodes)
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -265,11 +265,11 @@ class Tab:
         self.scroll = 0
         self.url = url
         self.history.append(url)
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -280,9 +280,9 @@ class Tab:
             except:
                 continue
             rules.extend(CSSParser(body).parse())
-        style(self.nodes, sorted(rules, key=cascade_priority))
+        style(self.node, sorted(rules, key=cascade_priority))
 
-        self.document = DocumentLayout(self.nodes)
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -254,11 +254,11 @@ class Tab:
         self.url = url
         self.history.append(url)
         body = url.request(payload)
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"
@@ -272,8 +272,8 @@ class Tab:
         self.render()
 
     def render(self):
-        style(self.nodes, sorted(self.rules, key=cascade_priority))
-        self.document = DocumentLayout(self.nodes)
+        style(self.node, sorted(self.rules, key=cascade_priority))
+        self.document = DocumentLayout(self.node)
         self.document.layout()
         self.display_list = []
         paint_tree(self.document, self.display_list)

--- a/src/lab9-tests.md
+++ b/src/lab9-tests.md
@@ -120,7 +120,7 @@ Once we have a `Node` object we can call `getAttribute`:
 
 Note that this is "live": as the page changes `querySelectorAll` gives new results:
 
-    >>> b.tabs[0].nodes.children[0].children[0].children[0].attributes['id'] = 'blah'
+    >>> b.tabs[0].node.children[0].children[0].children[0].attributes['id'] = 'blah'
     >>> js.run("test", "document.querySelectorAll('p')[0].getAttribute('id')")
     'blah'
 
@@ -195,7 +195,7 @@ Events are the trickiest thing to test here. First, let's do a basic test of
 adding an event listener and then triggering it. I'll use the `div` element to
 test things:
 
-    >>> div = b.tabs[0].nodes.children[0].children[0]
+    >>> div = b.tabs[0].node.children[0].children[0]
     >>> js.run("test", "var div = document.querySelectorAll('div')[0]")
     >>> js.run("test", "div.addEventListener('test', function(e) { console.log('Listener ran!')})")
     >>> js.dispatch_event("test", div)

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -68,7 +68,7 @@ class JSContext:
     def querySelectorAll(self, selector_text):
         selector = CSSParser(selector_text).selector()
         nodes = [node for node
-                 in tree_to_list(self.tab.nodes, [])
+                 in tree_to_list(self.tab.node, [])
                  if selector.matches(node)]
         return [self.get_handle(node) for node in nodes]
 
@@ -93,11 +93,11 @@ class Tab:
         self.url = url
         self.history.append(url)
         body = url.request(payload)
-        self.nodes = HTMLParser(body).parse()
+        self.node = HTMLParser(body).parse()
 
         self.js = JSContext(self)
         scripts = [node.attributes["src"] for node
-                   in tree_to_list(self.nodes, [])
+                   in tree_to_list(self.node, [])
                    if isinstance(node, Element)
                    and node.tag == "script"
                    and "src" in node.attributes]
@@ -111,7 +111,7 @@ class Tab:
 
         self.rules = DEFAULT_STYLE_SHEET.copy()
         links = [node.attributes["href"]
-                 for node in tree_to_list(self.nodes, [])
+                 for node in tree_to_list(self.node, [])
                  if isinstance(node, Element)
                  and node.tag == "link"
                  and node.attributes.get("rel") == "stylesheet"


### PR DESCRIPTION
...since it's just a root node.

A reader got confused about it since `DocumentLayout`'s constructor takes a node but it looks like it is being passed `nodes`.