### PR TITLE
Fix #1435 by naming KHTML instead of Webkit

### DIFF
--- a/book/history.md
+++ b/book/history.md
@@ -281,7 +281,7 @@ war"](https://en.wikipedia.org/wiki/Browser_wars#First_Browser_War_(1995%E2%80%9
 ensued: a competition between Netscape Navigator and [Internet Explorer]. There
 were also other browsers with smaller market shares; one notable example is
 [Opera](https://en.wikipedia.org/wiki/Opera_(web_browser)). The
-[WebKit](https://en.wikipedia.org/wiki/WebKit) project began in 1999;
+[KHTML](https://en.wikipedia.org/wiki/KHTML) project began in 1999;
 [Safari](https://en.wikipedia.org/wiki/Safari_(web_browser)) and
 [Chromium](https://www.chromium.org/)-based browsers, such as Chrome and newer
 versions of [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge), descend from


### PR DESCRIPTION
#1435 points out that we say Webkit started in 1999, when actually KHTML started then, and Webkit proper started 2001. I decided to fix it by referring to KHTML in this sentence; the context is we're talking about stuff that happened in the first browser war and the start of Webkit 2001 kind of feels like after the first browser war and maybe even the foothills of the second.