### PR TITLE
Add missing definition of the 'w' variable

### DIFF
--- a/book/chrome.md
+++ b/book/chrome.md
@@ -137,6 +137,7 @@ method for that:
 class BlockLayout:
     def word(self, node, word):
         # ...
+        w = font.measure(word)
         if self.cursor_x + w > self.width:
             self.new_line()
 ```


### PR DESCRIPTION
Reported by a reader.

`w` in `word` is never defined in the book text.