### PR TITLE
Standardize on "dirty flag" not "dirty bit"

### DIFF
--- a/book/animations.md
+++ b/book/animations.md
@@ -854,7 +854,7 @@ class Browser:
 All that's left is wiring these methods up; let's rename
 `raster_and_draw` to `composite_raster_and_draw` (to remind us that
 there's now an additional composite step) and add our two new methods.
-(And don't forget to rename the corresponding dirty bit and call
+(And don't forget to rename the corresponding dirty flag and call
 sites.)
 
 ``` {.python}
@@ -1167,7 +1167,7 @@ class Tab:
 Inside this loop we need to do two things. First, call the
 animation's `animate` method and save the new value to the node's
 `style`. Second, since that changes rendering inputs, set a
-dirty bit requiring rendering later.^[We also need to
+dirty flag requiring rendering later.^[We also need to
 schedule an animation frame for the next frame of the animation, but
 `set_needs_render` already does that for us.] The whole rendering cycle between the browser and main threads is summarized
 in Figure 2.
@@ -1203,7 +1203,7 @@ class Tab:
 
 To implement `set_needs_layout`, we've got to replace the single
 `needs_render` flag with three flags: `needs_style`, `needs_layout`,
-and `needs_paint`. In our implementation, setting a dirty bit earlier
+and `needs_paint`. In our implementation, setting a dirty flag earlier
 in the pipeline will end up causing everything after it to also run,^[This
 is yet another difference from real browsers, which optimize some
 cases that just require style and paint, or other combinations.]
@@ -1233,8 +1233,8 @@ class Tab:
         self.browser.set_needs_animation_frame(self)
 ```
 
-To support these new dirty bits, `render` must check each phase's bit
-instead of checking `needs_render` at the start:[^timer-obsolete]
+To support these new dirty flags, `render` must check each phase's
+flag instead of checking `needs_render` at the start:[^timer-obsolete]
 
 ``` {.python}
 class Tab:
@@ -1414,9 +1414,9 @@ class Tab:
 ```
 
 Now for the browser thread. First, add `needs_composite`, `needs_raster` and
-`needs_draw` dirty bits and corresponding `set_needs_composite`,
+`needs_draw` dirty flags and corresponding `set_needs_composite`,
 `set_needs_raster`, and `set_needs_draw` methods (and remove the old dirty
-bit):
+flag):
 
 ``` {.python}
 class Browser:
@@ -2316,7 +2316,7 @@ function, and one or two others.
 transfoms and scrolling, but they are not fully composited and threaded,
 and transform transition animations are not supported. Implement these.
 (Hint: for transforms, it just requires following the same pattern as for
-`opacity`; for scrolling, it requires setting fewer dirty bits in
+`opacity`; for scrolling, it requires setting fewer dirty flags in
 `handle_down`.) [A simultaneous transform and opacity animation][tr-example] should now work, without any raster, and scrolling on that page should not
 raster either.
 

--- a/book/embeds.md
+++ b/book/embeds.md
@@ -1000,7 +1000,7 @@ class Frame:
             # ...
 ```
 
-Again, these dirty bits move to the `Frame` because they relate to the
+Again, these dirty flags move to the `Frame` because they relate to the
 frame's part of rendering.
 
 Unlike images, iframes have *no [intrinsic size][intrinsic-size]*:

--- a/book/glossary.md
+++ b/book/glossary.md
@@ -385,6 +385,11 @@ Device pixel ratio
 : The ratio between the screen pixel resolution and a
 "typical" screen (defined as the pixel resolution of a 1990s CRT).
 
+Dirty flag
+
+: A boolean variable that indicates whether some other piece of data
+  is up to date and thus usable or out of date and thus invalidated.
+
 Display list
 
 : A sequence of graphics commands explaining how to draw a

--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -642,8 +642,8 @@ varying rate between 60 and 24.
 [refresh-rate]: https://www.intel.com/content/www/us/en/gaming/resources/highest-refresh-rate-gaming.html
 [hobbit-fps]: https://www.extremetech.com/extreme/128113-why-movies-are-moving-from-24-to-48-fps
 
-Optimizing with Dirty Bits
-==========================
+Optimizing with Dirty Flags
+===========================
 
 If you run this on your computer, there's a good chance your CPU usage
 will spike and your batteries will start draining. That's because
@@ -654,9 +654,9 @@ the web page will not have changed at all, so the old styles, layout
 trees, and display lists would have worked just as well as the new
 ones.
 
-Let's fix this using a *dirty bit*, a piece of state that tells us if
+Let's fix this using a *dirty flag*, a piece of state that tells us if
 some complex data structure is up to date. Since we want to know if we
-need to run `render`, let's call our dirty bit `needs_render`:
+need to run `render`, let's call our dirty flag `needs_render`:
 
 ``` {.python}
 class Tab:
@@ -718,12 +718,12 @@ doing `raster_and_draw` every time the active tab runs a task.
 But sometimes that task is just running JavaScript that doesn't touch
 the web page, and the `raster_and_draw` call is a waste.
 
-We can avoid this using another dirty bit, which I'll call
+We can avoid this using another dirty flag, which I'll call
 `needs_raster_and_draw`:[^not-just-speed]
 
-[^not-just-speed]: The `needs_raster_and_draw` dirty bit doesn't just
+[^not-just-speed]: The `needs_raster_and_draw` dirty flag doesn't just
 make the browser a bit more efficient. Later in this chapter, we'll
-add multiple browser threads, and at that point this dirty bit is
+add multiple browser threads, and at that point this dirty flag is
 necessary to avoid erratic behavior when animating. Try removing it
 later and see for yourself!
 
@@ -777,7 +777,7 @@ class Chrome:
         return False
 ```
 
-And the `Tab` should also set this bit after running `render`:
+And the `Tab` should also set this flag after running `render`:
 
 ``` {.python dropline=set_needs_raster_and_draw}
 class Tab:
@@ -942,7 +942,7 @@ later, they might end up delayed by many, many frames.
 
 Luckily, rendering is special in that it never makes sense to have two
 rendering tasks in a row, since the page wouldn't have changed in
-between. To avoid having two rendering tasks we'll add a dirty bit
+between. To avoid having two rendering tasks we'll add a dirty flag
 called `needs_animation_frame` to the `Browser` that indicates
 whether a rendering task actually needs to be scheduled:
 
@@ -979,7 +979,7 @@ class Browser:
 ```
 
 Note that `set_needs_animation_frame` will only actually set the dirty
-bit if called from the active tab. This guarantees that inactive tabs
+flag if called from the active tab. This guarantees that inactive tabs
 can't interfere with active tabs. Besides preventing scripts from
 scheduling too many animation frames, this system also makes sure that
 if our browser consistently runs slower than 30 frames per second, we

--- a/src/lab16.py
+++ b/src/lab16.py
@@ -84,7 +84,7 @@ class ProtectedField:
             dependency.invalidations.add(self)
         self.frozen_dependencies = True
 
-    def set_ancestor_dirty_bits(self):
+    def set_ancestor_dirty_flags(self):
         parent = self.parent
         while parent and not parent.has_dirty_descendants:
             parent.has_dirty_descendants = True
@@ -93,12 +93,12 @@ class ProtectedField:
     def mark(self):
         if self.dirty: return
         self.dirty = True
-        self.set_ancestor_dirty_bits()
+        self.set_ancestor_dirty_flags()
 
     def notify(self):
         for field in self.invalidations:
             field.mark()
-        self.set_ancestor_dirty_bits()
+        self.set_ancestor_dirty_flags()
 
     def set(self, value):
         # if self.value != None:


### PR DESCRIPTION
I counted and "dirty bit" had fewer uses than "dirty flag" so "dirty flag" it is. Updated all the uses (including one in source code!) and also added the term to the glossary.