### PR TITLE
Remove an unnecessary condition acquire/release pair

### DIFF
--- a/book/scheduling.md
+++ b/book/scheduling.md
@@ -301,9 +301,6 @@ class TaskRunner:
         self.condition.release()
         if task:
             task.run()
-
-        self.condition.acquire(blocking=True)
-        self.condition.release()
 ```
 
 [condition-variable]: https://docs.python.org/3/library/threading.html#threading.Condition


### PR DESCRIPTION
Per discussion in [#1440](https://github.com/browserengineering/book/pull/1440#discussion_r3121413581), these two lines of code don't do anything and we just forgot to remove them.