### PR TITLE
Use 'normal' instead of 400, to avoid parsing errors in tkinter

### DIFF
--- a/infra/template.html
+++ b/infra/template.html
@@ -11,8 +11,10 @@
   <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/crimsonpro/v24/q5uBsoa5M_tv7IihmnkabARekYNwDeChrlU.woff2" as=font type="font/woff2">
   <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/crimsonpro/v24/q5uDsoa5M_tv7IihmnkabARboYF6CsKj.woff2" as=font type="font/woff2">
   <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/inconsolata/v32/QlddNThLqRwH-OJ1UHjlKENVzkWGVkL3GZQmAwLyya15IDhunA.woff2" as=font type="font/woff2">
+  <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/inconsolata/v32/QlddNThLqRwH-OJ1UHjlKENVzkWGVkL3GZQmAwLyya15.woff2" as=font type="font/woff2">
   <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/crimsonpro/v24/q5uDsoa5M_tv7IihmnkabARboYE.woff2" as=font type="font/woff2">
   <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/crimsonpro/v24/q5uBsoa5M_tv7IihmnkabARekYNwDQ.woff2" as=font type="font/woff2">
+  <link rel="preload" crossorigin href="https://fonts.gstatic.com/s/spectral/v13/rnCr-xNNww_2s0amA9M5knjsS_ul.woff2" as=font type="font/woff2">
 
   <meta name="generator" content="pandoc" />
 

--- a/www/book.css
+++ b/www/book.css
@@ -16,7 +16,7 @@
 html { font-size: 24px; line-height: 1.2; padding: 1em; }
 body {
     max-width: 60ch; margin: 0 auto; font-family: 'Crimson Pro', 'Times', serif;
-    font-weight: 400; text-align: justify; hyphens: auto; -webkit-hyphens: auto;
+    font-weight: normal; text-align: justify; hyphens: auto; -webkit-hyphens: auto;
 }
 @media (prefers-color-scheme: light) {
 body {
@@ -64,7 +64,7 @@ h1:not(.title):hover::after {
 }
 
 header { text-align: center; margin: 3em 0 1em; }
-header h1 { margin: 0; font-size: 200%; font-weight: 400; text-align: center; letter-spacing: -0.08ex }
+header h1 { margin: 0; font-size: 200%; font-weight: normal; text-align: center; letter-spacing: -0.08ex }
 .main header h1 { font-size: 200%; } /* override another style ugh */
 .main header * { margin: 0; }
 header .author { font-style: italic; }


### PR DESCRIPTION
The lab6-10 browsers don't know how to parse "400" for a font, just "bold" and "normal", so changing book.css to use "normal" to avoid crashing the lab browser.

This was pointed out by a reader of the book.