### PR TITLE
Use versioned permalink for Python tkinter font documentation

### DIFF
--- a/book/text.md
+++ b/book/text.md
@@ -926,7 +926,7 @@ def get_font(size, weight, style):
 `metrics` for some reason, and is recommended by the [Python
 documentation][metrics-doc].
 
-[metrics-doc]: https://github.com/python/cpython/blob/main/Lib/tkinter/font.py#L163
+[metrics-doc]: https://github.com/python/cpython/blob/v3.14.0/Lib/tkinter/font.py#L166-L167
 
 Then the `word` method can call `get_font` instead of creating a `Font`
 object directly:


### PR DESCRIPTION
The current link to Python's tkinter font documentation points to the main branch (https://github.com/python/cpython/blob/main/Lib/tkinter/font.py#L163), which will become outdated as line numbers change over time.

This PR updates the link to use a versioned tag (v3.14.0) instead, ensuring it continues to point to the correct code location. The line reference is also updated from L163 to L166-L167 to match the actual location in the tagged version.