### PR TITLE
Clean up the index page now that the book is out

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -14,16 +14,13 @@ JavaScript, in a couple thousand lines of Python.
 ::: {.description}
 # Buy _Web Browser Engineering_
 
-_Web Browser Engineering_ is now available in the US and the UK
-from
-[Oxford University Press](https://global.oup.com/academic/product/web-browser-engineering-9780198913863)
+Please support us by buying a physical copy of _Web Browser
+Engineering_ from [Oxford University
+Press](https://global.oup.com/academic/product/web-browser-engineering-9780198913863)
 and from resellers like
-[Amazon](https://www.amazon.com/Web-Browser-Engineering-Pavel-Panchekha/dp/0198913869/),
-for $50 US / £40 UK.
-
-Please consider buying a physical copy for your bookshelf if you enjoy
-the book. More countries, and even some translations, are
-coming soon.
+[Amazon](https://www.amazon.com/Web-Browser-Engineering-Pavel-Panchekha/dp/0198913869/).
+It's currently available in the US ($50) and the UK (£40), with more
+countries and even translations coming soon.
 :::
 
 :::::

--- a/book/index.md
+++ b/book/index.md
@@ -25,7 +25,7 @@ countries and even translations coming soon.
 
 :::::
 
-Follow this book's [blog][blog], [Mastodon][mastodon] or [Twitter][twitter] for updates.
+Follow this book's [blog][blog], [Mastodon][mastodon], or [Twitter][twitter] for updates.
 There's a [discussion forum][forum] for the book on Github, or you
 can [email us directly](mailto:author@browser.engineering).
 

--- a/book/index.md
+++ b/book/index.md
@@ -8,35 +8,33 @@ Web browsers are ubiquitous, but how do they work? This book explains,
 building a basic but complete web browser, from networking to
 JavaScript, in a couple thousand lines of Python.
 
-::: {.todo}
-This draft version of the book includes unfinished chapters, and those
-chapters make inaccurate claims, fail to match published chapters, or
-misbehave. Read them at your own risk.
-:::
-
 ::::: {.wide-ad}
 ![The cover for Web Browser Engineering, from Oxford University Press](im/cover.jpg)
 
 ::: {.description}
-# Pre-order _Web Browser Engineering_
+# Buy _Web Browser Engineering_
 
-_Web Browser Engineering_ will be published by Oxford University
-Press early this year. To get it as soon as it's out,
-[pre-order now!](https://global.oup.com/academic/product/web-browser-engineering-9780198913863)
+_Web Browser Engineering_ is now available in the US and the UK
+from
+[Oxford University Press](https://global.oup.com/academic/product/web-browser-engineering-9780198913863)
+and from resellers like
+[Amazon](https://www.amazon.com/Web-Browser-Engineering-Pavel-Panchekha/dp/0198913869/),
+for $50 US / £40 UK.
+
+Please consider buying a physical copy for your bookshelf if you enjoy
+the book. More countries, and even some translations, are
+coming soon.
 :::
 
 :::::
 
-Follow this book's [blog](https://browserbook.substack.com/archive) or
-[Twitter](https://twitter.com/browserbook) for updates. You can also
-talk about the book with others in our [discussion forum][forum].
+Follow this book's [blog][blog] or [Twitter][twitter] for updates.
+There's a [discussion forum][forum] for the book on Github, or you
+can [email us directly](mailto:author@browser.engineering).
 
+[blog]: https://browserbook.substack.com/archive
+[twitter]: https://twitter.com/browserbook
 [forum]: https://github.com/browserengineering/book/discussions
-
-If you are enjoying the book online, consider supporting us by buying a
-physical copy for your home bookshelf.
-
-You can also email us [here](mailto:author@browser.engineering).
 
 ::: {.intro}
 Introduction

--- a/book/index.md
+++ b/book/index.md
@@ -25,7 +25,7 @@ countries and even translations coming soon.
 
 :::::
 
-Follow this book's [blog][blog] or [Twitter][twitter] for updates.
+Follow this book's [blog][blog], [Mastodon][mastodon] or [Twitter][twitter] for updates.
 There's a [discussion forum][forum] for the book on Github, or you
 can [email us directly](mailto:author@browser.engineering).
 

--- a/book/index.md
+++ b/book/index.md
@@ -31,6 +31,7 @@ can [email us directly](mailto:author@browser.engineering).
 
 [blog]: https://browserbook.substack.com/archive
 [twitter]: https://twitter.com/browserbook
+[mastodon]: https://indieweb.social/@browserbook
 [forum]: https://github.com/browserengineering/book/discussions
 
 ::: {.intro}

--- a/config.json
+++ b/config.json
@@ -130,18 +130,6 @@
             "show_signup": false,
             "print": true
         },
-        "draft": {
-            "base": "../",
-            "draft": true,
-            "show_toc": true,
-            "show_disabled": true,
-            "show_quiz": true,
-            "show_todos": true
-        },
-        "blog": {
-            "base": "../",
-            "show_signup": true
-        },
         "onepage": {
             "show_toc": true
         }

--- a/infra/template.html
+++ b/infra/template.html
@@ -74,12 +74,12 @@ $endif$
 $if(main)$$else$
 <aside class="ad">
   <div class="wide">
-    <img src="im/cover.jpg" alt="The cover design for Web Browser Engineering, published by Oxford University Press. Click the cover to pre-order.">
-    <a class="preorder" href="https://global.oup.com/academic/product/web-browser-engineering-9780198913863">Preorder »</a>
+    <img src="im/cover.jpg" alt="The cover for Web Browser Engineering, published by Oxford University Press. Click the cover to buy a copy.">
+    <a class="preorder" href="https://global.oup.com/academic/product/web-browser-engineering-9780198913863">Buy a copy »</a>
   </div>
   <p class="narrow">
-    <span><i>Web Browser Engineering</i> will be out soon.</span>
-    <a href="https://global.oup.com/academic/product/web-browser-engineering-9780198913863">Pre-order now »</a>
+    <span><i>Web Browser Engineering</i> is now available in hard copy.</span>
+    <a href="https://global.oup.com/academic/product/web-browser-engineering-9780198913863">Buy a copy »</a>
   </p>
 </aside>
 $endif$

--- a/infra/template.html
+++ b/infra/template.html
@@ -78,7 +78,7 @@ $if(main)$$else$
     <a class="preorder" href="https://global.oup.com/academic/product/web-browser-engineering-9780198913863">Buy a copy »</a>
   </div>
   <p class="narrow">
-    <span><i>Web Browser Engineering</i> is now available in hard copy.</span>
+    <span><i>Web Browser Engineering</i> is now available.</span>
     <a href="https://global.oup.com/academic/product/web-browser-engineering-9780198913863">Buy a copy »</a>
   </p>
 </aside>


### PR DESCRIPTION
This PR:

- Changers the "preorder" text to "buy the book" on the main page
- Also, similar updates on chapter pages
- Links to Amazon as well, I figure more sales are better
- Moves the "please support us" text into the blue box
- Drops some remaining "draft" support stuff

Screenshot:

<img width="833" alt="image" src="https://github.com/user-attachments/assets/068d7c54-7e23-4c45-92ed-b1e035f4bb4d" />
