### PR TITLE
Make description of `lex` function a little clearer

### DIFF
--- a/book/text.md
+++ b/book/text.md
@@ -443,8 +443,8 @@ Here I've renamed the `text` variable to `buffer`, since it now stores
 either text or tag contents before they can be used. The name also
 reminds us that, at the end of the loop, we need to check whether
 there's buffered text and what we should do with it. Here, `lex` dumps
-any accumulated text as a `Text` object. Otherwise, if you never saw
-an angle bracket, you'd return an empty list of tokens. But unfinished
+any accumulated text as a `Text` object. This way, even if it never
+sees an angle bracket, it'll still return a text token. But unfinished
 tags, like in `Hi!<hr`, are thrown out.[^errortag]
 
 [^errortag]: This may strike you as an odd decision: why not


### PR DESCRIPTION
This fix addresses #1417 by @negibokken. The phrasing with "Otherwise" is a kind of double-negative, which is hard to follow; better to explicitly describe the function as it exists.