### PR TITLE
Correct description of lex function in Chapter 3.4

### DIFF
--- a/book/text.md
+++ b/book/text.md
@@ -443,9 +443,8 @@ Here I've renamed the `text` variable to `buffer`, since it now stores
 either text or tag contents before they can be used. The name also
 reminds us that, at the end of the loop, we need to check whether
 there's buffered text and what we should do with it. Here, `lex` dumps
-any accumulated text as a `Text` object. Otherwise, if you never saw
-an angle bracket, you'd return an empty list of tokens. But unfinished
-tags, like in `Hi!<hr`, are thrown out.[^errortag]
+any accumulated text as a `Text` object.  But unfinished tags, like in
+`Hi!<hr`, are thrown out.[^errortag]
 
 [^errortag]: This may strike you as an odd decision: why not
     finish up the tag for the author? I don't know, but dropping


### PR DESCRIPTION
This PR proposes a correction to the description of the `lex` function's behavior in Chapter 3.4.

The documentation currently states:
"Otherwise, if you never saw an angle bracket, you’d return an empty list of tokens."

However, this statement is inconsistent with the behavior of the provided `lex` function code. When a string Alltag "Hello, world!" (which contains no angle brackets) is passed to the `lex` function, it returns a list containing a `Text` object (`[Text("Hello, world!")]`), not an empty list.

This is demonstrated by the following code and its output:

```
$ cat main.py
class Text:
    def __init__(self, text):
        self.text = text


class Tag:
    def __init__(self, tag):
        self.tag = tag


def lex(body):
    out = []
    buffer = ""
    in_tag = False
    for c in body:
        if c == "<":
            in_tag = True
            if buffer:
                out.append(Text(buffer))
            buffer = ""
        elif c == ">":
            in_tag = False
            out.append(Tag(buffer))
            buffer = ""
        else:
            buffer += c
    if not in_tag and buffer:
        out.append(Text(buffer))
    return out


for token in lex("Hello, world!"):
    if isinstance(token, Text):
        print(f"Text: {token.text}")
    elif isinstance(token, Tag):
        print(f"Tag: {token.tag}")

$ python3 main.py
Text: Hello, world!

```

As the output shows, the input "Hello, world!" results in [Text("Hello, world!")].

Therefore, this patch removes the aforementioned incorrect sentence to accurately reflect the function's behavior.