### PR TITLE
Remove unnecessary sentence in accessibility.md

### DIFF
--- a/book/accessibility.md
+++ b/book/accessibility.md
@@ -1230,10 +1230,6 @@ class InputLayout:
         return cmds
 ```
 
-I also changed the cursor drawing to only happen if the node is
-focused *and* it's an `input` element. Tabbing over to a `button`
-element should not draw a cursor!
-
 Unfortunately, handling links is a little more complicated. That's
 because one `<a>` element corresponds to multiple `TextLayout`
 objects, so there's not just one layout object where we can stick the


### PR DESCRIPTION
They should be in the above section, which already contains a similar sentence, so I think this is misplaced and redundant.

Above section is below
```
Similarly, InputLayout used to draw a cursor for any focused element. Now that button elements can be focused, it needs to be more careful:
```