### PR TITLE
Missing code in animations.md

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -1720,6 +1720,7 @@ class VisualEffect:
         # ...
         self.needs_compositing = any([
             child.needs_compositing for child in self.children
+            if isinstance(child, VisualEffect)
         ])
 ```
 


### PR DESCRIPTION
src/lab13.py has this condition, but book doesn't have it.

If not, we can see the below error message.

```
  File "/Users/user/workspace/project/Web-Browser-Engineering/src_ko/browser.py", line 1045, in __init__
    child.needs_compositing for child in self.children
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'DrawText' object has no attribute 'needs_compositing'
```