### PR TITLE
Tweak language in blue box to fit

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -14,15 +14,14 @@ JavaScript, in a couple thousand lines of Python.
 ::: {.description}
 # Buy _Web Browser Engineering_
 
-Please support us by buying a physical copy of _Web Browser
-Engineering_ from [Oxford University
+Please support us by buying _Web Browser Engineering_ from [Oxford University
 Press](https://global.oup.com/academic/product/web-browser-engineering-9780198913863)
-and from resellers like
+or from a reseller like
 [Bookshop.org](https://bookshop.org/p/books/web-browser-engineering-chris-harrelson/21588966),
 [B&N](https://www.barnesandnoble.com/w/web-browser-engineering-pavel-panchekha/1146050176),
 and [Amazon](https://www.amazon.com/Web-Browser-Engineering-Pavel-Panchekha/dp/0198913869/).
-It's currently available in the US ($50) and the UK (£40), with more
-countries and even translations coming soon.
+It's currently $50 in the US and £40 in the UK, with similar prices in
+many other countries. Translations are coming soon!
 :::
 
 :::::


### PR DESCRIPTION
Adding Bookshop.org and B&N in #1398 made the text advertising the book one line too long. This PR word-smiths a bit to fix it.

Old:

<img width="828" alt="image" src="https://github.com/user-attachments/assets/48d6a797-28c6-427e-9df5-e0da5b90b637" />

New:

<img width="830" alt="image" src="https://github.com/user-attachments/assets/73adf065-1d23-4673-b7ee-dc50cb5ae0ff" />

The text about "many other countries" refers to at least Canada, but I also checked and it seems to be sold on French Amazon and Polish Amazon, so I think we can say "many countries".