### PR TITLE
Missing assert for BROKEN_IMAGE in embeds.md

### DIFF
--- a/book/embeds.md
+++ b/book/embeds.md
@@ -170,6 +170,8 @@ class Tab:
         for img in images:
             try:
                 # ...
+                assert img.image, \
+                    "Failed to recognize image format for " + str(image_url)
             except Exception as e:
                 print("Image", img.attributes.get("src", ""),
                     "crashed", e)


### PR DESCRIPTION
Book explains `try` statment for `BROKEN_IMAGE`, but it omits the `assert` when `img.image` is None.