### PR TITLE
Remove unnecessary sentence in animations.md

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -569,7 +569,6 @@ class DrawLine(PaintCommand):
         # ...
 ```
 
-`MakeLTRB` creates the `rect` for the `PaintCommand` constructor.
 We can also give a superclass to visual effects:
 
 ``` {.python replace=):/%2c%20node%3dNone):}


### PR DESCRIPTION
IMHO,
This sentence seems to me to be instructing the reader to create the rect with MakeLTRB.

But in visual-effects.md, we already switched to using MakeLTRB, and here it just seems to be about passing it to the superclass. Wouldn’t it be better to just remove this sentence?