### PR TITLE
Add a Go Further about querySelectorAll

### DIFF
--- a/book/scripts.md
+++ b/book/scripts.md
@@ -565,6 +565,20 @@ document = { querySelectorAll: function(s) {
     handle. That means you can't use equality to compare `Node`
     objects. I'll ignore that but a real browser wouldn't.
 
+::: {.further}
+Early browsers didn't offer `querySelectorAll`, only `getElementById`
+and `getElementsByTagName`, and the [earliest versions][gEBS] of
+`querySelectorAll` were [JavaScript re-implementations][jSelect],
+especially in the popular and influential [jQuery
+library](https://jquery.org). But since browsers *already* implement
+CSS selectors, it [only makes sense][selector-api] to expose that
+implementation to JavaScript directly.
+:::
+
+[gEBS]: https://simonwillison.net/2003/Mar/25/getElementsBySelector/
+[jSelect]: https://johnresig.com/blog/selectors-in-javascript/
+[selector-api]: https://www.w3.org/TR/2006/WD-selectors-api-20060525/#introduction
+
 Wrapping Handles
 ================
 


### PR DESCRIPTION
This PR solves the second half of #1340 by adding a "Go Further" block about the history of querySelectorAll API. Interesting coincidence: the first version of this was done by Simon Willison, who is now famous for his LLM blog. Crazy!