### PR TITLE
Additional info on changing is_focused through focus_element

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1207,7 +1207,7 @@ def paint_outline(node, cmds, rect, zoom):
 ```
 
 Set this `is_focused` flag in a new `focus_element` method that we'll now use
-to change the `focus` field in a `Tab` (and update existing code that sets
+to change the `focus` field in a `Tab` (you should also update existing code that sets
 `is_focused` directly to call `focus_element` instead):
 
 ``` {.python}

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1208,7 +1208,7 @@ def paint_outline(node, cmds, rect, zoom):
 
 Set this `is_focused` flag in a new `focus_element` method that we'll now use
 to change the `focus` field in a `Tab` (and update existing code that sets
-`is_focused` directly to call focus_element instead):
+`is_focused` directly to call `focus_element` instead):
 
 ``` {.python}
 class Tab:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1208,7 +1208,7 @@ def paint_outline(node, cmds, rect, zoom):
 
 Set this `is_focused` flag in a new `focus_element` method that we'll now use
 to change the `focus` field in a `Tab` (and update existing code that sets
-is_focused directly to call focus_element instead:
+`is_focused` directly to call focus_element instead):
 
 ``` {.python}
 class Tab:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1207,7 +1207,8 @@ def paint_outline(node, cmds, rect, zoom):
 ```
 
 Set this `is_focused` flag in a new `focus_element` method that we'll now use
-to change the `focus` field in a `Tab`:
+to change the `focus` field in a `Tab`. Update existing code that sets
+is_focused directly to call focus_element instead:
 
 ``` {.python}
 class Tab:

--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1207,7 +1207,7 @@ def paint_outline(node, cmds, rect, zoom):
 ```
 
 Set this `is_focused` flag in a new `focus_element` method that we'll now use
-to change the `focus` field in a `Tab`. Update existing code that sets
+to change the `focus` field in a `Tab` (and update existing code that sets
 is_focused directly to call focus_element instead:
 
 ``` {.python}


### PR DESCRIPTION
As a non-native speaker,
I may be misreading it.
The original sentence by itself doesn’t make it clear that code setting the is_focused assignments should be changed to call focus_element().
So I thought adding a sentence like this might help.

Fell free to change or drop this if you have better one or it's enough.