### PR TITLE
Add a test coverage Makefile rule

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,22 @@
+[run]
+source=
+  lab1
+  lab2
+  lab3
+  lab4
+  lab5
+  lab6
+  lab7
+  lab8
+  lab9
+  lab10
+  lab11
+  lab12
+  lab13
+  lab14
+  lab15
+  lab16
+  
+[report]
+omit=
+  */inliner

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ src/outline*.txt
 latex/*
 browser.trace
 package.json
+.coverage
+bin/
+lib/
+pyvenv.cfg


### PR DESCRIPTION
This PR adds support for PyCoverage to the test suite. It, luckily, wasn't that hard. Looking through the coverage reports for current tests, we're missing tests for:

- [ ] Chapter 1: invalid URL handling; the `load` function
- [ ] Chapter 2: all good :)
- [ ] Chapter 3: the `</p>` tag, line wrapping apparently
- [ ] Chapter 4: the new `open_tag` and `close_tag` functions, the new `load` method
- [ ] Chapter 5: line wrapping, the `scrolldown` method
- [ ] Chapter 6: line wrapping, styles that don't download
- [ ] Chapter 7: line wrapping, `self_rect`, non-transparent backgrounds, some of the `__repr__` lines, downloading CSS, clipping off the bottom of the screen, the `scrolldown` and `handle_down` methods, the `keypress` and `handle_key` methods, clicking on the active tab
- [ ] Chapter 8: `https` URLs, `<br>` tags, `<input>` elements breaking lines, backgrounds, downloading CSS, blurring an element, clicking `<input>` and `<a>` elements and walking up the layout tree when clicking, also clicking on neutral elements to blur, the `keypress` and `handle_key` methods
- [ ] Chapter 9: failure to download scripts, downloading CSS, blurring when clicking on an `input` element, clicking on neutral elements to blur
- [ ] Chapter 10: `https` URLs, failure to download scripts, failure to download styles

There are a lot more failures after that point, with pretty bad test coverage for Chapter 12 especially, but all in due time.