### PR TITLE
In Chapter 6, casefold only once

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1074,7 +1074,7 @@ class CSSParser:
         # ...
         val = self.until_chars(until)
         # ...
-        return prop.casefold(), val.strip()
+        return prop, val.strip()
 ```
 
 Inside a CSS rule body, a property value continues until a semicolon

--- a/book/animations.md
+++ b/book/animations.md
@@ -1074,7 +1074,7 @@ class CSSParser:
         # ...
         val = self.until_chars(until)
         # ...
-        return prop, val.strip()
+        return prop.casefold(), val.strip()
 ```
 
 Inside a CSS rule body, a property value continues until a semicolon

--- a/book/styles.md
+++ b/book/styles.md
@@ -114,7 +114,7 @@ def pair(self):
     self.literal(":")
     self.whitespace()
     val = self.word()
-    return prop, val
+    return prop.casefold(), val
 ```
 
 We can parse sequences by calling parsing functions in a loop. For
@@ -125,7 +125,7 @@ def body(self):
     pairs = {}
     while self.i < len(self.s):
         prop, val = self.pair()
-        pairs[prop.casefold()] = val
+        pairs[prop] = val
         self.whitespace()
         self.literal(";")
         self.whitespace()

--- a/book/styles.md
+++ b/book/styles.md
@@ -114,7 +114,7 @@ def pair(self):
     self.literal(":")
     self.whitespace()
     val = self.word()
-    return prop.casefold(), val
+    return prop, val
 ```
 
 We can parse sequences by calling parsing functions in a loop. For

--- a/book/text.md
+++ b/book/text.md
@@ -443,8 +443,8 @@ Here I've renamed the `text` variable to `buffer`, since it now stores
 either text or tag contents before they can be used. The name also
 reminds us that, at the end of the loop, we need to check whether
 there's buffered text and what we should do with it. Here, `lex` dumps
-any accumulated text as a `Text` object. Otherwise, if you never saw
-an angle bracket, you'd return an empty list of tokens. But unfinished
+any accumulated text as a `Text` object. This way, even if it never
+sees an angle bracket, it'll still return a text token. But unfinished
 tags, like in `Hi!<hr`, are thrown out.[^errortag]
 
 [^errortag]: This may strike you as an odd decision: why not

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -330,14 +330,14 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.until_chars(until)
-        return prop, val.strip()
+        return prop.casefold(), val.strip()
 
     def body(self):
         pairs = {}
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
                 prop, val = self.pair([";", "}"])
-                pairs[prop.casefold()] = val
+                pairs[prop] = val
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()

--- a/src/lab13.py
+++ b/src/lab13.py
@@ -330,7 +330,7 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.until_chars(until)
-        return prop.casefold(), val.strip()
+        return prop, val.strip()
 
     def body(self):
         pairs = {}

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -72,7 +72,7 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.word()
-        return prop.casefold(), val
+        return prop, val
 
     def ignore_until(self, chars):
         while self.i < len(self.s):

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -72,7 +72,7 @@ class CSSParser:
         self.literal(":")
         self.whitespace()
         val = self.word()
-        return prop, val
+        return prop.casefold(), val
 
     def ignore_until(self, chars):
         while self.i < len(self.s):
@@ -87,7 +87,7 @@ class CSSParser:
         while self.i < len(self.s) and self.s[self.i] != "}":
             try:
                 prop, val = self.pair()
-                pairs[prop.casefold()] = val
+                pairs[prop] = val
                 self.whitespace()
                 self.literal(";")
                 self.whitespace()


### PR DESCRIPTION
This PR fixes #1419, which points out that, when parsing CSS, we case-fold property names once. This PR changes it to be casefolded before being put into a dictionary, which is how we normally do it.