### PR TITLE
Two minor tweaks

### DIFF
--- a/src/lab16.hints
+++ b/src/lab16.hints
@@ -22,5 +22,6 @@
 {"code": "DEFAULT_STYLE_SHEET.copy()", "js": "constants.DEFAULT_STYLE_SHEET.slice()"},
 {"code": "node.attributes.get('rel') == 'stylesheet'", "js": "node.attributes['rel'] == 'stylesheet'"},
 {"code": "CSS_PROPERTIES", "type": "dict"},
-{"code": "self.node.attributes", "type": "dict"}
+{"code": "self.node.attributes", "type": "dict"},
+{"code": "img.attributes", "type": "dict"}
 ]

--- a/www/book.css
+++ b/www/book.css
@@ -224,7 +224,7 @@ img { max-width: 100%; }
 .demo:before { content: "Demonstration"; color: gray; }
 .further { outline: 2px solid green; }
 .further:before { content: "Go further"; font-weight: bold; color: green; }
-.widget { width: 100%; border: 2px solid navy; }
+.widget { width: round(down, 100%, 1px); border: 2px solid navy; box-sizing: border-box; }
 .center { text-align: center }
 .example, .output { outline: 2px solid lightgray; padding: 1em }
 


### PR DESCRIPTION
- The `round` CSS function avoids a tiny white gap in widgets caused by iframes rounding to the nearest device pixel size
- The hint fixes compilation for Chapter 16. All other chapters already compile cleanly.