### PR TITLE
Edit example so it renders blue in lab6

### DIFF
--- a/book/styles.md
+++ b/book/styles.md
@@ -19,9 +19,13 @@ Parsing with Functions
 One way a web page can change its appearance is with the `style`\index{style}
 attribute. For example, this changes an element's background color:
 
-``` {.html .example style=background-color:lightblue}
-<div style="background-color:lightblue"></div>
+``` {.html .example}
+<div style="background-color:lightblue">Blue background</div>
 ```
+
+And it renders like this:
+
+<div style="background-color:lightblue">Blue background</div>
 
 More generally, a `style` attribute contains property–value pairs
 separated by semicolons. The browser looks at those CSS


### PR DESCRIPTION
Previously the pre tag inserted by pandoc would override the color.

Reported by a reader.